### PR TITLE
Adapt code to changes in MATSim-PR2336: Changes in MATSimTestUtils -> compareEvents

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.matsim</groupId>
         <artifactId>matsim-all</artifactId>
-        <version>15.0-PR2334</version>
+        <version>15.0-PR2335</version>
 <!--        <version>15.0-SNAPSHOT</version>-->
         <relativePath/>
     </parent>

--- a/src/test/java/example/lsp/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirectTest.java
+++ b/src/test/java/example/lsp/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirectTest.java
@@ -50,7 +50,7 @@ public class ExampleSchedulingOfTransportChainHubsVsDirectTest {
 		}
 
 		//Compare events files
-		MatsimTestUtils.compareEventsFiles(utils.getInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
+		MatsimTestUtils.assertEqualEventsFiles(utils.getInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 
 	@Test
@@ -69,6 +69,6 @@ public class ExampleSchedulingOfTransportChainHubsVsDirectTest {
 		}
 
 		//Compare events files
-		MatsimTestUtils.compareEventsFiles(utils.getInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
+		MatsimTestUtils.assertEqualEventsFiles(utils.getInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 }

--- a/src/test/java/example/lsp/lspReplanning/CollectionLSPReplanningTest.java
+++ b/src/test/java/example/lsp/lspReplanning/CollectionLSPReplanningTest.java
@@ -225,8 +225,7 @@ public class CollectionLSPReplanningTest {
 
 	@Test
 	public void compareEvents(){
-		// 0 = "Files are equal".
-		Assert.assertEquals(0, MatsimTestUtils.compareEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" ));
+		MatsimTestUtils.assertEqualEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 
 }

--- a/src/test/java/example/lsp/lspScoring/CollectionLSPScoringTest.java
+++ b/src/test/java/example/lsp/lspScoring/CollectionLSPScoringTest.java
@@ -177,7 +177,6 @@ public class CollectionLSPScoringTest {
 
 	@Test
 	public void compareEvents(){
-		// 0 = "Files are equal".
-		Assert.assertEquals(0, MatsimTestUtils.compareEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" ));
+		MatsimTestUtils.assertEqualEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 }

--- a/src/test/java/example/lsp/lspScoring/MultipleIterationsCollectionLSPScoringTest.java
+++ b/src/test/java/example/lsp/lspScoring/MultipleIterationsCollectionLSPScoringTest.java
@@ -206,7 +206,6 @@ public class MultipleIterationsCollectionLSPScoringTest {
 
 	@Test
 	public void compareEvents(){
-		// 0 = "Files are equal".
-		Assert.assertEquals(0, MatsimTestUtils.compareEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" ));
+		MatsimTestUtils.assertEqualEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 }

--- a/src/test/java/example/lsp/mobsimExamples/ExampleMobsimOfSimpleLSPTest.java
+++ b/src/test/java/example/lsp/mobsimExamples/ExampleMobsimOfSimpleLSPTest.java
@@ -31,8 +31,7 @@ public class ExampleMobsimOfSimpleLSPTest {
 			fail();
 		}
 
-		// 0 = "Files are equal".
-		Assert.assertEquals(0, MatsimTestUtils.compareEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" ));
+		MatsimTestUtils.assertEqualEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 
 }

--- a/src/test/java/example/lsp/simulationTrackers/CollectionTrackerTest.java
+++ b/src/test/java/example/lsp/simulationTrackers/CollectionTrackerTest.java
@@ -319,7 +319,6 @@ public class CollectionTrackerTest {
 
 	@Test
 	public void compareEvents(){
-		// 0 = "Files are equal".
-		Assert.assertEquals(0, MatsimTestUtils.compareEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" ));
+		MatsimTestUtils.assertEqualEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 }

--- a/src/test/java/lspMobsimTests/CollectionLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/CollectionLSPMobsimTest.java
@@ -245,8 +245,7 @@ public class CollectionLSPMobsimTest {
 
 	@Test
 	public void compareEvents(){
-		// 0 = "Files are equal".
-		Assert.assertEquals(0, MatsimTestUtils.compareEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" ));
+		MatsimTestUtils.assertEqualEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 
 }

--- a/src/test/java/lspMobsimTests/CompleteLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/CompleteLSPMobsimTest.java
@@ -336,8 +336,7 @@ public class CompleteLSPMobsimTest {
 
 	@Test
 	public void compareEvents(){
-		// 0 = "Files are equal".
-		Assert.assertEquals(0, MatsimTestUtils.compareEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" ));
+		MatsimTestUtils.assertEqualEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 }
 

--- a/src/test/java/lspMobsimTests/FirstReloadLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/FirstReloadLSPMobsimTest.java
@@ -244,7 +244,6 @@ public class FirstReloadLSPMobsimTest {
 
 	@Test
 	public void compareEvents(){
-		// 0 = "Files are equal".
-		Assert.assertEquals(0, MatsimTestUtils.compareEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" ));
+		MatsimTestUtils.assertEqualEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 }

--- a/src/test/java/lspMobsimTests/MainRunLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MainRunLSPMobsimTest.java
@@ -279,7 +279,6 @@ public class MainRunLSPMobsimTest {
 
 	@Test
 	public void compareEvents(){
-		// 0 = "Files are equal".
-		Assert.assertEquals(0, MatsimTestUtils.compareEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" ));
+		MatsimTestUtils.assertEqualEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 }

--- a/src/test/java/lspMobsimTests/MainRunOnlyLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MainRunOnlyLSPMobsimTest.java
@@ -224,7 +224,6 @@ public class MainRunOnlyLSPMobsimTest {
 
 	@Test
 	public void compareEvents(){
-		// 0 = "Files are equal".
-		Assert.assertEquals(0, MatsimTestUtils.compareEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" ));
+		MatsimTestUtils.assertEqualEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 }

--- a/src/test/java/lspMobsimTests/MultipleIterationsCollectionLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleIterationsCollectionLSPMobsimTest.java
@@ -25,7 +25,6 @@ import lsp.shipment.LSPShipment;
 import lsp.shipment.ShipmentPlanElement;
 import lsp.shipment.ShipmentUtils;
 import lsp.usecase.UsecaseUtils;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -220,7 +219,6 @@ public class MultipleIterationsCollectionLSPMobsimTest {
 
 	@Test
 	public void compareEvents(){
-		// 0 = "Files are equal".
-		Assert.assertEquals(0, MatsimTestUtils.compareEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" ));
+		MatsimTestUtils.assertEqualEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 }

--- a/src/test/java/lspMobsimTests/MultipleIterationsFirstReloadLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleIterationsFirstReloadLSPMobsimTest.java
@@ -252,7 +252,6 @@ public class MultipleIterationsFirstReloadLSPMobsimTest {
 
 	@Test
 	public void compareEvents(){
-		// 0 = "Files are equal".
-		Assert.assertEquals(0, MatsimTestUtils.compareEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" ));
+		MatsimTestUtils.assertEqualEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 }

--- a/src/test/java/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
@@ -296,7 +296,6 @@ public class MultipleIterationsMainRunLSPMobsimTest {
 
 	@Test
 	public void compareEvents(){
-		// 0 = "Files are equal".
-		Assert.assertEquals(0, MatsimTestUtils.compareEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" ));
+		MatsimTestUtils.assertEqualEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 }

--- a/src/test/java/lspMobsimTests/MultipleIterationsSecondReloadLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleIterationsSecondReloadLSPMobsimTest.java
@@ -312,7 +312,6 @@ public class MultipleIterationsSecondReloadLSPMobsimTest {
 
 	@Test
 	public void compareEvents(){
-		// 0 = "Files are equal".
-		Assert.assertEquals(0, MatsimTestUtils.compareEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" ));
+		MatsimTestUtils.assertEqualEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 }

--- a/src/test/java/lspMobsimTests/MultipleItreationsCompleteLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleItreationsCompleteLSPMobsimTest.java
@@ -355,8 +355,7 @@ public class MultipleItreationsCompleteLSPMobsimTest {
 
 	@Test
 	public void compareEvents(){
-		// 0 = "Files are equal".
-		Assert.assertEquals(0, MatsimTestUtils.compareEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" ));
+		MatsimTestUtils.assertEqualEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 
 }

--- a/src/test/java/lspMobsimTests/MultipleShipmentsCollectionLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleShipmentsCollectionLSPMobsimTest.java
@@ -205,7 +205,6 @@ public class MultipleShipmentsCollectionLSPMobsimTest {
 
 	@Test
 	public void compareEvents(){
-		// 0 = "Files are equal".
-		Assert.assertEquals(0, MatsimTestUtils.compareEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" ));
+		MatsimTestUtils.assertEqualEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 }

--- a/src/test/java/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
@@ -358,8 +358,7 @@ public class MultipleShipmentsCompleteLSPMobsimTest {
 
 	@Test
 	public void compareEvents(){
-		// 0 = "Files are equal".
-		Assert.assertEquals(0, MatsimTestUtils.compareEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" ));
+		MatsimTestUtils.assertEqualEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 }
 

--- a/src/test/java/lspMobsimTests/MultipleShipmentsFirstReloadLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleShipmentsFirstReloadLSPMobsimTest.java
@@ -249,7 +249,6 @@ public class MultipleShipmentsFirstReloadLSPMobsimTest {
 
 	@Test
 	public void compareEvents(){
-		// 0 = "Files are equal".
-		Assert.assertEquals(0, MatsimTestUtils.compareEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" ));
+		MatsimTestUtils.assertEqualEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 }

--- a/src/test/java/lspMobsimTests/MultipleShipmentsMainRunLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleShipmentsMainRunLSPMobsimTest.java
@@ -285,7 +285,6 @@ public class MultipleShipmentsMainRunLSPMobsimTest {
 
 	@Test
 	public void compareEvents(){
-		// 0 = "Files are equal".
-		Assert.assertEquals(0, MatsimTestUtils.compareEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" ));
+		MatsimTestUtils.assertEqualEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 }

--- a/src/test/java/lspMobsimTests/MultipleShipmentsSecondReloadLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleShipmentsSecondReloadLSPMobsimTest.java
@@ -312,7 +312,6 @@ public class MultipleShipmentsSecondReloadLSPMobsimTest {
 
 	@Test
 	public void compareEvents(){
-		// 0 = "Files are equal".
-		Assert.assertEquals(0, MatsimTestUtils.compareEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" ));
+		MatsimTestUtils.assertEqualEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 }

--- a/src/test/java/lspMobsimTests/RepeatedMultipleShipmentsCompleteLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/RepeatedMultipleShipmentsCompleteLSPMobsimTest.java
@@ -357,8 +357,7 @@ public class RepeatedMultipleShipmentsCompleteLSPMobsimTest {
 
 	@Test
 	public void compareEvents(){
-		// 0 = "Files are equal".
-		Assert.assertEquals(0, MatsimTestUtils.compareEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" ));
+		MatsimTestUtils.assertEqualEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 }
 

--- a/src/test/java/lspMobsimTests/SecondReloadLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/SecondReloadLSPMobsimTest.java
@@ -304,7 +304,6 @@ public class SecondReloadLSPMobsimTest {
 
 	@Test
 	public void compareEvents(){
-		// 0 = "Files are equal".
-		Assert.assertEquals(0, MatsimTestUtils.compareEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" ));
+		MatsimTestUtils.assertEqualEventsFiles(utils.getClassInputDirectory() + "output_events.xml.gz", utils.getOutputDirectory() + "output_events.xml.gz" );
 	}
 }


### PR DESCRIPTION
see https://github.com/matsim-org/matsim-libs/pull/2336

can be merged after:
- [x] PR on matsim-libs is merged
- [x] matsim-version is updated in pom

