### PR TITLE
Write out LSPs in each iteration

### DIFF
--- a/src/main/java/example/lsp/initialPlans/ExampleTwoChains.java
+++ b/src/main/java/example/lsp/initialPlans/ExampleTwoChains.java
@@ -19,6 +19,7 @@ import org.matsim.contrib.freight.controler.FreightUtils;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.config.groups.VspExperimentalConfigGroup;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
@@ -94,6 +95,9 @@ public class ExampleTwoChains {
 		});
 
 		log.info("Run MATSim");
+
+		//The VSP default settings are designed for person transport simulation. After talking to Kai, they will be set to WARN here. Kai MT may'23
+		controler.getConfig().vspExperimental().setVspDefaultsCheckingLevel(VspExperimentalConfigGroup.VspDefaultsCheckingLevel.warn);
 		controler.run();
 
 		new LSPPlanXmlWriter(LSPUtils.getLSPs(controler.getScenario())).write(controler.getConfig().controler().getOutputDirectory() + "/lsps.xml");

--- a/src/main/java/example/lsp/initialPlans/ExampleTwoChains.java
+++ b/src/main/java/example/lsp/initialPlans/ExampleTwoChains.java
@@ -128,7 +128,7 @@ public class ExampleTwoChains {
 			config.controler().setLastIteration(2);
 		}
 		config.network().setInputFile(String.valueOf(IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("freight-chessboard-9x9"), "grid9x9.xml")));
-		config.controler().setOverwriteFileSetting(OutputDirectoryHierarchy.OverwriteFileSetting.overwriteExistingFiles);
+		config.controler().setOverwriteFileSetting(OutputDirectoryHierarchy.OverwriteFileSetting.deleteDirectoryIfExists);
 		config.controler().setWriteEventsInterval(1);
 
 		FreightConfigGroup freightConfig = ConfigUtils.addOrGetModule(config, FreightConfigGroup.class);

--- a/src/main/java/lsp/LSPControlerListener.java
+++ b/src/main/java/lsp/LSPControlerListener.java
@@ -54,6 +54,7 @@ class LSPControlerListener implements BeforeMobsimListener, AfterMobsimListener,
 	@Inject private MatsimServices matsimServices;
 	@Inject private LSPScorerFactory lspScoringFunctionFactory;
 	@Inject @Nullable private LSPStrategyManager strategyManager;
+	@Inject private OutputDirectoryHierarchy controlerIO;
 
 	@Inject private CarrierAgentTracker carrierAgentTracker;
 
@@ -176,7 +177,6 @@ class LSPControlerListener implements BeforeMobsimListener, AfterMobsimListener,
 
 	@Override
 	public void notifyIterationEnds(IterationEndsEvent event) {
-//		var io = new OutputDirectoryHierarchy(scenario.getConfig());
-//		new LSPPlanXmlWriter(LSPUtils.getLSPs(scenario)).write(io.getIterationFilename(event.getIteration(), "lsps.xml"));
+		new LSPPlanXmlWriter(LSPUtils.getLSPs(scenario)).write(controlerIO.getIterationFilename(event.getIteration(), "lsps.xml"));
 	}
 }


### PR DESCRIPTION
This is working now.
The `lsps.xml` will be written out in the regular `it.`-directories.

@nixlaos: The trick was to inject the `controlerIO` so the same one is used in each iteration. In our first try, we have built it up every time. Due to that, it then every time deleted the directory again, and thus it was not there as expected :(