### PR TITLE
Added LogisticChainElement-Id to LSP-XML-File

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
     <parent>
         <groupId>org.matsim</groupId>
         <artifactId>matsim-all</artifactId>
-<!--		<version>15.0-PR2452</version>-->
-        <version>15.0-SNAPSHOT</version>
+		<version>16.0-PR2523</version>
+<!--        <version>15.0-SNAPSHOT</version>-->
         <relativePath/>
     </parent>
     

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
     <parent>
         <groupId>org.matsim</groupId>
         <artifactId>matsim-all</artifactId>
-		<version>15.0-PR2452</version>
-<!--        <version>15.0-SNAPSHOT</version>-->
+<!--		<version>15.0-PR2452</version>-->
+        <version>15.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     

--- a/src/main/java/lsp/LSPConstants.java
+++ b/src/main/java/lsp/LSPConstants.java
@@ -41,11 +41,11 @@ public abstract class LSPConstants {
             static final String RESOURCE = "resource";
     static final String LOGISTIC_CHAINS = "logisticChains";
             static final String LOGISTIC_CHAIN = "logisticChain";
+            static final String LOGISTIC_CHAIN_ELEMENT = "logisticChainElement";
             static final String SHIPMENT_PLANS = "shipmentPlans";
             static final String SHIPMENT_PLAN = "shipmentPlan";
                 static final String SHIPMENT_ID = "shipmentId";
                 static final String ELEMENT = "element";
-                    static final String ELEMENT_ID = "id";
                     static final String TYPE = "type";
                     static final String START_TIME = "startTime";
                     static final String END_TIME = "endTime";

--- a/src/main/java/lsp/LSPPlanXmlParserV1.java
+++ b/src/main/java/lsp/LSPPlanXmlParserV1.java
@@ -208,10 +208,7 @@ class LSPPlanXmlParserV1 extends MatsimXmlParser {
 			}
 			case LOGISTIC_CHAIN_ELEMENT -> {
 				String logisticChainElementId = atts.getValue(ID);
-//				logisticChainElementIds.add(logisticChainElementId);
-
 				String resourceId = atts.getValue(RESOURCE_ID);
-//				lspResourceIds.add(resourceId);
 
 				elementIdResourceIdMap.put(logisticChainElementId, resourceId);
 			}
@@ -336,6 +333,8 @@ class LSPPlanXmlParserV1 extends MatsimXmlParser {
 						}
 					}
 				}
+
+				elementIdResourceIdMap.clear();
 
 				//create logisticChain
 				LogisticChain logisticChain = LSPUtils.LogisticChainBuilder.newInstance(Id.create(chainId, LogisticChain.class))

--- a/src/main/java/lsp/LSPPlanXmlWriter.java
+++ b/src/main/java/lsp/LSPPlanXmlWriter.java
@@ -173,7 +173,8 @@ public class LSPPlanXmlWriter extends MatsimXmlWriter {
 			for (LogisticChain logisticChain : plan.getLogisticChain()) {
 				writer.write("\t\t\t\t\t\t<" + LOGISTIC_CHAIN + " " + ID + "=\"" + logisticChain.getId() + "\">\n");
 				for (LogisticChainElement chainElement : logisticChain.getLogisticChainElements()) {
-					writer.write("\t\t\t\t\t\t\t<" + RESOURCE + " " + ID + "=\"" + chainElement.getResource().getId() + "\"/>\n");
+					writer.write("\t\t\t\t\t\t\t<" + LOGISTIC_CHAIN_ELEMENT + " " + ID + "=\"" + chainElement.getId() + "\" ");
+					writer.write(RESOURCE_ID + "=\"" + chainElement.getResource().getId() + "\"/>\n");
 				}
 				writer.write("\t\t\t\t\t\t</" + LOGISTIC_CHAIN + ">\n");
 				writer.write("\t\t\t\t\t</" + LOGISTIC_CHAINS + ">\n");

--- a/src/main/java/lsp/usecase/UsecaseUtils.java
+++ b/src/main/java/lsp/usecase/UsecaseUtils.java
@@ -437,14 +437,19 @@ public class UsecaseUtils {
 
 	private static final String CARRIER_TYPE_ATTR = "carrierType" ;
 
-	public static CARRIER_TYPE getCarrierType(Carrier carrier ) {
-		String result = (String) carrier.getAttributes().getAttribute(CARRIER_TYPE_ATTR);
-		if (result == null){
-			log.warn("Requested attribute " + CARRIER_TYPE_ATTR + " does not exists. Will return " + CARRIER_TYPE.undefined );
-			return CARRIER_TYPE.undefined;
+	public static CARRIER_TYPE getCarrierType(Carrier carrier) {
+		if (carrier.getAttributes().getAttribute(CARRIER_TYPE_ATTR) instanceof CARRIER_TYPE carrierType) {
+			return carrierType;
 		} else {
-			return CARRIER_TYPE.valueOf(result);
+			String result = (String) carrier.getAttributes().getAttribute(CARRIER_TYPE_ATTR);
+			if (result == null){
+				log.warn("Requested attribute " + CARRIER_TYPE_ATTR + " does not exists. Will return " + CARRIER_TYPE.undefined );
+				return CARRIER_TYPE.undefined;
+			} else {
+				return CARRIER_TYPE.valueOf(result);
+			}
 		}
+
 	}
 	private static void setCarrierType( Carrier carrier,  CARRIER_TYPE carrierType ) {
 		carrier.getAttributes().putAttribute(CARRIER_TYPE_ATTR, carrierType ) ;

--- a/src/main/java/lsp/usecase/UsecaseUtils.java
+++ b/src/main/java/lsp/usecase/UsecaseUtils.java
@@ -438,12 +438,12 @@ public class UsecaseUtils {
 	private static final String CARRIER_TYPE_ATTR = "carrierType" ;
 
 	public static CARRIER_TYPE getCarrierType(Carrier carrier ) {
-		CARRIER_TYPE result = (CARRIER_TYPE) carrier.getAttributes().getAttribute(CARRIER_TYPE_ATTR);
+		String result = (String) carrier.getAttributes().getAttribute(CARRIER_TYPE_ATTR);
 		if (result == null){
-			log.error("Requested attribute " + CARRIER_TYPE_ATTR + " does not exists. Will return " + CARRIER_TYPE.undefined );
+			log.warn("Requested attribute " + CARRIER_TYPE_ATTR + " does not exists. Will return " + CARRIER_TYPE.undefined );
 			return CARRIER_TYPE.undefined;
 		} else {
-			return result ;
+			return CARRIER_TYPE.valueOf(result);
 		}
 	}
 	private static void setCarrierType( Carrier carrier,  CARRIER_TYPE carrierType ) {

--- a/src/test/java/lsp/LSPReadWriteTest.java
+++ b/src/test/java/lsp/LSPReadWriteTest.java
@@ -41,7 +41,7 @@ public class LSPReadWriteTest {
 	@Test
 	public void readWriteReadTest() throws FileNotFoundException, IOException {
 
-		LSPs lsPs = new LSPs(Collections.emptyList());
+		LSPs lsps = new LSPs(Collections.emptyList());
 		Carriers carriers = new Carriers();
 		CarrierVehicleTypes carrierVehicleTypes = new CarrierVehicleTypes();
 
@@ -55,17 +55,18 @@ public class LSPReadWriteTest {
 		CarrierPlanXmlReader carrierReader = new CarrierPlanXmlReader(carriers, carrierVehicleTypes);
 		carrierReader.readFile(utils.getPackageInputDirectory() + "carriers.xml");
 
-		LSPPlanXmlReader reader = new LSPPlanXmlReader(lsPs, carriers);
+		LSPPlanXmlReader reader = new LSPPlanXmlReader(lsps, carriers);
 		reader.readFile(inputFilename);
 
-		new LSPPlanXmlWriter(lsPs).write(outputFilename);
+		new LSPPlanXmlWriter(lsps).write(outputFilename);
 
-		lsPs.getLSPs().clear();
+		//clear and 2nd read - based on written file.
+		lsps.getLSPs().clear();
 
-		LSPPlanXmlReader reader2 = new LSPPlanXmlReader(lsPs, carriers);
+		LSPPlanXmlReader reader2 = new LSPPlanXmlReader(lsps, carriers);
 		reader2.readFile(outputFilename);
 
-		new LSPPlanXmlWriter(lsPs).write(outputFilename2);
+		new LSPPlanXmlWriter(lsps).write(outputFilename2);
 
 		MatsimTestUtils.assertEqualFilesLineByLine(inputFilename, outputFilename2);
 	}

--- a/src/test/java/lsp/LSPReadWriteTest.java
+++ b/src/test/java/lsp/LSPReadWriteTest.java
@@ -2,11 +2,12 @@ package lsp;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.matsim.contrib.freight.carrier.*;
+import org.matsim.contrib.freight.carrier.CarrierPlanXmlReader;
+import org.matsim.contrib.freight.carrier.CarrierVehicleTypeReader;
+import org.matsim.contrib.freight.carrier.CarrierVehicleTypes;
+import org.matsim.contrib.freight.carrier.Carriers;
 import org.matsim.testcases.MatsimTestUtils;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.util.Collections;
 
 public class LSPReadWriteTest {
@@ -15,7 +16,7 @@ public class LSPReadWriteTest {
 	public MatsimTestUtils utils = new MatsimTestUtils();
 
 	@Test
-	public void readWriteTest() throws FileNotFoundException, IOException {
+	public void readWriteTest() {
 
 		LSPs lsPs = new LSPs(Collections.emptyList());
 		Carriers carriers = new Carriers();
@@ -39,7 +40,7 @@ public class LSPReadWriteTest {
 	}
 
 	@Test
-	public void readWriteReadTest() throws FileNotFoundException, IOException {
+	public void readWriteReadTest() {
 
 		LSPs lsps = new LSPs(Collections.emptyList());
 		Carriers carriers = new Carriers();

--- a/test/input/lsp/carriers.xml
+++ b/test/input/lsp/carriers.xml
@@ -1,35 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
-	<carriers>
-		<carrier id="directCarrier">
-			<attributes>
-				<attribute name="carrierType" class="java.lang.String">distributionCarrier</attribute>
-			</attributes>
-			<capabilities fleetSize="INFINITE">
-				<vehicles>
-					<vehicle id="directTruck" depotLinkId="i(5,0)" typeId="large50" earliestStart="00:00:00" latestEnd="596523:14:07"/>
-				</vehicles>
-			</capabilities>
-		</carrier>
 
-		<carrier id="mainCarrier">
-			<attributes>
-				<attribute name="carrierType" class="java.lang.String">mainRunCarrier</attribute>
-			</attributes>
-			<capabilities fleetSize="INFINITE">
-				<vehicles>
-					<vehicle id="mainTruck" depotLinkId="i(5,0)" typeId="large50" earliestStart="00:00:00" latestEnd="596523:14:07"/>
-				</vehicles>
-			</capabilities>
-		</carrier>
+<carriers xmlns="http://www.matsim.org/files/dtd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.matsim.org/files/dtd http://www.matsim.org/files/dtd/carriersDefinitions_v2.1.xsd">
+	<carrier id="directCarrier">
+		<attributes>
+			<attribute name="carrierType" class="lsp.usecase.UsecaseUtils$CARRIER_TYPE">distributionCarrier</attribute>
+		</attributes>
+		<capabilities fleetSize="INFINITE">
+			<vehicles>
+				<vehicle id="directTruck" depotLinkId="i(5,0)" typeId="large50" earliestStart="00:00:00" latestEnd="596523:14:07"/>
+			</vehicles>
 
-		<carrier id="distributionCarrier">
-			<attributes>
-				<attribute name="carrierType" class="java.lang.String">distributionCarrier</attribute>
-			</attributes>
-			<capabilities fleetSize="INFINITE">
-				<vehicles>
-					<vehicle id="distributionTruck" depotLinkId="j(5,3)" typeId="small05" earliestStart="00:00:00" latestEnd="596523:14:07"/>
-				</vehicles>
-			</capabilities>
-		</carrier>
-	</carriers>
+		</capabilities>
+
+	</carrier>
+
+	<carrier id="mainCarrier">
+		<attributes>
+			<attribute name="carrierType" class="lsp.usecase.UsecaseUtils$CARRIER_TYPE">mainRunCarrier</attribute>
+		</attributes>
+		<capabilities fleetSize="INFINITE">
+			<vehicles>
+				<vehicle id="mainTruck" depotLinkId="i(5,0)" typeId="large50" earliestStart="00:00:00" latestEnd="596523:14:07"/>
+			</vehicles>
+
+		</capabilities>
+
+	</carrier>
+
+	<carrier id="distributionCarrier">
+		<attributes>
+			<attribute name="carrierType" class="lsp.usecase.UsecaseUtils$CARRIER_TYPE">distributionCarrier</attribute>
+		</attributes>
+		<capabilities fleetSize="INFINITE">
+			<vehicles>
+				<vehicle id="distributionTruck" depotLinkId="j(5,3)" typeId="small05" earliestStart="00:00:00" latestEnd="596523:14:07"/>
+			</vehicles>
+
+		</capabilities>
+
+	</carrier>
+
+</carriers>

--- a/test/input/lsp/carriers.xml
+++ b/test/input/lsp/carriers.xml
@@ -2,7 +2,7 @@
 	<carriers>
 		<carrier id="directCarrier">
 			<attributes>
-				<attribute name="carrierType" class="lsp.usecase.UsecaseUtils$CARRIER_TYPE">distributionCarrier</attribute>
+				<attribute name="carrierType" class="java.lang.String">distributionCarrier</attribute>
 			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
@@ -13,7 +13,7 @@
 
 		<carrier id="mainCarrier">
 			<attributes>
-				<attribute name="carrierType" class="lsp.usecase.UsecaseUtils$CARRIER_TYPE">mainRunCarrier</attribute>
+				<attribute name="carrierType" class="java.lang.String">mainRunCarrier</attribute>
 			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
@@ -24,7 +24,7 @@
 
 		<carrier id="distributionCarrier">
 			<attributes>
-				<attribute name="carrierType" class="lsp.usecase.UsecaseUtils$CARRIER_TYPE">distributionCarrier</attribute>
+				<attribute name="carrierType" class="java.lang.String">distributionCarrier</attribute>
 			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>

--- a/test/input/lsp/lsps.xml
+++ b/test/input/lsp/lsps.xml
@@ -30,7 +30,7 @@
 				<plan score="-1476.2" selected="false">
 					<logisticChains>
 						<logisticChain id="directSolution">
-							<resource id="directCarrier"/>
+							<logisticChainElement id="directCarrierLSE" resourceId="directCarrier"/>
 						</logisticChain>
 					</logisticChains>
 					<shipmentPlans>
@@ -129,9 +129,9 @@
 				<plan score="-492.33" selected="true">
 					<logisticChains>
 						<logisticChain id="hubSolution">
-							<resource id="mainCarrier"/>
-							<resource id="Hub"/>
-							<resource id="distributionCarrier"/>
+							<logisticChainElement id="mainCarrierLSE" resourceId="mainCarrier"/>
+							<logisticChainElement id="HubLSE" resourceId="Hub"/>
+							<logisticChainElement id="distributionCarrierLSE" resourceId="distributionCarrier"/>
 						</logisticChain>
 					</logisticChains>
 					<shipmentPlans>


### PR DESCRIPTION
Added constant to LSPConstants, amended LSPPlanXmlWriter and LSPPlanXmlParserV1 
getCarrierType able to return Carrier type directly without casting to String
