### PR TITLE
Cleanup

### DIFF
--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
@@ -230,9 +230,7 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
     double startTime = lastLeg.getExpectedDepartureTime() + lastLeg.getExpectedTransportTime();
     builder.setStartTime(startTime);
     builder.setEndTime(startTime + getUnloadEndTime(tour));
-    builder.setCarrierId(carrier.getId());
-    builder.setLinkId(tour.getEndLinkId());
-    builder.setCarrierService(serviceActivity.getService());
+
     ShipmentPlanElement unload = builder.build();
     String idString =
         unload.getResourceId()

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
@@ -145,9 +145,7 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
         legBeforeService.getExpectedDepartureTime() + legBeforeService.getExpectedTransportTime();
     builder.setStartTime(startTimeOfLoading);
     builder.setEndTime(startTimeOfLoading + tuple.getShipment().getDeliveryServiceTime());
-    builder.setCarrierId(carrier.getId());
-    builder.setLinkId(serviceActivity.getLocation());
-    builder.setCarrierService(serviceActivity.getService());
+
     ShipmentPlanElement load = builder.build();
     String idString =
         load.getResourceId() + "" + load.getLogisticChainElement().getId() + load.getElementType();

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
@@ -309,9 +309,7 @@ import org.matsim.vehicles.VehicleType;
 
     builder.setStartTime(startTime);
     builder.setEndTime(endTime);
-    builder.setCarrierId(carrier.getId());
-    builder.setLinkId(serviceActivity.getLocation());
-    builder.setCarrierService(serviceActivity.getService());
+
     ShipmentPlanElement unload = builder.build();
     String idString =
         unload.getResourceId()

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
@@ -237,9 +237,6 @@ import org.matsim.vehicles.VehicleType;
     }
     builder.setStartTime(startTimeOfTransport - cumulatedLoadingTime);
     builder.setEndTime(startTimeOfTransport);
-    builder.setCarrierId(carrier.getId());
-    builder.setLinkId(tour.getStartLinkId());
-    builder.setCarrierService(serviceActivity.getService());
 
     ShipmentPlanElement load = builder.build();
     String idString =

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/MainRunCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/MainRunCarrierScheduler.java
@@ -363,9 +363,7 @@ import org.matsim.vehicles.VehicleType;
         legAfterStart.getExpectedDepartureTime()
             + legAfterStart.getExpectedTransportTime()
             + cumulatedLoadingTime);
-    builder.setCarrierId(carrier.getId());
-    builder.setLinkId(tour.getEndLinkId());
-    builder.setCarrierService(serviceActivity.getService());
+
     ShipmentPlanElement unload = builder.build();
     String idString =
         unload.getResourceId()

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/MainRunCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/MainRunCarrierScheduler.java
@@ -262,7 +262,7 @@ import org.matsim.vehicles.VehicleType;
             for (LSPShipmentCarrierServicePair pair : pairs) {
               if (pair.tuple == carrierPair.tuple
                   && pair.service.getId() == carrierPair.service.getId()) {
-                addShipmentLoadElement(lspShipmentWithTime, tour, serviceActivity);
+                addShipmentLoadElement(lspShipmentWithTime, tour);
                 addShipmentTransportElement(lspShipmentWithTime, tour, serviceActivity);
                 addShipmentUnloadElement(lspShipmentWithTime, tour, serviceActivity);
                 addMainTourRunStartEventHandler(pair.service, lspShipmentWithTime, resource, tour);
@@ -276,7 +276,7 @@ import org.matsim.vehicles.VehicleType;
   }
 
   private void addShipmentLoadElement(
-      LspShipmentWithTime tuple, Tour tour, Tour.ServiceActivity serviceActivity) {
+      LspShipmentWithTime tuple, Tour tour) {
     ShipmentUtils.ScheduledShipmentLoadBuilder builder =
         ShipmentUtils.ScheduledShipmentLoadBuilder.newInstance();
     builder.setResourceId(resource.getId());
@@ -297,9 +297,7 @@ import org.matsim.vehicles.VehicleType;
     }
     builder.setStartTime(startTimeOfTransport - cumulatedLoadingTime);
     builder.setEndTime(startTimeOfTransport);
-    builder.setCarrierId(carrier.getId());
-    builder.setLinkId(tour.getStartLinkId());
-    builder.setCarrierService(serviceActivity.getService());
+
     ShipmentPlanElement load = builder.build();
     String idString =
         load.getResourceId()

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/TransshipmentHubTourEndEventHandler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/TransshipmentHubTourEndEventHandler.java
@@ -165,7 +165,7 @@ public class TransshipmentHubTourEndEventHandler
                 final double startTime = event.getTime();
                 final double endTime = startTime + expHandlingDuration;
 
-                logHandlingInHub(serviceActivity.getService(), event, startTime, endTime);
+                logHandlingInHub(serviceActivity.getService(), startTime, endTime);
                 throwHandlingEvent(event, lspShipment, expHandlingDuration);
               }
             }
@@ -192,7 +192,7 @@ public class TransshipmentHubTourEndEventHandler
               final double startTime = event.getTime() + expUnloadingTime;
               final double endTime = startTime + expHandlingDuration;
 
-              logHandlingInHub(carrierService, event, startTime, endTime);
+              logHandlingInHub(carrierService, startTime, endTime);
               throwHandlingEvent(event, lspShipment, expHandlingDuration);
             }
           }
@@ -224,7 +224,7 @@ public class TransshipmentHubTourEndEventHandler
   }
 
   private void logHandlingInHub(
-      CarrierService carrierService, CarrierTourEndEvent event, double startTime, double endTime) {
+          CarrierService carrierService, double startTime, double endTime) {
 
     LSPShipment lspShipment = servicesWaitedFor.get(carrierService).shipment;
 
@@ -259,16 +259,6 @@ public class TransshipmentHubTourEndEventHandler
     eventsManager.processEvent(
         new HandlingInHubStartsEvent(
             event.getTime(), linkId, lspShipment.getId(), resourceId, expHandlingDuration));
-  }
-
-  private double getUnloadEndTime(Tour tour) {
-    double unloadEndTime = 0;
-    for (TourElement element : tour.getTourElements()) {
-      if (element instanceof ServiceActivity serviceActivity) {
-        unloadEndTime = unloadEndTime + serviceActivity.getDuration();
-      }
-    }
-    return unloadEndTime;
   }
 
   private boolean allServicesAreInOnePoint(Tour tour) {

--- a/src/main/java/org/matsim/freight/logistics/shipment/ScheduledShipmentLoad.java
+++ b/src/main/java/org/matsim/freight/logistics/shipment/ScheduledShipmentLoad.java
@@ -21,8 +21,6 @@
 package org.matsim.freight.logistics.shipment;
 
 import org.matsim.api.core.v01.Id;
-import org.matsim.freight.carriers.Carrier;
-import org.matsim.freight.carriers.CarrierService;
 import org.matsim.freight.logistics.LSPResource;
 import org.matsim.freight.logistics.LogisticChainElement;
 
@@ -32,17 +30,13 @@ class ScheduledShipmentLoad implements ShipmentPlanElement {
   private final double endTime;
   private final LogisticChainElement element;
   private final Id<LSPResource> resourceId;
-  private final Id<Carrier> carrierId;
-  private final CarrierService carrierService;
 
-  ScheduledShipmentLoad(ShipmentUtils.ScheduledShipmentLoadBuilder builder) {
+    ScheduledShipmentLoad(ShipmentUtils.ScheduledShipmentLoadBuilder builder) {
     this.startTime = builder.startTime;
     this.endTime = builder.endTime;
     this.element = builder.element;
     this.resourceId = builder.resourceId;
-    this.carrierId = builder.carrierId;
-    this.carrierService = builder.carrierService;
-  }
+    }
 
   @Override
   public String getElementType() {
@@ -69,11 +63,4 @@ class ScheduledShipmentLoad implements ShipmentPlanElement {
     return resourceId;
   }
 
-  public Id<Carrier> getCarrierId() {
-    return carrierId;
-  }
-
-  public CarrierService getCarrierService() {
-    return carrierService;
-  }
 }

--- a/src/main/java/org/matsim/freight/logistics/shipment/ScheduledShipmentUnload.java
+++ b/src/main/java/org/matsim/freight/logistics/shipment/ScheduledShipmentUnload.java
@@ -32,17 +32,13 @@ class ScheduledShipmentUnload implements ShipmentPlanElement {
   private final double endTime;
   private final LogisticChainElement element;
   private final Id<LSPResource> resourceId;
-  private final Id<Carrier> carrierId;
-  private final CarrierService carrierService;
 
-  ScheduledShipmentUnload(ShipmentUtils.ScheduledShipmentUnloadBuilder builder) {
+    ScheduledShipmentUnload(ShipmentUtils.ScheduledShipmentUnloadBuilder builder) {
     this.startTime = builder.startTime;
     this.endTime = builder.endTime;
     this.element = builder.element;
     this.resourceId = builder.resourceId;
-    this.carrierId = builder.carrierId;
-    this.carrierService = builder.carrierService;
-  }
+    }
 
   @Override
   public String getElementType() {
@@ -69,11 +65,4 @@ class ScheduledShipmentUnload implements ShipmentPlanElement {
     return resourceId;
   }
 
-  public Id<Carrier> getCarrierId() {
-    return carrierId;
-  }
-
-  public CarrierService getCarrierService() {
-    return carrierService;
-  }
 }

--- a/src/main/java/org/matsim/freight/logistics/shipment/ShipmentUtils.java
+++ b/src/main/java/org/matsim/freight/logistics/shipment/ShipmentUtils.java
@@ -249,9 +249,6 @@ public final class ShipmentUtils {
     double endTime;
     LogisticChainElement element;
     Id<LSPResource> resourceId;
-    Id<Carrier> carrierId;
-    Id<Link> linkId;
-    CarrierService carrierService;
 
     private ScheduledShipmentUnloadBuilder() {}
 
@@ -273,18 +270,6 @@ public final class ShipmentUtils {
 
     public void setResourceId(Id<LSPResource> resourceId) {
       this.resourceId = resourceId;
-    }
-
-    public void setCarrierId(Id<Carrier> carrierId) {
-      this.carrierId = carrierId;
-    }
-
-    public void setLinkId(Id<Link> linkId) {
-      this.linkId = linkId;
-    }
-
-    public void setCarrierService(CarrierService carrierService) {
-      this.carrierService = carrierService;
     }
 
     public ScheduledShipmentUnload build() {

--- a/src/main/java/org/matsim/freight/logistics/shipment/ShipmentUtils.java
+++ b/src/main/java/org/matsim/freight/logistics/shipment/ShipmentUtils.java
@@ -60,49 +60,67 @@ public final class ShipmentUtils {
     return newShipmentPlan;
   }
 
-  public static final class LoggedShipmentHandleBuilder {
-    double startTime;
-    double endTime;
-    LogisticChainElement element;
-    Id<LSPResource> resourceId;
-    Id<Link> linkId;
+  public static final class LSPShipmentBuilder {
+    final Id<LSPShipment> id;
+    final List<Requirement> requirements;
+    Id<Link> fromLinkId;
+    Id<Link> toLinkId;
+    TimeWindow startTimeWindow;
+    TimeWindow endTimeWindow;
+    int capacityDemand;
+    double deliveryServiceTime;
+    double pickupServiceTime;
 
-    private LoggedShipmentHandleBuilder() {}
-
-    public static LoggedShipmentHandleBuilder newInstance() {
-      return new LoggedShipmentHandleBuilder();
+    private LSPShipmentBuilder(Id<LSPShipment> id) {
+      this.requirements = new ArrayList<>();
+      this.id = id;
     }
 
-    public LoggedShipmentHandleBuilder setStartTime(double startTime) {
-      this.startTime = startTime;
+    public static LSPShipmentBuilder newInstance(Id<LSPShipment> id) {
+      return new LSPShipmentBuilder(id);
+    }
+
+    public void setFromLinkId(Id<Link> fromLinkId) {
+      this.fromLinkId = fromLinkId;
+    }
+
+    public void setToLinkId(Id<Link> toLinkId) {
+      this.toLinkId = toLinkId;
+    }
+
+    public void setStartTimeWindow(TimeWindow startTimeWindow) {
+      this.startTimeWindow = startTimeWindow;
+    }
+
+    public void setEndTimeWindow(TimeWindow endTimeWindow) {
+      this.endTimeWindow = endTimeWindow;
+    }
+
+    public void setCapacityDemand(int capacityDemand) {
+      this.capacityDemand = capacityDemand;
+    }
+
+    public void setDeliveryServiceTime(double serviceTime) {
+      this.deliveryServiceTime = serviceTime;
+    }
+
+    public LSPShipmentBuilder setPickupServiceTime(double serviceTime) {
+      this.pickupServiceTime = serviceTime;
       return this;
     }
 
-    public LoggedShipmentHandleBuilder setEndTime(double endTime) {
-      this.endTime = endTime;
-      return this;
+    public void addRequirement(Requirement requirement) {
+      requirements.add(requirement);
     }
 
-    public LoggedShipmentHandleBuilder setLogisticsChainElement(LogisticChainElement element) {
-      this.element = element;
-      return this;
+    public LSPShipment build() {
+      return new LSPShipmentImpl(this);
     }
-
-    public LoggedShipmentHandleBuilder setResourceId(Id<LSPResource> resourceId) {
-      this.resourceId = resourceId;
-      return this;
-    }
-
-    public LoggedShipmentHandleBuilder setLinkId(Id<Link> linkId) {
-      this.linkId = linkId;
-      return this;
-    }
-
-    public ShipmentPlanElement build() {
-      return new LoggedShipmentHandle(this);
-    }
-
   }
+
+  //-----------------------------
+  // LoggedShipment<..> builders
+  //-----------------------------
 
   @SuppressWarnings("ClassEscapesDefinedScope")
   public static final class LoggedShipmentLoadBuilder {
@@ -244,16 +262,18 @@ public final class ShipmentUtils {
   }
 
   @SuppressWarnings("ClassEscapesDefinedScope")
-  public static final class ScheduledShipmentUnloadBuilder {
+  public static final class LoggedShipmentUnloadBuilder {
     double startTime;
     double endTime;
     LogisticChainElement element;
     Id<LSPResource> resourceId;
+    Id<Carrier> carrierId;
+    Id<Link> linkId;
 
-    private ScheduledShipmentUnloadBuilder() {}
+    private LoggedShipmentUnloadBuilder() {}
 
-    public static ScheduledShipmentUnloadBuilder newInstance() {
-      return new ScheduledShipmentUnloadBuilder();
+    public static LoggedShipmentUnloadBuilder newInstance() {
+      return new LoggedShipmentUnloadBuilder();
     }
 
     public void setStartTime(double startTime) {
@@ -264,7 +284,7 @@ public final class ShipmentUtils {
       this.endTime = endTime;
     }
 
-    public void setLogisticsChainElement(LogisticChainElement element) {
+    public void setLogisticChainElement(LogisticChainElement element) {
       this.element = element;
     }
 
@@ -272,8 +292,97 @@ public final class ShipmentUtils {
       this.resourceId = resourceId;
     }
 
-    public ScheduledShipmentUnload build() {
-      return new ScheduledShipmentUnload(this);
+    public void setLinkId(Id<Link> linkId) {
+      this.linkId = linkId;
+    }
+
+    public void setCarrierId(Id<Carrier> carrierId) {
+      this.carrierId = carrierId;
+    }
+
+    public LoggedShipmentUnload build() {
+      return new LoggedShipmentUnload(this);
+    }
+  }
+
+  public static final class LoggedShipmentHandleBuilder {
+    double startTime;
+    double endTime;
+    LogisticChainElement element;
+    Id<LSPResource> resourceId;
+    Id<Link> linkId;
+
+    private LoggedShipmentHandleBuilder() {}
+
+    public static LoggedShipmentHandleBuilder newInstance() {
+      return new LoggedShipmentHandleBuilder();
+    }
+
+    public LoggedShipmentHandleBuilder setStartTime(double startTime) {
+      this.startTime = startTime;
+      return this;
+    }
+
+    public LoggedShipmentHandleBuilder setEndTime(double endTime) {
+      this.endTime = endTime;
+      return this;
+    }
+
+    public LoggedShipmentHandleBuilder setLogisticsChainElement(LogisticChainElement element) {
+      this.element = element;
+      return this;
+    }
+
+    public LoggedShipmentHandleBuilder setResourceId(Id<LSPResource> resourceId) {
+      this.resourceId = resourceId;
+      return this;
+    }
+
+    public LoggedShipmentHandleBuilder setLinkId(Id<Link> linkId) {
+      this.linkId = linkId;
+      return this;
+    }
+
+    public ShipmentPlanElement build() {
+      return new LoggedShipmentHandle(this);
+    }
+  }
+
+  //-----------------------------
+  // ScheduledShipment<..> builders
+  //-----------------------------
+
+  @SuppressWarnings("ClassEscapesDefinedScope")
+  public static final class ScheduledShipmentLoadBuilder {
+    double startTime;
+    double endTime;
+    LogisticChainElement element;
+    Id<LSPResource> resourceId;
+
+    private ScheduledShipmentLoadBuilder() {}
+
+    public static ScheduledShipmentLoadBuilder newInstance() {
+      return new ScheduledShipmentLoadBuilder();
+    }
+
+    public void setStartTime(double startTime) {
+      this.startTime = startTime;
+    }
+
+    public void setEndTime(double endTime) {
+      this.endTime = endTime;
+    }
+
+    public void setLogisticChainElement(LogisticChainElement element) {
+      this.element = element;
+    }
+
+    public void setResourceId(Id<LSPResource> resourceId) {
+      this.resourceId = resourceId;
+    }
+
+    public ScheduledShipmentLoad build() {
+      return new ScheduledShipmentLoad(this);
     }
   }
 
@@ -332,16 +441,16 @@ public final class ShipmentUtils {
   }
 
   @SuppressWarnings("ClassEscapesDefinedScope")
-  public static final class ScheduledShipmentLoadBuilder {
+  public static final class ScheduledShipmentUnloadBuilder {
     double startTime;
     double endTime;
     LogisticChainElement element;
     Id<LSPResource> resourceId;
 
-    private ScheduledShipmentLoadBuilder() {}
+    private ScheduledShipmentUnloadBuilder() {}
 
-    public static ScheduledShipmentLoadBuilder newInstance() {
-      return new ScheduledShipmentLoadBuilder();
+    public static ScheduledShipmentUnloadBuilder newInstance() {
+      return new ScheduledShipmentUnloadBuilder();
     }
 
     public void setStartTime(double startTime) {
@@ -352,7 +461,7 @@ public final class ShipmentUtils {
       this.endTime = endTime;
     }
 
-    public void setLogisticChainElement(LogisticChainElement element) {
+    public void setLogisticsChainElement(LogisticChainElement element) {
       this.element = element;
     }
 
@@ -360,8 +469,8 @@ public final class ShipmentUtils {
       this.resourceId = resourceId;
     }
 
-    public ScheduledShipmentLoad build() {
-      return new ScheduledShipmentLoad(this);
+    public ScheduledShipmentUnload build() {
+      return new ScheduledShipmentUnload(this);
     }
   }
 
@@ -399,105 +508,4 @@ public final class ShipmentUtils {
     }
   }
 
-  @SuppressWarnings("ClassEscapesDefinedScope")
-  public static final class LoggedShipmentUnloadBuilder {
-    double startTime;
-    double endTime;
-    LogisticChainElement element;
-    Id<LSPResource> resourceId;
-    Id<Carrier> carrierId;
-    Id<Link> linkId;
-
-    private LoggedShipmentUnloadBuilder() {}
-
-    public static LoggedShipmentUnloadBuilder newInstance() {
-      return new LoggedShipmentUnloadBuilder();
-    }
-
-    public void setStartTime(double startTime) {
-      this.startTime = startTime;
-    }
-
-    public void setEndTime(double endTime) {
-      this.endTime = endTime;
-    }
-
-    public void setLogisticChainElement(LogisticChainElement element) {
-      this.element = element;
-    }
-
-    public void setResourceId(Id<LSPResource> resourceId) {
-      this.resourceId = resourceId;
-    }
-
-    public void setLinkId(Id<Link> linkId) {
-      this.linkId = linkId;
-    }
-
-    public void setCarrierId(Id<Carrier> carrierId) {
-      this.carrierId = carrierId;
-    }
-
-    public LoggedShipmentUnload build() {
-      return new LoggedShipmentUnload(this);
-    }
-  }
-
-  public static final class LSPShipmentBuilder {
-    final Id<LSPShipment> id;
-    final List<Requirement> requirements;
-    Id<Link> fromLinkId;
-    Id<Link> toLinkId;
-    TimeWindow startTimeWindow;
-    TimeWindow endTimeWindow;
-    int capacityDemand;
-    double deliveryServiceTime;
-    double pickupServiceTime;
-
-    private LSPShipmentBuilder(Id<LSPShipment> id) {
-      this.requirements = new ArrayList<>();
-      this.id = id;
-    }
-
-    public static LSPShipmentBuilder newInstance(Id<LSPShipment> id) {
-      return new LSPShipmentBuilder(id);
-    }
-
-    public void setFromLinkId(Id<Link> fromLinkId) {
-      this.fromLinkId = fromLinkId;
-    }
-
-    public void setToLinkId(Id<Link> toLinkId) {
-      this.toLinkId = toLinkId;
-    }
-
-    public void setStartTimeWindow(TimeWindow startTimeWindow) {
-      this.startTimeWindow = startTimeWindow;
-    }
-
-    public void setEndTimeWindow(TimeWindow endTimeWindow) {
-      this.endTimeWindow = endTimeWindow;
-    }
-
-    public void setCapacityDemand(int capacityDemand) {
-      this.capacityDemand = capacityDemand;
-    }
-
-    public void setDeliveryServiceTime(double serviceTime) {
-      this.deliveryServiceTime = serviceTime;
-    }
-
-    public LSPShipmentBuilder setPickupServiceTime(double serviceTime) {
-      this.pickupServiceTime = serviceTime;
-      return this;
-    }
-
-    public void addRequirement(Requirement requirement) {
-      requirements.add(requirement);
-    }
-
-    public LSPShipment build() {
-      return new LSPShipmentImpl(this);
-    }
-  }
 }

--- a/src/main/java/org/matsim/freight/logistics/shipment/ShipmentUtils.java
+++ b/src/main/java/org/matsim/freight/logistics/shipment/ShipmentUtils.java
@@ -352,9 +352,6 @@ public final class ShipmentUtils {
     double endTime;
     LogisticChainElement element;
     Id<LSPResource> resourceId;
-    Id<Carrier> carrierId;
-    Id<Link> linkId;
-    CarrierService carrierService;
 
     private ScheduledShipmentLoadBuilder() {}
 
@@ -376,18 +373,6 @@ public final class ShipmentUtils {
 
     public void setResourceId(Id<LSPResource> resourceId) {
       this.resourceId = resourceId;
-    }
-
-    public void setLinkId(Id<Link> linkId) {
-      this.linkId = linkId;
-    }
-
-    public void setCarrierId(Id<Carrier> carrierId) {
-      this.carrierId = carrierId;
-    }
-
-    public void setCarrierService(CarrierService carrierService) {
-      this.carrierService = carrierService;
     }
 
     public ScheduledShipmentLoad build() {


### PR DESCRIPTION
Remove `CarrierService` and other no-needed stuff from `ScheduledShipmentLoad` and `ScheduledShipmentUnload`.

We need to get rid of all that `CarrierService` objects flying around almost everywhere... because mainly the LSP has its `LSPShipments` and this (or even better its Id) should be sufficient in most cases. 

Getting rid of the `CarrierService` also allows us to decide if we want to have the VRP based on `Service`s or `Shipment`s ... see #44 