### PR TITLE
WIP: LSP scoring based on carrier scores

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
 	<description>Logistic Service Provider (LSP) and related code for simulation logistic chains.</description>
 
 	<properties>
-		<matsim.version>15.0-SNAPSHOT</matsim.version>
-<!--		<matsim.version>15.0-PR2238</matsim.version>-->
+<!--		<matsim.version>15.0-SNAPSHOT</matsim.version>-->
+		<matsim.version>15.0-PR2249</matsim.version>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
 	<description>Logistic Service Provider (LSP) and related code for simulation logistic chains.</description>
 
 	<properties>
-<!--		<matsim.version>15.0-SNAPSHOT</matsim.version>-->
-		<matsim.version>15.0-PR2238</matsim.version>
+		<matsim.version>15.0-SNAPSHOT</matsim.version>
+<!--		<matsim.version>15.0-PR2238</matsim.version>-->
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/src/main/java/example/lsp/initialPlans/ExampleTwoEchelonGrid.java
+++ b/src/main/java/example/lsp/initialPlans/ExampleTwoEchelonGrid.java
@@ -89,6 +89,7 @@ final class ExampleTwoEchelonGrid {
 			.setCostPerDistanceUnit(0.0005)
 			.setCostPerTimeUnit(0.005)
 			.build();
+	public static final double HUBCOSTS_FIX = 120.;
 
 	private ExampleTwoEchelonGrid() {
 	} // so it cannot be instantiated
@@ -236,7 +237,7 @@ final class ExampleTwoEchelonGrid {
 			LSPResource hubResource = UsecaseUtils.TransshipmentHubBuilder.newInstance(Id.create("Hub", LSPResource.class), HUB_LINK_ID, scenario)
 					.setTransshipmentHubScheduler(hubScheduler)
 					.build();
-			LSPUtils.setFixedCost(hubResource, 120.); //Set fixed costs (per day) for the availability of the hub.
+			LSPUtils.setFixedCost(hubResource, HUBCOSTS_FIX); //Set fixed costs (per day) for the availability of the hub.
 
 			LogisticsSolutionElement hubLSE = LSPUtils.LogisticsSolutionElementBuilder.newInstance(Id.create("HubLSE", LogisticsSolutionElement.class))
 					.setResource(hubResource)

--- a/src/main/java/example/lsp/initialPlans/ExampleTwoEchelonGrid.java
+++ b/src/main/java/example/lsp/initialPlans/ExampleTwoEchelonGrid.java
@@ -354,8 +354,23 @@ final class ExampleTwoEchelonGrid {
 
 		@Override
 		public double getScoreForCurrentPlan() {
+			scoreLspCarriers();
 			scoreHub();
 			return score;
+		}
+
+		private void scoreLspCarriers() {
+			var lspPlan = lsp.getSelectedPlan();
+			for (LogisticsSolution solution : lspPlan.getSolutions()) {
+				for (LogisticsSolutionElement solutionElement : solution.getSolutionElements()) {
+					if (solutionElement.getResource() instanceof LSPCarrierResource carrierResource) {
+						var carriersScore = carrierResource.getCarrier().getSelectedPlan().getScore();
+						 if (carriersScore != null) {
+							 score = score + carriersScore;
+						 }
+					}
+				}
+			}
 		}
 
 		/**

--- a/src/main/java/example/lsp/initialPlans/MyCarrierScorer.java
+++ b/src/main/java/example/lsp/initialPlans/MyCarrierScorer.java
@@ -5,7 +5,6 @@ import org.matsim.contrib.freight.carrier.Carrier;
 import org.matsim.contrib.freight.carrier.CarrierPlan;
 import org.matsim.contrib.freight.carrier.ScheduledTour;
 import org.matsim.contrib.freight.controler.CarrierScoringFunctionFactory;
-import org.matsim.core.router.TripStructureUtils;
 import org.matsim.core.scoring.ScoringFunction;
 import org.matsim.core.scoring.SumScoringFunction;
 
@@ -24,11 +23,11 @@ class MyCarrierScorer implements CarrierScoringFunctionFactory {
 		VehicleEmploymentScoring vehicleEmploymentScoring = new VehicleEmploymentScoring(carrier);
 //		DriversLegScoring driverLegScoring = new DriversLegScoring(carrier, this.network);
 //		DriversActivityScoring actScoring = new DriversActivityScoring();
-		DriversTripScoring driversTripScoring = new DriversTripScoring( carrier, this.network);
+		TakeJspritScore takeJspritScore = new TakeJspritScore( carrier);
 //		sf.addScoringFunction(driverLegScoring);
 		sf.addScoringFunction(vehicleEmploymentScoring);
 //		sf.addScoringFunction(actScoring);
-		sf.addScoringFunction(driversTripScoring);
+		sf.addScoringFunction(takeJspritScore);
 		return sf;
 	}
 
@@ -58,6 +57,24 @@ class MyCarrierScorer implements CarrierScoringFunctionFactory {
 				}
 			}
 			return score;
+		}
+	}
+
+	private class TakeJspritScore implements SumScoringFunction.BasicScoring {
+
+		private final Carrier carrier;
+		public TakeJspritScore(Carrier carrier) {
+			super();
+			this.carrier = carrier;
+		}
+
+		@Override public void finish() {}
+
+		@Override public double getScore() {
+			if (carrier.getSelectedPlan().getScore() != null){
+				return carrier.getSelectedPlan().getScore();
+			}
+			return Double.NEGATIVE_INFINITY;
 		}
 	}
 
@@ -129,8 +146,8 @@ class MyCarrierScorer implements CarrierScoringFunctionFactory {
 //		@Override public void handleActivity(Activity activity) {
 //			if (activity instanceof FreightActivity freightActivity) {
 //				double actStartTime = freightActivity.getStartTime().seconds();
-//				// Scoring for missed TimeWindows -- Commented out, because it is unclear, which value to set here
-//				// and I do not have a replanning strategy, that forces e.g. a time-shift
+////				// Scoring for missed TimeWindows -- Commented out, because it is unclear, which value to set here
+////				// and I do not have a replanning strategy, that forces e.g. a time-shift
 ////				TimeWindow tw = freightActivity.getTimeWindow();
 ////				if(actStartTime > tw.getEnd()){
 ////					double penalty_score = (-1)*(actStartTime - tw.getEnd()) * missedTimeWindowPenalty;
@@ -141,7 +158,7 @@ class MyCarrierScorer implements CarrierScoringFunctionFactory {
 //				//TODO: Unclear how to get the right timeParameter out of the vehicleType - missing link between activity and driver/agent, that could be used.
 //				double actTimeCosts = (freightActivity.getEndTime().seconds() - actStartTime) * timeParameter;
 //				if (!(actTimeCosts >= 0.0)) throw new AssertionError("actTimeCosts must be positive");
-//				score += actTimeCosts*(-1);
+//				score += actTimeCosts * (-1);
 //			}
 //		}
 //
@@ -150,28 +167,5 @@ class MyCarrierScorer implements CarrierScoringFunctionFactory {
 //		}
 //	}
 
-	private static class DriversTripScoring implements SumScoringFunction.TripScoring {
-
-		private double score = 0.0;
-		private final Network network;
-		private final Carrier carrier;
-
-		public DriversTripScoring(Carrier carrier, Network network) {
-			super();
-			this.network = network;
-			this.carrier = carrier;
-		}
-
-		@Override public void finish() {}
-
-		@Override public double getScore() {
-			return score;
-		}
-
-		@Override public void handleTrip(TripStructureUtils.Trip trip) {
-			var myTrip  = trip;
-			score = score -1;
-		}
-	}
 
 }

--- a/src/main/java/example/lsp/initialPlans/MyCarrierScorer.java
+++ b/src/main/java/example/lsp/initialPlans/MyCarrierScorer.java
@@ -1,0 +1,63 @@
+package example.lsp.initialPlans;
+
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.freight.carrier.Carrier;
+import org.matsim.contrib.freight.controler.CarrierScoringFunctionFactory;
+import org.matsim.core.scoring.ScoringFunction;
+import org.matsim.core.scoring.SumScoringFunction;
+
+import javax.inject.Inject;
+
+/**
+ * @author Kai Martins-Turner (kturner)
+ */
+class MyCarrierScorer implements CarrierScoringFunctionFactory {
+
+	@Inject
+	private Network network;
+
+	public ScoringFunction createScoringFunction(Carrier carrier) {
+		SumScoringFunction sf = new SumScoringFunction();
+		DriversLegScoring driverLegScoring = new DriversLegScoring(carrier, this.network);
+		VehicleEmploymentScoring vehicleEmploymentScoring = new VehicleEmploymentScoring(carrier);
+		DriversActivityScoring actScoring = new DriversActivityScoring();
+		sf.addScoringFunction(driverLegScoring);
+		sf.addScoringFunction(vehicleEmploymentScoring);
+		sf.addScoringFunction(actScoring);
+		return sf;
+	}
+
+
+	private static class DriversLegScoring implements SumScoringFunction.BasicScoring {
+		public DriversLegScoring(Carrier carrier, Network network) {
+		}
+
+		@Override public void finish() {
+		}
+
+		@Override public double getScore() {
+			return -10;
+		}
+	}
+
+	private static class VehicleEmploymentScoring implements SumScoringFunction.BasicScoring{
+		public VehicleEmploymentScoring(Carrier carrier) {
+		}
+
+		@Override public void finish() {
+		}
+
+		@Override public double getScore() {
+			return -100;
+		}
+	}
+
+	private static class DriversActivityScoring implements SumScoringFunction.BasicScoring{
+		@Override public void finish() {
+		}
+
+		@Override public double getScore() {
+			return -.1;
+		}
+	}
+}

--- a/src/main/java/example/lsp/initialPlans/MyCarrierScorer.java
+++ b/src/main/java/example/lsp/initialPlans/MyCarrierScorer.java
@@ -1,10 +1,13 @@
 package example.lsp.initialPlans;
 
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.contrib.freight.carrier.Carrier;
-import org.matsim.contrib.freight.carrier.CarrierPlan;
-import org.matsim.contrib.freight.carrier.ScheduledTour;
+import org.matsim.api.core.v01.population.Leg;
+import org.matsim.contrib.freight.carrier.*;
 import org.matsim.contrib.freight.controler.CarrierScoringFunctionFactory;
+import org.matsim.core.gbl.Gbl;
+import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.scoring.ScoringFunction;
 import org.matsim.core.scoring.SumScoringFunction;
 
@@ -58,17 +61,54 @@ class MyCarrierScorer implements CarrierScoringFunctionFactory {
 		}
 	}
 
-	private static class DriversLegScoring implements SumScoringFunction.BasicScoring {
+	private static class DriversLegScoring implements SumScoringFunction.LegScoring {
+
+		private double score = 0.0;
+		private final Network network;
+		private final Carrier carrier;
+
 
 		public DriversLegScoring(Carrier carrier, Network network) {
+			super();
+			this.network = network;
+			this.carrier = carrier;
 		}
 
-		@Override public void finish() {
-		}
+		@Override public void finish() {}
+
 		@Override public double getScore() {
-			return -10;
+			return score;
 		}
 
+		@Override public void handleLeg(Leg leg) {
+			if(leg.getRoute() instanceof NetworkRoute nRoute){
+				CarrierVehicle vehicle = CarrierUtils.getCarrierVehicle(carrier, nRoute.getVehicleId());
+				Gbl.assertNotNull(vehicle);
+
+				//Distance based costs / score
+				{
+					double distance = 0.0;
+					//TODO KMT: Warum sind Start und EndLink hier enthalten? Ist das dann nicht ggf. doppelt gezählt - bei mehreren Legs in Folge?
+					distance += network.getLinks().get(nRoute.getStartLinkId()).getLength();
+					for (Id<Link> linkId : nRoute.getLinkIds()) {
+						distance += network.getLinks().get(linkId).getLength();
+					}
+					distance += network.getLinks().get(nRoute.getEndLinkId()).getLength();
+
+
+					double distanceCosts = distance * vehicle.getType().getCostInformation().getCostsPerMeter();
+					if (!(distanceCosts >= 0.0)) throw new AssertionError("distanceCosts must be positive");
+					score += (-1) * distanceCosts;
+				}
+
+				//Time-based (driving) costs /score
+				{
+					double timeCosts = leg.getTravelTime().seconds() * vehicle.getType().getCostInformation().getCostsPerSecond();
+					if (!(timeCosts >= 0.0)) throw new AssertionError("timeCosts of leg must be positive");
+					score += (-1) * timeCosts;
+				}
+			}
+		}
 	}
 
 	private static class DriversActivityScoring implements SumScoringFunction.BasicScoring{

--- a/src/main/java/example/lsp/initialPlans/MyCarrierScorer.java
+++ b/src/main/java/example/lsp/initialPlans/MyCarrierScorer.java
@@ -2,6 +2,8 @@ package example.lsp.initialPlans;
 
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.freight.carrier.Carrier;
+import org.matsim.contrib.freight.carrier.CarrierPlan;
+import org.matsim.contrib.freight.carrier.ScheduledTour;
 import org.matsim.contrib.freight.controler.CarrierScoringFunctionFactory;
 import org.matsim.core.scoring.ScoringFunction;
 import org.matsim.core.scoring.SumScoringFunction;
@@ -18,8 +20,8 @@ class MyCarrierScorer implements CarrierScoringFunctionFactory {
 
 	public ScoringFunction createScoringFunction(Carrier carrier) {
 		SumScoringFunction sf = new SumScoringFunction();
-		DriversLegScoring driverLegScoring = new DriversLegScoring(carrier, this.network);
 		VehicleEmploymentScoring vehicleEmploymentScoring = new VehicleEmploymentScoring(carrier);
+		DriversLegScoring driverLegScoring = new DriversLegScoring(carrier, this.network);
 		DriversActivityScoring actScoring = new DriversActivityScoring();
 		sf.addScoringFunction(driverLegScoring);
 		sf.addScoringFunction(vehicleEmploymentScoring);
@@ -28,28 +30,45 @@ class MyCarrierScorer implements CarrierScoringFunctionFactory {
 	}
 
 
+	/**
+	 * Score the (daily) fixed costs of each vehicle that is used.
+	 * Summing up for all tours. The values are taken from the vehicleCostInformation in the vehicleType.
+	 */
+	private static class VehicleEmploymentScoring implements SumScoringFunction.BasicScoring{
+
+		private final Carrier carrier;
+
+		public VehicleEmploymentScoring(Carrier carrier) {
+			super();
+			this.carrier = carrier;
+		}
+
+		@Override public void finish() {}
+
+		@Override public double getScore() {
+			double score = 0.;
+			CarrierPlan selectedPlan = carrier.getSelectedPlan();
+			if(selectedPlan == null) return 0.;
+			for(ScheduledTour tour : selectedPlan.getScheduledTours()){
+				if(!tour.getTour().getTourElements().isEmpty()){
+					score += (-1)*tour.getVehicle().getType().getCostInformation().getFixedCosts();
+				}
+			}
+			return score;
+		}
+	}
+
 	private static class DriversLegScoring implements SumScoringFunction.BasicScoring {
+
 		public DriversLegScoring(Carrier carrier, Network network) {
 		}
 
 		@Override public void finish() {
 		}
-
 		@Override public double getScore() {
 			return -10;
 		}
-	}
 
-	private static class VehicleEmploymentScoring implements SumScoringFunction.BasicScoring{
-		public VehicleEmploymentScoring(Carrier carrier) {
-		}
-
-		@Override public void finish() {
-		}
-
-		@Override public double getScore() {
-			return -100;
-		}
 	}
 
 	private static class DriversActivityScoring implements SumScoringFunction.BasicScoring{

--- a/src/main/java/example/lsp/initialPlans/MyLSPScorer.java
+++ b/src/main/java/example/lsp/initialPlans/MyLSPScorer.java
@@ -2,10 +2,6 @@ package example.lsp.initialPlans;
 
 import lsp.*;
 import lsp.usecase.TransshipmentHub;
-import org.matsim.contrib.freight.events.FreightServiceEndEvent;
-import org.matsim.contrib.freight.events.FreightTourEndEvent;
-import org.matsim.contrib.freight.events.eventhandler.FreightServiceEndEventHandler;
-import org.matsim.contrib.freight.events.eventhandler.FreightTourEndEventHandler;
 
 /**
  * A scorer for the LSP.
@@ -15,7 +11,7 @@ import org.matsim.contrib.freight.events.eventhandler.FreightTourEndEventHandler
  *
  * @author Kai Martins-Turner (kturner)
  */
-/*package-private*/ class MyLSPScorer implements LSPScorer, FreightTourEndEventHandler, FreightServiceEndEventHandler {
+/*package-private*/ class MyLSPScorer implements LSPScorer {
 	private double score = 0;
 
 	private LSP lsp;
@@ -69,15 +65,4 @@ import org.matsim.contrib.freight.events.eventhandler.FreightTourEndEventHandler
 		this.lsp = pointer;
 	}
 
-	@Override
-	public void handleEvent(FreightTourEndEvent event) {
-		score--;
-		// use event handlers to compute score.  In this case, score is decreased by one every time a service and a tour ends.
-	}
-
-	@Override
-	public void handleEvent(FreightServiceEndEvent event) {
-		score--;
-		// use event handlers to compute score.  In this case, score is decreased by one every time a service and a tour ends.
-	}
 }

--- a/src/main/java/lsp/LSPModule.java
+++ b/src/main/java/lsp/LSPModule.java
@@ -37,6 +37,7 @@ import org.matsim.contrib.freight.controler.CarrierAgentTracker;
 import org.matsim.contrib.freight.controler.CarrierScoringFunctionFactory;
 import org.matsim.contrib.freight.controler.CarrierStrategyManager;
 import org.matsim.contrib.freight.controler.FreightAgentSource;
+import org.matsim.contrib.freight.usecases.chessboard.CarrierScoringFunctionFactoryImpl;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.events.BeforeMobsimEvent;
@@ -102,7 +103,8 @@ public class LSPModule extends AbstractModule {
 		});
 
 		// the scorers are necessary to run a zeroth iteration to the end:
-		bind( CarrierScoringFunctionFactory.class ).to( CarrierScoringFactoryDummyImpl.class );
+//		bind( CarrierScoringFunctionFactory.class ).to( CarrierScoringFactoryDummyImpl.class );
+		bind( CarrierScoringFunctionFactory.class ).to( CarrierScoringFunctionFactoryImpl.class );
 		bind( LSPScorerFactory.class ).to( LSPScoringFunctionFactoryDummyImpl.class );
 
 		// for iterations, one needs to replace the following with something meaningful.  If nothing else, there are "empty implementations" that do nothing.  kai, jul'22

--- a/src/main/java/lsp/LSPModule.java
+++ b/src/main/java/lsp/LSPModule.java
@@ -33,11 +33,7 @@ import org.matsim.api.core.v01.population.Leg;
 import org.matsim.contrib.freight.FreightConfigGroup;
 import org.matsim.contrib.freight.carrier.Carrier;
 import org.matsim.contrib.freight.carrier.Carriers;
-import org.matsim.contrib.freight.controler.CarrierAgentTracker;
-import org.matsim.contrib.freight.controler.CarrierScoringFunctionFactory;
-import org.matsim.contrib.freight.controler.CarrierStrategyManager;
-import org.matsim.contrib.freight.controler.FreightAgentSource;
-import org.matsim.contrib.freight.usecases.chessboard.CarrierScoringFunctionFactoryImpl;
+import org.matsim.contrib.freight.controler.*;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.events.BeforeMobsimEvent;
@@ -63,6 +59,9 @@ public class LSPModule extends AbstractModule {
 
 		bind(LSPControlerListener.class).in(Singleton.class);
 		addControlerListenerBinding().to(LSPControlerListener.class);
+
+		bind(CarrierControlerListener.class).in( Singleton.class );
+		addControlerListenerBinding().to(CarrierControlerListener.class);
 
 		bind( CarrierAgentTracker.class ).in( Singleton.class );
 		addEventHandlerBinding().to( CarrierAgentTracker.class );
@@ -103,8 +102,8 @@ public class LSPModule extends AbstractModule {
 		});
 
 		// the scorers are necessary to run a zeroth iteration to the end:
-//		bind( CarrierScoringFunctionFactory.class ).to( CarrierScoringFactoryDummyImpl.class );
-		bind( CarrierScoringFunctionFactory.class ).to( CarrierScoringFunctionFactoryImpl.class );
+		bind( CarrierScoringFunctionFactory.class ).to( CarrierScoringFactoryDummyImpl.class );
+//		bind( CarrierScoringFunctionFactory.class ).to( CarrierScoringFunctionFactoryImpl.class );
 		bind( LSPScorerFactory.class ).to( LSPScoringFunctionFactoryDummyImpl.class );
 
 		// for iterations, one needs to replace the following with something meaningful.  If nothing else, there are "empty implementations" that do nothing.  kai, jul'22

--- a/src/main/java/lsp/usecase/CarrierSchedulerUtils.java
+++ b/src/main/java/lsp/usecase/CarrierSchedulerUtils.java
@@ -1,0 +1,42 @@
+package lsp.usecase;
+
+import com.graphhopper.jsprit.core.algorithm.VehicleRoutingAlgorithm;
+import com.graphhopper.jsprit.core.algorithm.box.Jsprit;
+import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem;
+import com.graphhopper.jsprit.core.problem.solution.VehicleRoutingProblemSolution;
+import com.graphhopper.jsprit.core.util.Solutions;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.freight.carrier.Carrier;
+import org.matsim.contrib.freight.carrier.CarrierPlan;
+import org.matsim.contrib.freight.jsprit.MatsimJspritFactory;
+import org.matsim.contrib.freight.jsprit.NetworkBasedTransportCosts;
+import org.matsim.contrib.freight.jsprit.NetworkRouter;
+
+import java.util.Collection;
+
+/**
+ * This class contains some code fragments, that are used in the different *CarrierScheduler classes.
+ * To avoid code duplication these methods are extracted and located here more centralized.
+ *
+ * @author Kai Martins-Turner (kturner)
+ */
+/*package-private*/ class CarrierSchedulerUtils {
+	static Carrier routeCarrier(Carrier carrier, Network network) {
+		VehicleRoutingProblem.Builder vrpBuilder = MatsimJspritFactory.createRoutingProblemBuilder(carrier, network);
+		NetworkBasedTransportCosts.Builder tpcostsBuilder = NetworkBasedTransportCosts.Builder.newInstance(network, UsecaseUtils.getVehicleTypeCollection(carrier));
+		NetworkBasedTransportCosts netbasedTransportcosts = tpcostsBuilder.build();
+		vrpBuilder.setRoutingCost(netbasedTransportcosts);
+		VehicleRoutingProblem vrp = vrpBuilder.build();
+
+		VehicleRoutingAlgorithm algorithm = Jsprit.createAlgorithm(vrp);
+		algorithm.setMaxIterations(1);
+		Collection<VehicleRoutingProblemSolution> solutions = algorithm.searchSolutions();
+
+		VehicleRoutingProblemSolution solution = Solutions.bestOf(solutions);
+
+		CarrierPlan plan = MatsimJspritFactory.createPlan(carrier, solution);
+		NetworkRouter.routePlan(plan, netbasedTransportcosts);
+		carrier.setSelectedPlan(plan);
+		return carrier;
+	}
+}

--- a/src/main/java/lsp/usecase/CarrierSchedulerUtils.java
+++ b/src/main/java/lsp/usecase/CarrierSchedulerUtils.java
@@ -13,6 +13,7 @@ import org.matsim.contrib.freight.jsprit.NetworkBasedTransportCosts;
 import org.matsim.contrib.freight.jsprit.NetworkRouter;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * This class contains some code fragments, that are used in the different *CarrierScheduler classes.
@@ -38,5 +39,15 @@ import java.util.Collection;
 		NetworkRouter.routePlan(plan, netbasedTransportcosts);
 		carrier.setSelectedPlan(plan);
 		return carrier;
+	}
+
+	static Double sumUpScore(List<CarrierPlan> scheduledPlans) {
+		double score = 0;
+		for (CarrierPlan scheduledPlan : scheduledPlans) {
+			if (scheduledPlan.getScore() != null) {
+				score = score + scheduledPlan.getScore();
+			}
+		}
+		return score;
 	}
 }

--- a/src/main/java/lsp/usecase/CollectionCarrierScheduler.java
+++ b/src/main/java/lsp/usecase/CollectionCarrierScheduler.java
@@ -66,7 +66,6 @@ import java.util.Collection;
 			this.carrier.getServices().clear();
 			this.carrier.getShipments().clear();
 			this.carrier.getPlans().clear();
-//			this.carrier.setSelectedPlan(null);
 		}
 	}
 

--- a/src/main/java/lsp/usecase/CollectionCarrierScheduler.java
+++ b/src/main/java/lsp/usecase/CollectionCarrierScheduler.java
@@ -66,7 +66,7 @@ import java.util.Collection;
 			this.carrier.getServices().clear();
 			this.carrier.getShipments().clear();
 			this.carrier.getPlans().clear();
-			this.carrier.setSelectedPlan(null);
+//			this.carrier.setSelectedPlan(null);
 		}
 	}
 

--- a/src/main/java/lsp/usecase/DistributionCarrierScheduler.java
+++ b/src/main/java/lsp/usecase/DistributionCarrierScheduler.java
@@ -69,7 +69,7 @@ import java.util.*;
 			this.carrier.getServices().clear();
 			this.carrier.getShipments().clear();
 			this.carrier.getPlans().clear();
-			this.carrier.setSelectedPlan(null);
+//			this.carrier.setSelectedPlan(null);
 		}
 	}
 

--- a/src/main/java/lsp/usecase/DistributionCarrierScheduler.java
+++ b/src/main/java/lsp/usecase/DistributionCarrierScheduler.java
@@ -69,7 +69,6 @@ import java.util.*;
 			this.carrier.getServices().clear();
 			this.carrier.getShipments().clear();
 			this.carrier.getPlans().clear();
-//			this.carrier.setSelectedPlan(null);
 		}
 	}
 

--- a/src/main/java/lsp/usecase/MainRunCarrierScheduler.java
+++ b/src/main/java/lsp/usecase/MainRunCarrierScheduler.java
@@ -69,7 +69,7 @@ import java.util.List;
 			this.carrier.getServices().clear();
 			this.carrier.getShipments().clear();
 			this.carrier.getPlans().clear();
-			this.carrier.setSelectedPlan(null);
+//			this.carrier.setSelectedPlan(null);
 		}
 	}
 	@Override protected void scheduleResource() {

--- a/src/main/java/lsp/usecase/MainRunCarrierScheduler.java
+++ b/src/main/java/lsp/usecase/MainRunCarrierScheduler.java
@@ -69,7 +69,6 @@ import java.util.List;
 			this.carrier.getServices().clear();
 			this.carrier.getShipments().clear();
 			this.carrier.getPlans().clear();
-//			this.carrier.setSelectedPlan(null);
 		}
 	}
 	@Override protected void scheduleResource() {
@@ -126,7 +125,6 @@ import java.util.List;
 			CarrierService carrierService = convertToCarrierService(tuple);
 			tourBuilder.scheduleService(carrierService);
 		}
-
 
 		tourBuilder.addLeg(new Leg());
 		tourBuilder.scheduleEnd(Id.create(resource.getEndLinkId(), Link.class));
@@ -274,7 +272,6 @@ import java.util.List;
 				break;
 			}
 		}
-
 	}
 
 	static class LSPCarrierPair {
@@ -285,6 +282,5 @@ import java.util.List;
 			this.tuple = tuple;
 			this.service = service;
 		}
-
 	}
 }

--- a/src/main/java/lsp/usecase/MainRunCarrierScheduler.java
+++ b/src/main/java/lsp/usecase/MainRunCarrierScheduler.java
@@ -32,10 +32,7 @@ import org.matsim.contrib.freight.jsprit.NetworkBasedTransportCosts;
 import org.matsim.contrib.freight.jsprit.NetworkRouter;
 import org.matsim.vehicles.VehicleType;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 
 /**
  * In the case of the MainRunResource, the incoming LSPShipments are bundled
@@ -76,8 +73,9 @@ import java.util.List;
 		List<ShipmentWithTime> copyOfAssignedShipments = new ArrayList<>(shipments);
 		copyOfAssignedShipments.sort(Comparator.comparingDouble(ShipmentWithTime::getTime));
 		ArrayList<ShipmentWithTime> shipmentsInCurrentTour = new ArrayList<>();
-		ArrayList<ScheduledTour> scheduledTours = new ArrayList<>();
-
+//		ArrayList<ScheduledTour> scheduledTours = new ArrayList<>();
+		List<CarrierPlan> scheduledPlans = new LinkedList<>();
+		
 		for (ShipmentWithTime tuple : copyOfAssignedShipments) {
 			VehicleType vehicleType = UsecaseUtils.getVehicleTypeCollection(carrier).iterator().next();
 			if ((load + tuple.getShipment().getSize()) <= vehicleType.getCapacity().getOther().intValue()) {
@@ -86,7 +84,8 @@ import java.util.List;
 			} else {
 				load = 0;
 				CarrierPlan plan = createPlan(carrier, shipmentsInCurrentTour);
-				scheduledTours.addAll(plan.getScheduledTours());
+//				scheduledTours.addAll(plan.getScheduledTours());
+				scheduledPlans.add(plan);
 				shipmentsInCurrentTour.clear();
 				shipmentsInCurrentTour.add(tuple);
 				load = load + tuple.getShipment().getSize();
@@ -95,10 +94,17 @@ import java.util.List;
 		}
 		if (!shipmentsInCurrentTour.isEmpty()) {
 			CarrierPlan plan = createPlan(carrier, shipmentsInCurrentTour);
-			scheduledTours.addAll(plan.getScheduledTours());
+//			scheduledTours.addAll(plan.getScheduledTours());
+			scheduledPlans.add(plan);
 			shipmentsInCurrentTour.clear();
 		}
+
+		List<ScheduledTour> scheduledTours = new LinkedList<>();
+		for (CarrierPlan scheduledPlan : scheduledPlans) {
+			scheduledTours.addAll(scheduledPlan.getScheduledTours());
+		}
 		CarrierPlan plan = new CarrierPlan(carrier, scheduledTours);
+		plan.setScore(CarrierSchedulerUtils.sumUpScore(scheduledPlans));
 		carrier.setSelectedPlan(plan);
 	}
 

--- a/src/test/java/example/lsp/lspScoring/MultipleIterationsCollectionLSPScoringTest.java
+++ b/src/test/java/example/lsp/lspScoring/MultipleIterationsCollectionLSPScoringTest.java
@@ -33,12 +33,16 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.freight.FreightConfigGroup;
 import org.matsim.contrib.freight.carrier.*;
 import org.matsim.contrib.freight.carrier.CarrierCapabilities.FleetSize;
+import org.matsim.contrib.freight.controler.CarrierStrategyManager;
+import org.matsim.contrib.freight.controler.CarrierStrategyManagerImpl;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
 import org.matsim.core.network.io.MatsimNetworkReader;
+import org.matsim.core.replanning.GenericPlanStrategyImpl;
+import org.matsim.core.replanning.selectors.RandomPlanSelector;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.vehicles.VehicleType;
 
@@ -174,7 +178,11 @@ public class MultipleIterationsCollectionLSPScoringTest {
 			@Override public void install(){
 				bind( LSPScorerFactory.class ).toInstance( ( lsp) -> new ExampleLSPScoring.TipScorer() );
 				bind( LSPStrategyManager.class ).toInstance( new LSPModule.LSPStrategyManagerEmptyImpl() );
-				// yyyyyy It is NOT clear to me why one does not have to set CarrierStrategyManager.  kai, jul'22
+				bind( CarrierStrategyManager.class ).toProvider(() -> {
+					CarrierStrategyManager strategyManager = new CarrierStrategyManagerImpl();
+					strategyManager.addStrategy(new GenericPlanStrategyImpl<>(new RandomPlanSelector<>()), null, 1);
+					return strategyManager;
+				});
 			}
 		});
 		config.controler().setFirstIteration(0);

--- a/src/test/java/lspMobsimTests/MultipleIterationsCollectionLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleIterationsCollectionLSPMobsimTest.java
@@ -34,6 +34,8 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.freight.FreightConfigGroup;
 import org.matsim.contrib.freight.carrier.*;
 import org.matsim.contrib.freight.carrier.CarrierCapabilities.FleetSize;
+import org.matsim.contrib.freight.controler.CarrierStrategyManager;
+import org.matsim.contrib.freight.controler.CarrierStrategyManagerImpl;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.AbstractModule;
@@ -41,6 +43,8 @@ import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
 import org.matsim.core.gbl.MatsimRandom;
 import org.matsim.core.network.io.MatsimNetworkReader;
+import org.matsim.core.replanning.GenericPlanStrategyImpl;
+import org.matsim.core.replanning.selectors.RandomPlanSelector;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.vehicles.VehicleType;
 
@@ -170,6 +174,11 @@ public class MultipleIterationsCollectionLSPMobsimTest {
 		controler.addOverridingModule( new AbstractModule(){
 			@Override public void install(){
 				bind( LSPStrategyManager.class ).toInstance( new LSPModule.LSPStrategyManagerEmptyImpl() );
+				bind( CarrierStrategyManager.class ).toProvider(() -> {
+					CarrierStrategyManager strategyManager = new CarrierStrategyManagerImpl();
+					strategyManager.addStrategy(new GenericPlanStrategyImpl<>(new RandomPlanSelector<>()), null, 1);
+					return strategyManager;
+				});
 			}
 		} );
 		config.controler().setFirstIteration(0);

--- a/src/test/java/lspMobsimTests/MultipleIterationsFirstReloadLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleIterationsFirstReloadLSPMobsimTest.java
@@ -34,6 +34,8 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.freight.FreightConfigGroup;
 import org.matsim.contrib.freight.carrier.*;
 import org.matsim.contrib.freight.carrier.CarrierCapabilities.FleetSize;
+import org.matsim.contrib.freight.controler.CarrierStrategyManager;
+import org.matsim.contrib.freight.controler.CarrierStrategyManagerImpl;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.AbstractModule;
@@ -41,6 +43,8 @@ import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
 import org.matsim.core.gbl.MatsimRandom;
 import org.matsim.core.network.io.MatsimNetworkReader;
+import org.matsim.core.replanning.GenericPlanStrategyImpl;
+import org.matsim.core.replanning.selectors.RandomPlanSelector;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.vehicles.VehicleType;
 
@@ -202,6 +206,11 @@ public class MultipleIterationsFirstReloadLSPMobsimTest {
 		controler.addOverridingModule( new AbstractModule(){
 			@Override public void install(){
 				bind( LSPStrategyManager.class ).toInstance( new LSPModule.LSPStrategyManagerEmptyImpl() );
+				bind( CarrierStrategyManager.class ).toProvider(() -> {
+					CarrierStrategyManager strategyManager = new CarrierStrategyManagerImpl();
+					strategyManager.addStrategy(new GenericPlanStrategyImpl<>(new RandomPlanSelector<>()), null, 1);
+					return strategyManager;
+				});
 			}
 		} );
 		config.controler().setFirstIteration(0);

--- a/src/test/java/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
@@ -34,6 +34,8 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.freight.FreightConfigGroup;
 import org.matsim.contrib.freight.carrier.*;
 import org.matsim.contrib.freight.carrier.CarrierCapabilities.FleetSize;
+import org.matsim.contrib.freight.controler.CarrierStrategyManager;
+import org.matsim.contrib.freight.controler.CarrierStrategyManagerImpl;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.AbstractModule;
@@ -41,6 +43,8 @@ import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
 import org.matsim.core.gbl.MatsimRandom;
 import org.matsim.core.network.io.MatsimNetworkReader;
+import org.matsim.core.replanning.GenericPlanStrategyImpl;
+import org.matsim.core.replanning.selectors.RandomPlanSelector;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
@@ -242,6 +246,11 @@ public class MultipleIterationsMainRunLSPMobsimTest {
 		controler.addOverridingModule( new AbstractModule(){
 			@Override public void install(){
 				bind( LSPStrategyManager.class ).toInstance( new LSPModule.LSPStrategyManagerEmptyImpl() );
+				bind( CarrierStrategyManager.class ).toProvider(() -> {
+					CarrierStrategyManager strategyManager = new CarrierStrategyManagerImpl();
+					strategyManager.addStrategy(new GenericPlanStrategyImpl<>(new RandomPlanSelector<>()), null, 1);
+					return strategyManager;
+				});
 			}
 		} );
 		config.controler().setFirstIteration(0);

--- a/src/test/java/lspMobsimTests/MultipleIterationsSecondReloadLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleIterationsSecondReloadLSPMobsimTest.java
@@ -34,6 +34,8 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.freight.FreightConfigGroup;
 import org.matsim.contrib.freight.carrier.*;
 import org.matsim.contrib.freight.carrier.CarrierCapabilities.FleetSize;
+import org.matsim.contrib.freight.controler.CarrierStrategyManager;
+import org.matsim.contrib.freight.controler.CarrierStrategyManagerImpl;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.AbstractModule;
@@ -41,6 +43,8 @@ import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
 import org.matsim.core.gbl.MatsimRandom;
 import org.matsim.core.network.io.MatsimNetworkReader;
+import org.matsim.core.replanning.GenericPlanStrategyImpl;
+import org.matsim.core.replanning.selectors.RandomPlanSelector;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
@@ -264,6 +268,11 @@ public class MultipleIterationsSecondReloadLSPMobsimTest {
 		controler.addOverridingModule( new AbstractModule(){
 			@Override public void install(){
 				bind( LSPStrategyManager.class ).toInstance( new LSPModule.LSPStrategyManagerEmptyImpl() );
+				bind( CarrierStrategyManager.class ).toProvider(() -> {
+					CarrierStrategyManager strategyManager = new CarrierStrategyManagerImpl();
+					strategyManager.addStrategy(new GenericPlanStrategyImpl<>(new RandomPlanSelector<>()), null, 1);
+					return strategyManager;
+				});
 			}
 		} );
 		config.controler().setFirstIteration(0);

--- a/src/test/java/lspMobsimTests/MultipleItreationsCompleteLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleItreationsCompleteLSPMobsimTest.java
@@ -34,6 +34,8 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.freight.FreightConfigGroup;
 import org.matsim.contrib.freight.carrier.*;
 import org.matsim.contrib.freight.carrier.CarrierCapabilities.FleetSize;
+import org.matsim.contrib.freight.controler.CarrierStrategyManager;
+import org.matsim.contrib.freight.controler.CarrierStrategyManagerImpl;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.AbstractModule;
@@ -41,6 +43,8 @@ import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
 import org.matsim.core.gbl.MatsimRandom;
 import org.matsim.core.network.io.MatsimNetworkReader;
+import org.matsim.core.replanning.GenericPlanStrategyImpl;
+import org.matsim.core.replanning.selectors.RandomPlanSelector;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
@@ -303,6 +307,11 @@ public class MultipleItreationsCompleteLSPMobsimTest {
 		controler.addOverridingModule( new AbstractModule(){
 			@Override public void install(){
 				bind( LSPStrategyManager.class ).toInstance( new LSPModule.LSPStrategyManagerEmptyImpl() );
+				bind( CarrierStrategyManager.class ).toProvider(() -> {
+					CarrierStrategyManager strategyManager = new CarrierStrategyManagerImpl();
+					strategyManager.addStrategy(new GenericPlanStrategyImpl<>(new RandomPlanSelector<>()), null, 1);
+					return strategyManager;
+				});
 			}
 		} );
 		config.controler().setFirstIteration(0);
@@ -335,5 +344,8 @@ public class MultipleItreationsCompleteLSPMobsimTest {
 			}
 		}
 	}
+
 }
+
+
 

--- a/src/test/java/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
@@ -36,6 +36,8 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.freight.FreightConfigGroup;
 import org.matsim.contrib.freight.carrier.*;
 import org.matsim.contrib.freight.carrier.CarrierCapabilities.FleetSize;
+import org.matsim.contrib.freight.controler.CarrierStrategyManager;
+import org.matsim.contrib.freight.controler.CarrierStrategyManagerImpl;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.AbstractModule;
@@ -43,6 +45,8 @@ import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
 import org.matsim.core.gbl.MatsimRandom;
 import org.matsim.core.network.io.MatsimNetworkReader;
+import org.matsim.core.replanning.GenericPlanStrategyImpl;
+import org.matsim.core.replanning.selectors.RandomPlanSelector;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
@@ -306,6 +310,11 @@ public class MultipleShipmentsCompleteLSPMobsimTest {
 		controler.addOverridingModule( new AbstractModule(){
 			@Override public void install(){
 				bind( LSPStrategyManager.class ).toInstance( new LSPModule.LSPStrategyManagerEmptyImpl() );
+				bind( CarrierStrategyManager.class ).toProvider(() -> {
+					CarrierStrategyManager strategyManager = new CarrierStrategyManagerImpl();
+					strategyManager.addStrategy(new GenericPlanStrategyImpl<>(new RandomPlanSelector<>()), null, 1);
+					return strategyManager;
+				});
 			}
 		} );
 		config.controler().setFirstIteration(0);

--- a/src/test/java/lspMobsimTests/MultipleShipmentsSecondReloadLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleShipmentsSecondReloadLSPMobsimTest.java
@@ -34,6 +34,8 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.freight.FreightConfigGroup;
 import org.matsim.contrib.freight.carrier.*;
 import org.matsim.contrib.freight.carrier.CarrierCapabilities.FleetSize;
+import org.matsim.contrib.freight.controler.CarrierStrategyManager;
+import org.matsim.contrib.freight.controler.CarrierStrategyManagerImpl;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.AbstractModule;
@@ -41,6 +43,8 @@ import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
 import org.matsim.core.gbl.MatsimRandom;
 import org.matsim.core.network.io.MatsimNetworkReader;
+import org.matsim.core.replanning.GenericPlanStrategyImpl;
+import org.matsim.core.replanning.selectors.RandomPlanSelector;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
@@ -264,6 +268,11 @@ public class MultipleShipmentsSecondReloadLSPMobsimTest {
 		controler.addOverridingModule( new AbstractModule(){
 			@Override public void install(){
 				bind( LSPStrategyManager.class ).toInstance( new LSPModule.LSPStrategyManagerEmptyImpl() );
+				bind( CarrierStrategyManager.class ).toProvider(() -> {
+					CarrierStrategyManager strategyManager = new CarrierStrategyManagerImpl();
+					strategyManager.addStrategy(new GenericPlanStrategyImpl<>(new RandomPlanSelector<>()), null, 1);
+					return strategyManager;
+				});
 			}
 		} );
 		config.controler().setFirstIteration(0);


### PR DESCRIPTION
Implement a scoring for the LSP using:
- the scores of its Carrier(s)
- add additional scores for the Hubs

This is a first version and under development.

--
This PR currently also includes a fix in the *CarrierScheduler, which removes an unnecessary and error-producing "null" plan in the carrier.