### PR TITLE
Make LSPConstants extending CarrierConstants,

### DIFF
--- a/src/main/java/org/matsim/freight/logistics/LSPConstants.java
+++ b/src/main/java/org/matsim/freight/logistics/LSPConstants.java
@@ -1,53 +1,30 @@
 package org.matsim.freight.logistics;
 
-public abstract class LSPConstants {
+import org.matsim.freight.carriers.CarrierConstants;
 
-  public static final String LSPS_DEFINITIONS = "lspsDefinitions";
-  public static final String LSPS = "LSPs";
-  public static final String LSP = "lsp";
-  public static final String HUB = "hub";
-  public static final String LOCATION = "location";
-  public static final String FIXED_COST = "fixedCost";
-  public static final String SCHEDULER = "scheduler";
+public abstract class LSPConstants extends CarrierConstants {
+
   public static final String CAPACITY_NEED_FIXED = "capacityNeedFixed";
   public static final String CAPACITY_NEED_LINEAR = "capacityNeedLinear";
-  public static final String CARRIER = "carrier";
-  public static final String ATTRIBUTES = "attributes";
-  public static final String ATTRIBUTE = "attribute";
-  public static final String CAPABILITIES = "capabilities";
-  public static final String FLEET_SIZE = "fleetSize";
-  public static final String VEHICLE = "vehicle";
-  public static final String DEPOT_LINK_ID = "depotLinkId";
-  public static final String TYPE_ID = "typeId";
-  public static final String VEHICLE_EARLIEST_START = "earliestStart";
-  public static final String VEHICLE_LATEST_END = "latestEnd";
-  public static final String SHIPMENTS = "shipments";
-  public static final String SHIPMENT = "shipment";
-  public static final String ID = "id";
-  public static final String FROM = "from";
-  public static final String TO = "to";
-  public static final String SIZE = "size";
-  public static final String START_PICKUP = "startPickup";
-  public static final String END_PICKUP = "endPickup";
-  public static final String START_DELIVERY = "startDelivery";
-  public static final String END_DELIVERY = "endDelivery";
-  public static final String PICKUP_SERVICE_TIME = "pickupServiceTime";
-  public static final String DELIVERY_SERVICE_TIME = "deliveryServiceTime";
-  public static final String LSP_PLANS = "LspPlans";
-  public static final String LSP_PLAN = "LspPlan";
-  public static final String SCORE = "score";
-  public static final String SELECTED = "selected";
-  public static final String RESOURCES = "resources";
-  public static final String LOGISTIC_CHAINS = "logisticChains";
-  public static final String LOGISTIC_CHAIN = "logisticChain";
-  public static final String LOGISTIC_CHAIN_ELEMENT = "logisticChainElement";
-  public static final String SHIPMENT_PLANS = "shipmentPlans";
-  public static final String SHIPMENT_PLAN = "shipmentPlan";
-  public static final String SHIPMENT_ID = "shipmentId";
   public static final String CHAIN_ID = "chainId";
   public static final String ELEMENT = "element";
-  public static final String TYPE = "type";
-  public static final String START_TIME = "startTime";
   public static final String END_TIME = "endTime";
+  public static final String FIXED_COST = "fixedCost";
+  public static final String HUB = "hub";
+  public static final String LOCATION = "location";
+  public static final String LOGISTIC_CHAIN = "logisticChain";
+  public static final String LOGISTIC_CHAINS = "logisticChains";
+  public static final String LOGISTIC_CHAIN_ELEMENT = "logisticChainElement";
+  public static final String LSP = "lsp";
+  public static final String LSPS = "LSPs";
+  public static final String LSPS_DEFINITIONS = "lspsDefinitions";
+  public static final String LSP_PLAN = "LspPlan";
+  public static final String LSP_PLANS = "LspPlans";
+  public static final String RESOURCES = "resources";
   public static final String RESOURCE_ID = "resourceId";
+  public static final String SCHEDULER = "scheduler";
+  public static final String SHIPMENT_PLAN = "shipmentPlan";
+  public static final String SHIPMENT_PLANS = "shipmentPlans";
+  public static final String START_TIME = "startTime";
+  public static final String TYPE = "type";
 }

--- a/src/main/java/org/matsim/freight/logistics/io/LSPPlanXmlParserV1.java
+++ b/src/main/java/org/matsim/freight/logistics/io/LSPPlanXmlParserV1.java
@@ -21,6 +21,8 @@
 package org.matsim.freight.logistics.io;
 
 import static org.matsim.freight.logistics.LSPConstants.*;
+import static org.matsim.utils.objectattributes.attributable.AttributesUtils.ATTRIBUTE;
+import static org.matsim.utils.objectattributes.attributable.AttributesUtils.ATTRIBUTES;
 
 import java.util.*;
 import org.apache.logging.log4j.LogManager;
@@ -167,9 +169,9 @@ class LSPPlanXmlParserV1 extends MatsimXmlParser {
                 Id.create(vehicleId, Vehicle.class),
                 Id.create(depotLinkId, Link.class),
                 vehicleType);
-        String startTime = atts.getValue(VEHICLE_EARLIEST_START);
+        String startTime = atts.getValue(EARLIEST_START);
         if (startTime != null) vehicleBuilder.setEarliestStart(parseTimeToDouble(startTime));
-        String endTime = atts.getValue(VEHICLE_LATEST_END);
+        String endTime = atts.getValue(LATEST_END);
         if (endTime != null) vehicleBuilder.setLatestEnd(parseTimeToDouble(endTime));
 
         CarrierVehicle vehicle = vehicleBuilder.build();


### PR DESCRIPTION
 ..., so we can(re-)use them directly. No need to define them twice.

Use AttributeUtils.* for Attribute constants, instead of redefining them.

Sort the entries in `LSPConstants` alphabetically.