### PR TITLE
Fix thesis branch

### DIFF
--- a/src/main/java/example/lsp/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirect.java
+++ b/src/main/java/example/lsp/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirect.java
@@ -20,7 +20,7 @@
 
 package example.lsp.initialPlans;
 
-import example.lsp.multipleChains.AssignmentStrategyFactory;
+import example.lsp.lspReplanning.AssignmentStrategyFactory;
 import lsp.*;
 import lsp.resourceImplementations.distributionCarrier.DistributionCarrierUtils;
 import lsp.resourceImplementations.mainRunCarrier.MainRunCarrierUtils;

--- a/src/main/java/example/lsp/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirect.java
+++ b/src/main/java/example/lsp/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirect.java
@@ -20,6 +20,7 @@
 
 package example.lsp.initialPlans;
 
+import example.lsp.multipleChains.AssignmentStrategyFactory;
 import lsp.*;
 import lsp.resourceImplementations.distributionCarrier.DistributionCarrierUtils;
 import lsp.resourceImplementations.mainRunCarrier.MainRunCarrierUtils;
@@ -146,7 +147,7 @@ import java.util.*;
 				// The above means there will be no replanning.  The below needs at least one strategy to be happy.  kai, jul'22
 				bind( LSPStrategyManager.class ).toProvider(() -> {
 					LSPStrategyManager strategyManager = new LSPStrategyManagerImpl();
-					strategyManager.addStrategy(new GenericPlanStrategyImpl<>(new RandomPlanSelector<>()), null, 1. );
+					strategyManager.addStrategy(new AssignmentStrategyFactory().createStrategy(), null, 1);
 					return strategyManager;
 				});
 				bind( CarrierStrategyManager.class ).toProvider(() -> {

--- a/src/main/java/example/lsp/lspReplanning/AssignmentStrategyFactory.java
+++ b/src/main/java/example/lsp/lspReplanning/AssignmentStrategyFactory.java
@@ -12,6 +12,19 @@ import org.matsim.core.replanning.ReplanningContext;
 import org.matsim.core.replanning.modules.GenericPlanStrategyModule;
 import org.matsim.core.replanning.selectors.RandomPlanSelector;
 
+/**
+ * @deprecated  This class is a work-around. Please do not use this method for any new runs!
+ * <p>
+ * The plan-handling below was previously done in the LSPControlerListener during replanning.
+ * Since we (nrichter, kturner) are now running with one replanning strategies, which will allow to move shipments within
+ * the same (LSP) plan to a different logisticChain. As a consequence, the code below is not needed for us (starting from now).
+ * More than that, it is in part working against the new workflow, because the (re) assignment should **not** be done during replanning anymore.
+ * <p>
+ * The code here is used so that the old stuff from (tm).
+ * It keeps this old behaviour (and tests passing) with its own strategy, instead running it for everyone.
+ * <p>
+ * nrichter, kturner Jul'23
+ */
 @Deprecated
 public class AssignmentStrategyFactory {
 

--- a/src/main/java/example/lsp/lspReplanning/AssignmentStrategyFactory.java
+++ b/src/main/java/example/lsp/lspReplanning/AssignmentStrategyFactory.java
@@ -1,4 +1,4 @@
-package example.lsp.multipleChains;
+package example.lsp.lspReplanning;
 
 import lsp.LSP;
 import lsp.LSPPlan;

--- a/src/main/java/example/lsp/lspReplanning/TomorrowShipmentAssignerStrategyFactory.java
+++ b/src/main/java/example/lsp/lspReplanning/TomorrowShipmentAssignerStrategyFactory.java
@@ -20,10 +20,9 @@
 
 package example.lsp.lspReplanning;
 
-import lsp.LSP;
-import lsp.LSPPlan;
-import lsp.ShipmentAssigner;
+import lsp.*;
 import lsp.shipment.LSPShipment;
+import lsp.shipment.ShipmentUtils;
 import org.matsim.core.replanning.GenericPlanStrategy;
 import org.matsim.core.replanning.GenericPlanStrategyImpl;
 import org.matsim.core.replanning.ReplanningContext;
@@ -32,6 +31,7 @@ import org.matsim.core.replanning.selectors.BestPlanSelector;
 
 import java.util.Collection;
 
+@Deprecated
 /*package-private*/ class TomorrowShipmentAssignerStrategyFactory {
 
 	private final ShipmentAssigner assigner;
@@ -60,6 +60,20 @@ import java.util.Collection;
 				Collection<LSPShipment> shipments = lsp.getShipments();
 				for (LSPShipment shipment : shipments) {
 					assigner.assignToPlan(plan ,shipment);
+				}
+
+				for (LogisticChain solution : plan.getLogisticChains()) {
+					solution.getShipmentIds().clear();
+					for (LogisticChainElement element : solution.getLogisticChainElements()) {
+						element.getIncomingShipments().clear();
+						element.getOutgoingShipments().clear();
+					}
+				}
+
+				for (LSPShipment shipment : plan.getLSP().getShipments()) {
+					ShipmentUtils.getOrCreateShipmentPlan(plan, shipment.getId()).clear();
+					shipment.getShipmentLog().clear();
+					plan.getAssigner().assignToPlan(plan, shipment);
 				}
 			}
 

--- a/src/main/java/example/lsp/multipleChains/AssignmentStrategyFactory.java
+++ b/src/main/java/example/lsp/multipleChains/AssignmentStrategyFactory.java
@@ -1,0 +1,58 @@
+package example.lsp.multipleChains;
+
+import lsp.LSP;
+import lsp.LSPPlan;
+import lsp.LogisticChain;
+import lsp.LogisticChainElement;
+import lsp.shipment.LSPShipment;
+import lsp.shipment.ShipmentUtils;
+import org.matsim.core.replanning.GenericPlanStrategy;
+import org.matsim.core.replanning.GenericPlanStrategyImpl;
+import org.matsim.core.replanning.ReplanningContext;
+import org.matsim.core.replanning.modules.GenericPlanStrategyModule;
+import org.matsim.core.replanning.selectors.RandomPlanSelector;
+
+@Deprecated
+public class AssignmentStrategyFactory {
+
+	public AssignmentStrategyFactory() {
+	}
+
+	public GenericPlanStrategy<LSPPlan, LSP> createStrategy() {
+
+		GenericPlanStrategyImpl<LSPPlan, LSP> strategy = new GenericPlanStrategyImpl<>(new RandomPlanSelector<>());
+		GenericPlanStrategyModule<LSPPlan> assignmentModule = new GenericPlanStrategyModule<>() {
+
+			@Override
+			public void prepareReplanning(ReplanningContext replanningContext) {
+			}
+
+			@Override
+			public void handlePlan(LSPPlan lspPlan) {
+
+				for (LogisticChain solution : lspPlan.getLogisticChains()) {
+					solution.getShipmentIds().clear();
+					for (LogisticChainElement element : solution.getLogisticChainElements()) {
+						element.getIncomingShipments().clear();
+						element.getOutgoingShipments().clear();
+					}
+				}
+
+				for (LSPShipment shipment : lspPlan.getLSP().getShipments()) {
+					ShipmentUtils.getOrCreateShipmentPlan(lspPlan, shipment.getId()).clear();
+					shipment.getShipmentLog().clear();
+					lspPlan.getAssigner().assignToPlan(lspPlan, shipment);
+				}
+			}
+
+			@Override
+			public void finishReplanning() {
+			}
+
+		};
+
+		strategy.addStrategyModule(assignmentModule);
+		return strategy;
+	}
+
+}

--- a/src/main/java/lsp/LSPControlerListener.java
+++ b/src/main/java/lsp/LSPControlerListener.java
@@ -23,7 +23,6 @@ package lsp;
 
 import jakarta.inject.Inject;
 import lsp.shipment.LSPShipment;
-import lsp.shipment.ShipmentUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Scenario;
@@ -45,21 +44,17 @@ import java.util.List;
 
 
 class LSPControlerListener implements BeforeMobsimListener, AfterMobsimListener, ScoringListener,
-							  ReplanningListener, IterationStartsListener, IterationEndsListener, ShutdownListener {
+		ReplanningListener, IterationStartsListener, IterationEndsListener, ShutdownListener {
 	private static final Logger log = LogManager.getLogger( LSPControlerListener.class );
 	private final Scenario scenario;
-
 	private final List<EventHandler> registeredHandlers = new ArrayList<>();
-//	private CarrierAgentTracker carrierResourceTracker;
 
 	@Inject private EventsManager eventsManager;
 	@Inject private MatsimServices matsimServices;
 	@Inject private LSPScorerFactory lspScoringFunctionFactory;
 	@Inject @Nullable private LSPStrategyManager strategyManager;
 	@Inject private OutputDirectoryHierarchy controlerIO;
-
 	@Inject private CarrierAgentTracker carrierAgentTracker;
-
 	@Inject LSPControlerListener( Scenario scenario ) {
 		this.scenario = scenario;
 	}
@@ -123,9 +118,9 @@ class LSPControlerListener implements BeforeMobsimListener, AfterMobsimListener,
 		LSPs lsps = LSPUtils.getLSPs(scenario);
 		strategyManager.run(lsps.getLSPs().values(), event.getIteration(), event.getReplanningContext());
 
-			for (LSP lsp : lsps.getLSPs().values()) {
-				lsp.scheduleLogisticChains();
-			}
+		for (LSP lsp : lsps.getLSPs().values()) {
+			lsp.scheduleLogisticChains();
+		}
 
 		//Update carriers in scenario and CarrierAgentTracker
 		carrierAgentTracker.getCarriers().getCarriers().clear();
@@ -149,9 +144,9 @@ class LSPControlerListener implements BeforeMobsimListener, AfterMobsimListener,
 	}
 
 
-
 	Carriers getCarriersFromLSP() {
 		LSPs lsps = LSPUtils.getLSPs(scenario);
+		assert ! lsps.getLSPs().isEmpty();
 
 		Carriers carriers = new Carriers();
 		for (LSP lsp : lsps.getLSPs().values()) {

--- a/src/main/java/lsp/LSPControlerListener.java
+++ b/src/main/java/lsp/LSPControlerListener.java
@@ -121,42 +121,18 @@ class LSPControlerListener implements BeforeMobsimListener, AfterMobsimListener,
 		}
 
 		LSPs lsps = LSPUtils.getLSPs(scenario);
-		strategyManager.run( lsps.getLSPs().values(), event.getIteration(), event.getReplanningContext() );
-//		for( LSP lsp : lsps.getLSPs().values() ){
-//			lsp.getSelectedPlan().getAssigner().setLSP(lsp);//TODO: Feels weird, but getting NullPointer because of missing lsp inside the assigner
-//			//TODO: Do we need to do it for each plan, if it gets selected???
-//			// yyyyyy Means IMO that something is incomplete with the plans copying.  kai, jul'22
-//		}
-//
-		if (event.getIteration() != 0) {
-			for (LSP lsp : lsps.getLSPs().values()) {
-				for (LogisticChain solution : lsp.getSelectedPlan().getLogisticChains()) {
-					solution.getShipmentIds().clear();
-					for (LogisticChainElement element : solution.getLogisticChainElements()) {
-						element.getIncomingShipments().clear();
-						element.getOutgoingShipments().clear();
-					}
-				}
+		strategyManager.run(lsps.getLSPs().values(), event.getIteration(), event.getReplanningContext());
 
-				for (LSPShipment shipment : lsp.getShipments()) {
-					ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).clear();
-					shipment.getShipmentLog().clear();
-//					lsp.getSelectedPlan().getAssigner().assignToPlan(lsp.getSelectedPlan(), shipment);
-				}
+			for (LSP lsp : lsps.getLSPs().values()) {
 				lsp.scheduleLogisticChains();
 			}
-		}
-//
+
 		//Update carriers in scenario and CarrierAgentTracker
 		carrierAgentTracker.getCarriers().getCarriers().clear();
 		for (Carrier carrier : getCarriersFromLSP().getCarriers().values()) {
 			FreightUtils.getCarriers(scenario).addCarrier(carrier);
 			carrierAgentTracker.getCarriers().addCarrier(carrier);
 		}
-
-//		for (LSP lsp : lsps.getLSPs().values()) {
-//			lsp.scheduleLogisticChains();
-//		}
 
 	}
 

--- a/src/main/java/lsp/LSPControlerListener.java
+++ b/src/main/java/lsp/LSPControlerListener.java
@@ -141,7 +141,7 @@ class LSPControlerListener implements BeforeMobsimListener, AfterMobsimListener,
 				for (LSPShipment shipment : lsp.getShipments()) {
 					ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).clear();
 					shipment.getShipmentLog().clear();
-					lsp.getSelectedPlan().getAssigner().assignToPlan(lsp.getSelectedPlan(), shipment);
+//					lsp.getSelectedPlan().getAssigner().assignToPlan(lsp.getSelectedPlan(), shipment);
 				}
 				lsp.scheduleLogisticChains();
 			}

--- a/src/test/java/example/lsp/multipleChains/MultipleChainsReplanningTest.java
+++ b/src/test/java/example/lsp/multipleChains/MultipleChainsReplanningTest.java
@@ -55,11 +55,11 @@ public class MultipleChainsReplanningTest {
 			.build();
 
 	int initialPlanCount;
-	int initialPlanShipmentPlanCount = 0;
+	int initialPlanShipmentPlanCount;
 
-	int updatedPlanCount = 0;
-	int innovatedPlanShipmentPlanCount = 0;
-	int innovatedPlanFirstLogisticChainShipmentCount = 0;
+	int updatedPlanCount;
+	int innovatedPlanShipmentPlanCount;
+	int innovatedPlanFirstLogisticChainShipmentCount;
 	boolean innovatedPlanHasEmptyShipmentPlanElements = false;
 
 	@Before
@@ -191,7 +191,7 @@ public class MultipleChainsReplanningTest {
 					.addLogisticChainElement(rightCarrierElement)
 					.build();
 
-			final ShipmentAssigner shipmentAssigner = Utils.createRandomLogisticChainShipmentAssigner();
+			final ShipmentAssigner shipmentAssigner = Utils.createRoundRobinLogisticChainShipmentAssigner();
 			multipleOneEchelonChainsPlan = LSPUtils.createLSPPlan()
 					.addLogisticChain(leftChain)
 					.addLogisticChain(rightChain)

--- a/src/test/java/lspMobsimTests/MultipleIterationsCompleteLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleIterationsCompleteLSPMobsimTest.java
@@ -20,7 +20,7 @@
 
 package lspMobsimTests;
 
-import example.lsp.multipleChains.AssignmentStrategyFactory;
+import example.lsp.lspReplanning.AssignmentStrategyFactory;
 import lsp.*;
 import lsp.resourceImplementations.distributionCarrier.DistributionCarrierUtils;
 import lsp.resourceImplementations.collectionCarrier.CollectionCarrierUtils;

--- a/src/test/java/lspMobsimTests/MultipleIterationsCompleteLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleIterationsCompleteLSPMobsimTest.java
@@ -20,6 +20,7 @@
 
 package lspMobsimTests;
 
+import example.lsp.multipleChains.AssignmentStrategyFactory;
 import lsp.*;
 import lsp.resourceImplementations.distributionCarrier.DistributionCarrierUtils;
 import lsp.resourceImplementations.collectionCarrier.CollectionCarrierUtils;
@@ -309,7 +310,11 @@ public class MultipleIterationsCompleteLSPMobsimTest {
 		controler.addOverridingModule(new LSPModule());
 		controler.addOverridingModule( new AbstractModule(){
 			@Override public void install(){
-				bind( LSPStrategyManager.class ).toInstance( new LSPModule.LSPStrategyManagerEmptyImpl() );
+				bind( LSPStrategyManager.class ).toProvider(() -> {
+					LSPStrategyManager strategyManager = new LSPStrategyManagerImpl();
+					strategyManager.addStrategy(new AssignmentStrategyFactory().createStrategy(), null, 1);
+					return strategyManager;
+				});
 				bind( CarrierStrategyManager.class ).toProvider(() -> {
 					CarrierStrategyManager strategyManager = FreightUtils.createDefaultCarrierStrategyManager();
 					strategyManager.addStrategy(new GenericPlanStrategyImpl<>(new RandomPlanSelector<>()), null, 1);

--- a/src/test/java/lspMobsimTests/MultipleIterationsFirstReloadLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleIterationsFirstReloadLSPMobsimTest.java
@@ -20,7 +20,7 @@
 
 package lspMobsimTests;
 
-import example.lsp.multipleChains.AssignmentStrategyFactory;
+import example.lsp.lspReplanning.AssignmentStrategyFactory;
 import lsp.*;
 import lsp.resourceImplementations.collectionCarrier.CollectionCarrierUtils;
 import lsp.resourceImplementations.transshipmentHub.TranshipmentHubUtils;

--- a/src/test/java/lspMobsimTests/MultipleIterationsFirstReloadLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleIterationsFirstReloadLSPMobsimTest.java
@@ -20,6 +20,7 @@
 
 package lspMobsimTests;
 
+import example.lsp.multipleChains.AssignmentStrategyFactory;
 import lsp.*;
 import lsp.resourceImplementations.collectionCarrier.CollectionCarrierUtils;
 import lsp.resourceImplementations.transshipmentHub.TranshipmentHubUtils;
@@ -213,7 +214,11 @@ public class MultipleIterationsFirstReloadLSPMobsimTest {
 		controler.addOverridingModule(new LSPModule());
 		controler.addOverridingModule( new AbstractModule(){
 			@Override public void install(){
-				bind( LSPStrategyManager.class ).toInstance( new LSPModule.LSPStrategyManagerEmptyImpl() );
+				bind( LSPStrategyManager.class ).toProvider(() -> {
+					LSPStrategyManager strategyManager = new LSPStrategyManagerImpl();
+					strategyManager.addStrategy(new AssignmentStrategyFactory().createStrategy(), null, 1);
+					return strategyManager;
+				});
 				bind( CarrierStrategyManager.class ).toProvider(() -> {
 					CarrierStrategyManager strategyManager = FreightUtils.createDefaultCarrierStrategyManager();
 					strategyManager.addStrategy(new GenericPlanStrategyImpl<>(new RandomPlanSelector<>()), null, 1);

--- a/src/test/java/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
@@ -20,6 +20,7 @@
 
 package lspMobsimTests;
 
+import example.lsp.multipleChains.AssignmentStrategyFactory;
 import lsp.*;
 import lsp.resourceImplementations.collectionCarrier.CollectionCarrierUtils;
 import lsp.resourceImplementations.mainRunCarrier.MainRunCarrierUtils;
@@ -250,7 +251,11 @@ public class MultipleIterationsMainRunLSPMobsimTest {
 		controler.addOverridingModule(new LSPModule());
 		controler.addOverridingModule( new AbstractModule(){
 			@Override public void install(){
-				bind( LSPStrategyManager.class ).toInstance( new LSPModule.LSPStrategyManagerEmptyImpl() );
+				bind( LSPStrategyManager.class ).toProvider(() -> {
+					LSPStrategyManager strategyManager = new LSPStrategyManagerImpl();
+					strategyManager.addStrategy(new AssignmentStrategyFactory().createStrategy(), null, 1);
+					return strategyManager;
+				});
 				bind( CarrierStrategyManager.class ).toProvider(() -> {
 					CarrierStrategyManager strategyManager = FreightUtils.createDefaultCarrierStrategyManager();
 					strategyManager.addStrategy(new GenericPlanStrategyImpl<>(new RandomPlanSelector<>()), null, 1);

--- a/src/test/java/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
@@ -20,7 +20,7 @@
 
 package lspMobsimTests;
 
-import example.lsp.multipleChains.AssignmentStrategyFactory;
+import example.lsp.lspReplanning.AssignmentStrategyFactory;
 import lsp.*;
 import lsp.resourceImplementations.collectionCarrier.CollectionCarrierUtils;
 import lsp.resourceImplementations.mainRunCarrier.MainRunCarrierUtils;

--- a/src/test/java/lspMobsimTests/MultipleIterationsSecondReloadLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleIterationsSecondReloadLSPMobsimTest.java
@@ -20,7 +20,7 @@
 
 package lspMobsimTests;
 
-import example.lsp.multipleChains.AssignmentStrategyFactory;
+import example.lsp.lspReplanning.AssignmentStrategyFactory;
 import lsp.*;
 import lsp.resourceImplementations.collectionCarrier.CollectionCarrierUtils;
 import lsp.resourceImplementations.mainRunCarrier.MainRunCarrierUtils;

--- a/src/test/java/lspMobsimTests/MultipleIterationsSecondReloadLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleIterationsSecondReloadLSPMobsimTest.java
@@ -20,6 +20,7 @@
 
 package lspMobsimTests;
 
+import example.lsp.multipleChains.AssignmentStrategyFactory;
 import lsp.*;
 import lsp.resourceImplementations.collectionCarrier.CollectionCarrierUtils;
 import lsp.resourceImplementations.mainRunCarrier.MainRunCarrierUtils;
@@ -272,7 +273,11 @@ public class MultipleIterationsSecondReloadLSPMobsimTest {
 		controler.addOverridingModule(new LSPModule());
 		controler.addOverridingModule( new AbstractModule(){
 			@Override public void install(){
-				bind( LSPStrategyManager.class ).toInstance( new LSPModule.LSPStrategyManagerEmptyImpl() );
+				bind( LSPStrategyManager.class ).toProvider(() -> {
+					LSPStrategyManager strategyManager = new LSPStrategyManagerImpl();
+					strategyManager.addStrategy(new AssignmentStrategyFactory().createStrategy(), null, 1);
+					return strategyManager;
+				});
 				bind( CarrierStrategyManager.class ).toProvider(() -> {
 					CarrierStrategyManager strategyManager = FreightUtils.createDefaultCarrierStrategyManager();
 					strategyManager.addStrategy(new GenericPlanStrategyImpl<>(new RandomPlanSelector<>()), null, 1);

--- a/src/test/java/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
@@ -20,7 +20,7 @@
 
 package lspMobsimTests;
 
-import example.lsp.multipleChains.AssignmentStrategyFactory;
+import example.lsp.lspReplanning.AssignmentStrategyFactory;
 import lsp.*;
 import lsp.resourceImplementations.distributionCarrier.DistributionCarrierUtils;
 import lsp.resourceImplementations.collectionCarrier.CollectionCarrierUtils;

--- a/src/test/java/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
@@ -20,6 +20,7 @@
 
 package lspMobsimTests;
 
+import example.lsp.multipleChains.AssignmentStrategyFactory;
 import lsp.*;
 import lsp.resourceImplementations.distributionCarrier.DistributionCarrierUtils;
 import lsp.resourceImplementations.collectionCarrier.CollectionCarrierUtils;
@@ -312,7 +313,11 @@ public class MultipleShipmentsCompleteLSPMobsimTest {
 		controler.addOverridingModule(new LSPModule());
 		controler.addOverridingModule( new AbstractModule(){
 			@Override public void install(){
-				bind( LSPStrategyManager.class ).toInstance( new LSPModule.LSPStrategyManagerEmptyImpl() );
+				bind( LSPStrategyManager.class ).toProvider(() -> {
+					LSPStrategyManager strategyManager = new LSPStrategyManagerImpl();
+					strategyManager.addStrategy(new AssignmentStrategyFactory().createStrategy(), null, 1);
+					return strategyManager;
+				});
 				bind( CarrierStrategyManager.class ).toProvider(() -> {
 					CarrierStrategyManager strategyManager = FreightUtils.createDefaultCarrierStrategyManager();
 					strategyManager.addStrategy(new GenericPlanStrategyImpl<>(new RandomPlanSelector<>()), null, 1);

--- a/src/test/java/lspMobsimTests/MultipleShipmentsSecondReloadLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleShipmentsSecondReloadLSPMobsimTest.java
@@ -20,7 +20,7 @@
 
 package lspMobsimTests;
 
-import example.lsp.multipleChains.AssignmentStrategyFactory;
+import example.lsp.lspReplanning.AssignmentStrategyFactory;
 import lsp.*;
 import lsp.resourceImplementations.collectionCarrier.CollectionCarrierUtils;
 import lsp.resourceImplementations.mainRunCarrier.MainRunCarrierUtils;

--- a/src/test/java/lspMobsimTests/MultipleShipmentsSecondReloadLSPMobsimTest.java
+++ b/src/test/java/lspMobsimTests/MultipleShipmentsSecondReloadLSPMobsimTest.java
@@ -20,6 +20,7 @@
 
 package lspMobsimTests;
 
+import example.lsp.multipleChains.AssignmentStrategyFactory;
 import lsp.*;
 import lsp.resourceImplementations.collectionCarrier.CollectionCarrierUtils;
 import lsp.resourceImplementations.mainRunCarrier.MainRunCarrierUtils;
@@ -272,7 +273,11 @@ public class MultipleShipmentsSecondReloadLSPMobsimTest {
 		controler.addOverridingModule(new LSPModule());
 		controler.addOverridingModule( new AbstractModule(){
 			@Override public void install(){
-				bind( LSPStrategyManager.class ).toInstance( new LSPModule.LSPStrategyManagerEmptyImpl() );
+				bind( LSPStrategyManager.class ).toProvider(() -> {
+					LSPStrategyManager strategyManager = new LSPStrategyManagerImpl();
+					strategyManager.addStrategy(new AssignmentStrategyFactory().createStrategy(), null, 1);
+					return strategyManager;
+				});
 				bind( CarrierStrategyManager.class ).toProvider(() -> {
 					CarrierStrategyManager strategyManager = FreightUtils.createDefaultCarrierStrategyManager();
 					strategyManager.addStrategy(new GenericPlanStrategyImpl<>(new RandomPlanSelector<>()), null, 1);


### PR DESCRIPTION
With this PR, the errors in the `thesis`-branch of @nixlaos are fixed.

It mostly fixes an issue with (re) assignment of shipments during replanning: The fix consists of extracting this re-assignment from the `LSPControlerListener` to an own (deprecated) strategy and adding this strategy to the previously examples / tests of Tilman M. So they will stick to their previous behavior.

As a consequence, we will not have any issues with our new replanning strategies.
In the future, the **assignment should be done once** at the beginning of the simulation. **Further changes** of the `LSPPlan` are part of the **replanning.**

After merging it into the thesis-branch, the latter one should be ready for merging into `main.`