### PR TITLE
Add manual scoring for MainRunCarrier 

### DIFF
--- a/src/main/java/example/lsp/initialPlans/MyCarrierScorer.java
+++ b/src/main/java/example/lsp/initialPlans/MyCarrierScorer.java
@@ -20,12 +20,12 @@ class MyCarrierScorer implements CarrierScoringFunctionFactory {
 
 	public ScoringFunction createScoringFunction(Carrier carrier) {
 		SumScoringFunction sf = new SumScoringFunction();
-		VehicleEmploymentScoring vehicleEmploymentScoring = new VehicleEmploymentScoring(carrier);
+//		VehicleEmploymentScoring vehicleEmploymentScoring = new VehicleEmploymentScoring(carrier);
 //		DriversLegScoring driverLegScoring = new DriversLegScoring(carrier, this.network);
 //		DriversActivityScoring actScoring = new DriversActivityScoring();
 		TakeJspritScore takeJspritScore = new TakeJspritScore( carrier);
 //		sf.addScoringFunction(driverLegScoring);
-		sf.addScoringFunction(vehicleEmploymentScoring);
+//		sf.addScoringFunction(vehicleEmploymentScoring);
 //		sf.addScoringFunction(actScoring);
 		sf.addScoringFunction(takeJspritScore);
 		return sf;

--- a/src/main/java/lsp/usecase/MainRunCarrierScheduler.java
+++ b/src/main/java/lsp/usecase/MainRunCarrierScheduler.java
@@ -112,6 +112,7 @@ import java.util.*;
 	private int tourIdindex = 1; //Have unique TourIds for the MainRun.
 	private CarrierPlan createPlan(Carrier carrier, List<ShipmentWithTime> tuples) {
 
+		//TODO: Allgemein: Hier ist alles manuell zusammen gesetzt; es findet KEINE Tourenplanung statt!
 		NetworkBasedTransportCosts.Builder tpcostsBuilder = NetworkBasedTransportCosts.Builder.newInstance(resource.getNetwork(), UsecaseUtils.getVehicleTypeCollection(resource.getCarrier()));
 		NetworkBasedTransportCosts netbasedTransportcosts = tpcostsBuilder.build();
 		Collection<ScheduledTour> tours = new ArrayList<>();
@@ -135,6 +136,10 @@ import java.util.*;
 
 		tourBuilder.addLeg(new Leg());
 		tourBuilder.scheduleEnd(Id.create(resource.getEndLinkId(), Link.class));
+		//TODO: Option einfügen, dass es auch noch eine Fahrt zurück zum Depot gibt?
+		// Würde das optional machen, weil es ja nach Kontext Sinn ergeben kann (urban) aber nicht muss (langstrecke)
+		// Bei der Langstrecke kann man annehmen, dass das Fahrzeug ab dem Ziel einen neuen Auftrag nach irgendwo erhalten kann.
+		// Urban wird es eher ans Depot zurück kehren.
 		org.matsim.contrib.freight.carrier.Tour vehicleTour = tourBuilder.build();
 		CarrierVehicle vehicle = carrier.getCarrierCapabilities().getCarrierVehicles().values().iterator().next();
 		double tourStartTime = latestTupleTime + totalLoadingTime;
@@ -144,7 +149,7 @@ import java.util.*;
 		CarrierPlan plan = new CarrierPlan(carrier, tours);
 		NetworkRouter.routePlan(plan, netbasedTransportcosts);
 		{
-			//score plan
+			//score plan //TODO: ISt noch nicht perfekt identisch, weil Handling-Zeiten (Act.) noch fehlen.. Aber Startpunkt.
 			double score = 0.;
 			for (ScheduledTour scheduledTour : plan.getScheduledTours()) {
 				//vehicle fixed costs


### PR DESCRIPTION
The mainRunCarrier does not perform any jsprit VRP planning. Thus, there where NO score for its plan neither from jsprit nor from somewhere else.

Since the LSP scoring is based on the carrier's score, this lead to wrong LSP scores :(

Quickfixing it, with a manual scoring for the MainRunCarrier.