### PR TITLE
Improve solveVrpWithJsprit

### DIFF
--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/CarrierSchedulerUtils.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/CarrierSchedulerUtils.java
@@ -19,8 +19,6 @@ import org.matsim.freight.carriers.jsprit.MatsimJspritFactory;
 import org.matsim.freight.carriers.jsprit.NetworkBasedTransportCosts;
 import org.matsim.freight.carriers.jsprit.NetworkRouter;
 
-import javax.annotation.Nullable;
-
 /**
  * This class contains some code fragments, that are used in the different *CarrierScheduler
  * classes. To avoid code duplication these methods are extracted and located here more centralized.
@@ -109,7 +107,7 @@ public class CarrierSchedulerUtils {
   /**
    * Sum up the jsprit score of the given list of CarrierPlans.
    * As a consequence this is not from the one and only jsprit run, but from all jsprit runs af the different auxiliary carriers.
-   * @param scheduledPlans
+   * @param scheduledPlans the scheduled plans with the jsprit results
    * @return the summ of the scores coming from jsprit
    */
   public static Double sumUpJspritScore(List<CarrierPlan> scheduledPlans) {

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
@@ -83,7 +83,7 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
       CarrierService carrierService = convertToCarrierService(tupleToBeAssigned);
       carrier.getServices().put(carrierService.getId(), carrierService);
     }
-    carrier = CarrierSchedulerUtils.solveVrpWithJspritWithToll(carrier, resource.getNetwork(), rpscheme);
+    carrier = CarrierSchedulerUtils.solveVrpWithJsprit(carrier, resource.getNetwork(), rpscheme);
   }
 
   private CarrierService convertToCarrierService(LspShipmentWithTime tuple) {

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
@@ -102,7 +102,7 @@ import org.matsim.vehicles.VehicleType;
           > vehicleType.getCapacity().getOther().intValue()) {
         load = 0;
         Carrier auxiliaryCarrier =
-            CarrierSchedulerUtils.solveVrpWithJspritWithToll(
+            CarrierSchedulerUtils.solveVrpWithJsprit(
                 createAuxiliaryCarrier(
                     shipmentsInCurrentTour, availabilityTimeOfLastShipment + cumulatedLoadingTime),
                 resource.getNetwork(), rpscheme);
@@ -119,7 +119,7 @@ import org.matsim.vehicles.VehicleType;
 
     if (!shipmentsInCurrentTour.isEmpty()) {
       Carrier auxiliaryCarrier =
-          CarrierSchedulerUtils.solveVrpWithJspritWithToll(
+          CarrierSchedulerUtils.solveVrpWithJsprit(
               createAuxiliaryCarrier(
                   shipmentsInCurrentTour, availabilityTimeOfLastShipment + cumulatedLoadingTime),
               resource.getNetwork(), rpscheme);


### PR DESCRIPTION
- take` numberOfJspritIterations` from the `Carrier`s attribute ... if not set, use 1 as default (currently it was hard-coded to 1)
- re-unify the method, which calls jsprit: If a `RoadPricingScheme` is present, use it and plan with toll, otherwise run without toll.

This PR close #281 and #282.