### PR TITLE
MainRunCarrierRessource: Vehicles can now return to their start

### DIFF
--- a/src/main/java/example/lsp/initialPlans/ExampleTwoEchelonGrid.java
+++ b/src/main/java/example/lsp/initialPlans/ExampleTwoEchelonGrid.java
@@ -221,6 +221,7 @@ final class ExampleTwoEchelonGrid {
 					.setFromLinkId(DEPOT_LINK_ID)
 					.setMainRunCarrierScheduler(UsecaseUtils.createDefaultMainRunCarrierScheduler())
 					.setToLinkId(HUB_LINK_ID)
+					.setVehicleReturn(UsecaseUtils.VehicleReturn.returnToFromLink)
 					.build();
 
 			LogisticsSolutionElement mainCarrierLSE = LSPUtils.LogisticsSolutionElementBuilder.newInstance(Id.create("mainCarrierLSE", LogisticsSolutionElement.class))

--- a/src/main/java/lsp/usecase/MainRunCarrierResource.java
+++ b/src/main/java/lsp/usecase/MainRunCarrierResource.java
@@ -24,6 +24,8 @@ import lsp.LSPCarrierResource;
 import lsp.LSPDataObject;
 import lsp.LSPResource;
 import lsp.LogisticsSolutionElement;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
@@ -33,12 +35,17 @@ import java.util.Collection;
 
 /*package-private*/ class MainRunCarrierResource extends LSPDataObject<LSPResource> implements LSPCarrierResource {
 
+	private static final Logger log = LogManager.getLogger(MainRunCarrierResource.class);
+
 	private final Carrier carrier;
 	private final Id<Link> fromLinkId;
 	private final Id<Link> toLinkId;
 	private final Collection<LogisticsSolutionElement> clientElements;
 	private final MainRunCarrierScheduler mainRunScheduler;
+
+	private final UsecaseUtils.VehicleReturn vehicleReturn;
 	private final Network network;
+
 
 	MainRunCarrierResource(UsecaseUtils.MainRunCarrierResourceBuilder builder) {
 		super(builder.getId());
@@ -47,6 +54,12 @@ import java.util.Collection;
 		this.toLinkId = builder.getToLinkId();
 		this.clientElements = builder.getClientElements();
 		this.mainRunScheduler = builder.getMainRunScheduler();
+		if (builder.getVehicleReturn() != null){
+			this.vehicleReturn = builder.getVehicleReturn();
+		} else {
+			log.warn("Return behaviour was not specified. Using the following setting as default: " + UsecaseUtils.VehicleReturn.endAtToLink);
+			this.vehicleReturn = UsecaseUtils.VehicleReturn.endAtToLink;
+		}
 		this.network = builder.getNetwork();
 	}
 
@@ -78,4 +91,7 @@ import java.util.Collection;
 		return network;
 	}
 
+	public UsecaseUtils.VehicleReturn getVehicleReturn() {
+		return vehicleReturn;
+	}
 }

--- a/src/main/java/lsp/usecase/MainRunCarrierScheduler.java
+++ b/src/main/java/lsp/usecase/MainRunCarrierScheduler.java
@@ -135,11 +135,17 @@ import java.util.*;
 		}
 
 		tourBuilder.addLeg(new Leg());
-		tourBuilder.scheduleEnd(Id.create(resource.getEndLinkId(), Link.class));
-		//TODO: Option einfügen, dass es auch noch eine Fahrt zurück zum Depot gibt?
-		// Würde das optional machen, weil es ja nach Kontext Sinn ergeben kann (urban) aber nicht muss (langstrecke)
-		// Bei der Langstrecke kann man annehmen, dass das Fahrzeug ab dem Ziel einen neuen Auftrag nach irgendwo erhalten kann.
-		// Urban wird es eher ans Depot zurück kehren.
+		switch (resource.getVehicleReturn()) {
+			case returnToFromLink -> {
+				//The more "urban" behaviour: The vehicle returns to its origin (startLink).
+				tourBuilder.scheduleEnd(Id.create(resource.getStartLinkId(), Link.class));
+			}
+			case endAtToLink -> {
+				//The more "long-distance" behaviour: The vehicle ends at its destination (toLink).
+				tourBuilder.scheduleEnd(Id.create(resource.getEndLinkId(), Link.class));
+			}
+			default -> throw new IllegalStateException("Unexpected value: " + resource.getVehicleReturn());
+		}
 		org.matsim.contrib.freight.carrier.Tour vehicleTour = tourBuilder.build();
 		CarrierVehicle vehicle = carrier.getCarrierCapabilities().getCarrierVehicles().values().iterator().next();
 		double tourStartTime = latestTupleTime + totalLoadingTime;

--- a/src/main/java/lsp/usecase/UsecaseUtils.java
+++ b/src/main/java/lsp/usecase/UsecaseUtils.java
@@ -138,6 +138,8 @@ public class UsecaseUtils {
 		}
 	}
 
+	public enum VehicleReturn {returnToFromLink, endAtToLink}
+
 	public static class CollectionCarrierResourceBuilder {
 
 		final Id<LSPResource> id;
@@ -230,6 +232,7 @@ public class UsecaseUtils {
 		private Id<Link> fromLinkId;
 		private Id<Link> toLinkId;
 		private MainRunCarrierScheduler mainRunScheduler;
+		private VehicleReturn vehicleReturn;
 
 		private MainRunCarrierResourceBuilder(Id<LSPResource> id, Network network) {
 			this.id = id;
@@ -257,6 +260,11 @@ public class UsecaseUtils {
 		}
 		public MainRunCarrierResourceBuilder setMainRunCarrierScheduler(MainRunCarrierScheduler mainRunScheduler) {
 			this.mainRunScheduler = mainRunScheduler;
+			return this;
+		}
+
+		public MainRunCarrierResourceBuilder setVehicleReturn(VehicleReturn vehicleReturn){
+			this.vehicleReturn = vehicleReturn;
 			return this;
 		}
 
@@ -292,6 +300,10 @@ public class UsecaseUtils {
 
 		Network getNetwork() {
 			return network;
+		}
+
+		VehicleReturn getVehicleReturn() {
+			return vehicleReturn;
 		}
 	}
 


### PR DESCRIPTION
Add an enum/switch to choose, whether the mainRunCarrier's vehicle(s) should return to the fromLink or end at toLink.