### PR TITLE
Fix Event-based scoring after fixing in MATSim-libs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.matsim</groupId>
         <artifactId>matsim-all</artifactId>
-        <version>15.0-PR2335</version>
+        <version>15.0-PR2342</version>
 <!--        <version>15.0-SNAPSHOT</version>-->
         <relativePath/>
     </parent>


### PR DESCRIPTION
- Update MATSim version to PR2342
- Score now based on `vehicleId`s also for `LinkEnterEvent`s - this fixes the issues with the missing "mobsim" `vehicleId` in those events - see https://github.com/matsim-org/matsim-libs/pull/2341