### PR TITLE
Update to MATSim 16.0-PR2621

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
     <parent>
         <groupId>org.matsim</groupId>
         <artifactId>matsim-all</artifactId>
-<!--		<version>16.0-2023w19</version>-->
-        <version>16.0-2023w23</version>
+		<version>16.0-PR2621</version>
+<!--        <version>16.0-2023w23</version>-->
 <!--        <version>16.0-SNAPSHOT</version>-->
         <relativePath/>
     </parent>


### PR DESCRIPTION
To use the updated `CarrierPlanWriter`.

Will be merged tomorrow, once the new MATSim-Version is available.