### PR TITLE
Renaming of variables to avoid confusions (in the future)

### DIFF
--- a/src/main/java/org/matsim/freight/logistics/ForwardLogisticChainSchedulerImpl.java
+++ b/src/main/java/org/matsim/freight/logistics/ForwardLogisticChainSchedulerImpl.java
@@ -131,7 +131,7 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
     for (LogisticChain solution : lsp.getSelectedPlan().getLogisticChains()) {
       LogisticChainElement firstElement = getFirstElement(solution);
       assert firstElement != null;
-      for (Id<LSPShipment> lspShipmentId : solution.getShipmentIds()) {
+      for (Id<LSPShipment> lspShipmentId : solution.getLspShipmentIds()) {
         var shipment = LSPUtils.findLspShipment(lsp, lspShipmentId);
         assert shipment != null;
         firstElement

--- a/src/main/java/org/matsim/freight/logistics/InitialShipmentAssigner.java
+++ b/src/main/java/org/matsim/freight/logistics/InitialShipmentAssigner.java
@@ -39,5 +39,5 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
  */
 public interface InitialShipmentAssigner {
 
-  void assignToPlan(LSPPlan lspPlan, LSPShipment shipment);
+  void assignToPlan(LSPPlan lspPlan, LSPShipment lspShipment);
 }

--- a/src/main/java/org/matsim/freight/logistics/LSP.java
+++ b/src/main/java/org/matsim/freight/logistics/LSP.java
@@ -34,7 +34,7 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
 public interface LSP extends HasPlansAndId<LSPPlan, LSP>, HasSimulationTrackers<LSP> {
 
   /** yyyy does this have to be exposed? */
-  Collection<LSPShipment> getShipments();
+  Collection<LSPShipment> getLspShipments();
 
   /** ok (behavioral method) */
   void scheduleLogisticChains();
@@ -46,8 +46,8 @@ public interface LSP extends HasPlansAndId<LSPPlan, LSP>, HasSimulationTrackers<
   void scoreSelectedPlan();
 
   /**
-   * @param shipment ok (LSP needs to be told that it is responsible for shipment)
+   * @param lspShipment ok (LSP needs to be told that it is responsible for lspShipment)
    */
-  void assignShipmentToLSP(LSPShipment shipment);
+  void assignShipmentToLSP(LSPShipment lspShipment);
 
 }

--- a/src/main/java/org/matsim/freight/logistics/LSPControlerListener.java
+++ b/src/main/java/org/matsim/freight/logistics/LSPControlerListener.java
@@ -134,8 +134,8 @@ class LSPControlerListener
       }
 
       // simulation trackers of shipments:
-      for (LSPShipment shipment : lsp.getShipments()) {
-        registerSimulationTrackers(shipment);
+      for (LSPShipment lspShipment : lsp.getLspShipments()) {
+        registerSimulationTrackers(lspShipment);
       }
 
       // simulation trackers of solutions:

--- a/src/main/java/org/matsim/freight/logistics/LSPImpl.java
+++ b/src/main/java/org/matsim/freight/logistics/LSPImpl.java
@@ -30,8 +30,8 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
 /* package-private */ class LSPImpl extends LSPDataObject<LSP> implements LSP {
   private static final Logger log = LogManager.getLogger(LSPImpl.class);
 
-  private final Collection<LSPShipment> shipments;
-  private final ArrayList<LSPPlan> plans;
+  private final Collection<LSPShipment> lspShipments;
+  private final ArrayList<LSPPlan> lspPlans;
   private final LogisticChainScheduler logisticChainScheduler;
   private final Collection<LSPResource> resources;
   private LSPPlan selectedPlan;
@@ -41,13 +41,13 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
 
   LSPImpl(LSPUtils.LSPBuilder builder) {
     super(builder.id);
-    this.shipments = new ArrayList<>();
-    this.plans = new ArrayList<>();
+    this.lspShipments = new ArrayList<>();
+    this.lspPlans = new ArrayList<>();
     this.logisticChainScheduler = builder.logisticChainScheduler;
     this.logisticChainScheduler.setEmbeddingContainer(this);
     this.selectedPlan = builder.initialPlan;
     this.selectedPlan.setLSP(this);
-    this.plans.add(builder.initialPlan);
+    this.lspPlans.add(builder.initialPlan);
     this.resources = builder.resources;
   }
 
@@ -57,7 +57,7 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
       LogisticChain newPlanChain =
           LSPUtils.LogisticChainBuilder.newInstance(initialPlanChain.getId()).build();
       newPlanChain.getLogisticChainElements().addAll(initialPlanChain.getLogisticChainElements());
-      newPlanChain.getShipmentIds().addAll(initialPlanChain.getShipmentIds());
+      newPlanChain.getLspShipmentIds().addAll(initialPlanChain.getLspShipmentIds());
       newPlanChains.add(newPlanChain);
     }
 
@@ -95,7 +95,7 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
       }
     }
     plan.setLSP(this);
-    return plans.add(plan);
+    return lspPlans.add(plan);
   }
 
   @Override
@@ -107,7 +107,7 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
 
   @Override
   public ArrayList<LSPPlan> getPlans() {
-    return plans;
+    return lspPlans;
   }
 
   @Override
@@ -117,16 +117,16 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
 
   @Override
   public void setSelectedPlan(LSPPlan selectedPlan) {
-    if (!plans.contains(selectedPlan)) {
-      plans.add(selectedPlan);
+    if (!lspPlans.contains(selectedPlan)) {
+      lspPlans.add(selectedPlan);
     }
     this.selectedPlan = selectedPlan;
   }
 
   @Override
-  public boolean removePlan(LSPPlan plan) {
-    if (plans.contains(plan)) {
-      plans.remove(plan);
+  public boolean removePlan(LSPPlan lspPlan) {
+    if (lspPlans.contains(lspPlan)) {
+      lspPlans.remove(lspPlan);
       return true;
     } else {
       return false;
@@ -147,17 +147,17 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
   }
 
   @Override
-  public void assignShipmentToLSP(LSPShipment shipment) {
+  public void assignShipmentToLSP(LSPShipment lspShipment) {
     //		shipment.setLspId(this.getId()); // und rückweg dann auch darüber und dann
     // lsp.getselectedPlan.getShipment...
-    shipments.add(shipment);
-    for (LSPPlan lspPlan : plans) {
-      lspPlan.getInitialShipmentAssigner().assignToPlan(lspPlan, shipment);
+    lspShipments.add(lspShipment);
+    for (LSPPlan lspPlan : lspPlans) {
+      lspPlan.getInitialShipmentAssigner().assignToPlan(lspPlan, lspShipment);
     }
   }
 
   @Override
-  public Collection<LSPShipment> getShipments() {
-    return this.shipments;
+  public Collection<LSPShipment> getLspShipments() {
+    return this.lspShipments;
   }
 }

--- a/src/main/java/org/matsim/freight/logistics/LSPResourceScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/LSPResourceScheduler.java
@@ -81,7 +81,7 @@ public abstract class LSPResourceScheduler {
   private void presortIncomingShipments() {
     this.lspShipmentsWithTime = new ArrayList<>();
     for (LogisticChainElement element : resource.getClientElements()) {
-      lspShipmentsWithTime.addAll(element.getIncomingShipments().getShipments());
+      lspShipmentsWithTime.addAll(element.getIncomingShipments().getLspShipmentsWTime());
     }
     lspShipmentsWithTime.sort(Comparator.comparingDouble(LspShipmentWithTime::getTime));
   }
@@ -89,17 +89,17 @@ public abstract class LSPResourceScheduler {
   private void switchHandledShipments(int bufferTime) {
     for (LspShipmentWithTime lspShipmentWithTime : lspShipmentsWithTime) {
       var shipmentPlan =
-          ShipmentUtils.getOrCreateShipmentPlan(lspPlan, lspShipmentWithTime.getShipment().getId());
+          ShipmentUtils.getOrCreateShipmentPlan(lspPlan, lspShipmentWithTime.getLspShipment().getId());
       double endOfTransportTime = shipmentPlan.getMostRecentEntry().getEndTime() + bufferTime;
       LspShipmentWithTime outgoingTuple =
-          new LspShipmentWithTime(endOfTransportTime, lspShipmentWithTime.getShipment());
+          new LspShipmentWithTime(endOfTransportTime, lspShipmentWithTime.getLspShipment());
       for (LogisticChainElement element : resource.getClientElements()) {
-        if (element.getIncomingShipments().getShipments().contains(lspShipmentWithTime)) {
-          element.getOutgoingShipments().getShipments().add(outgoingTuple);
-          element.getIncomingShipments().getShipments().remove(lspShipmentWithTime);
+        if (element.getIncomingShipments().getLspShipmentsWTime().contains(lspShipmentWithTime)) {
+          element.getOutgoingShipments().getLspShipmentsWTime().add(outgoingTuple);
+          element.getIncomingShipments().getLspShipmentsWTime().remove(lspShipmentWithTime);
           if (element.getNextElement() != null) {
-            element.getNextElement().getIncomingShipments().getShipments().add(outgoingTuple);
-            element.getOutgoingShipments().getShipments().remove(outgoingTuple);
+            element.getNextElement().getIncomingShipments().getLspShipmentsWTime().add(outgoingTuple);
+            element.getOutgoingShipments().getLspShipmentsWTime().remove(outgoingTuple);
           }
         }
       }

--- a/src/main/java/org/matsim/freight/logistics/LSPUtils.java
+++ b/src/main/java/org/matsim/freight/logistics/LSPUtils.java
@@ -120,7 +120,7 @@ public final class LSPUtils {
    * @return the lspShipment object or null, if it is not found.
    */
   public static LSPShipment findLspShipment(LSP lsp, Id<LSPShipment> shipmentId) {
-    for (LSPShipment lspShipment : lsp.getShipments()) {
+    for (LSPShipment lspShipment : lsp.getLspShipments()) {
       if (lspShipment.getId().equals(shipmentId)) {
         return lspShipment;
       }

--- a/src/main/java/org/matsim/freight/logistics/LogisticChain.java
+++ b/src/main/java/org/matsim/freight/logistics/LogisticChain.java
@@ -42,7 +42,7 @@ public interface LogisticChain
 
   Collection<LogisticChainElement> getLogisticChainElements();
 
-  Collection<Id<LSPShipment>> getShipmentIds();
+  Collection<Id<LSPShipment>> getLspShipmentIds();
 
-  void addShipmentToChain(LSPShipment shipment);
+  void addShipmentToChain(LSPShipment lspShipment);
 }

--- a/src/main/java/org/matsim/freight/logistics/LogisticChainImpl.java
+++ b/src/main/java/org/matsim/freight/logistics/LogisticChainImpl.java
@@ -32,7 +32,7 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
   private static final Logger log = LogManager.getLogger(LogisticChainImpl.class);
 
   private final Collection<LogisticChainElement> logisticChainElements;
-  private final Collection<Id<LSPShipment>> shipmentIds;
+  private final Collection<Id<LSPShipment>> lspShipmentIds;
   private LSP lsp;
 
   LogisticChainImpl(LSPUtils.LogisticChainBuilder builder) {
@@ -41,7 +41,7 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
     for (LogisticChainElement element : this.logisticChainElements) {
       element.setEmbeddingContainer(this);
     }
-    this.shipmentIds = new ArrayList<>();
+    this.lspShipmentIds = new ArrayList<>();
   }
 
   @Override
@@ -60,13 +60,13 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
   }
 
   @Override
-  public Collection<Id<LSPShipment>> getShipmentIds() {
-    return shipmentIds;
+  public Collection<Id<LSPShipment>> getLspShipmentIds() {
+    return lspShipmentIds;
   }
 
   @Override
-  public void addShipmentToChain(LSPShipment shipment) {
-    shipmentIds.add(shipment.getId());
+  public void addShipmentToChain(LSPShipment lspShipment) {
+    lspShipmentIds.add(lspShipment.getId());
   }
 
   @Override
@@ -83,10 +83,10 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
       }
       strb.append("}");
     }
-    strb.append("[No of Shipments=").append(shipmentIds.size()).append("] \n");
-    if (!shipmentIds.isEmpty()) {
+    strb.append("[No of Shipments=").append(lspShipmentIds.size()).append("] \n");
+    if (!lspShipmentIds.isEmpty()) {
       strb.append("{ShipmentIds=");
-      for (Id<LSPShipment> lspShipmentId : shipmentIds) {
+      for (Id<LSPShipment> lspShipmentId : lspShipmentIds) {
         strb.append("[").append(lspShipmentId.toString()).append("]");
       }
       strb.append("}");

--- a/src/main/java/org/matsim/freight/logistics/LspShipmentWithTime.java
+++ b/src/main/java/org/matsim/freight/logistics/LspShipmentWithTime.java
@@ -29,16 +29,16 @@ public class LspShipmentWithTime {
   // means (delivery time?  current time?).  kai,
   // jun'22
 
-  private final LSPShipment shipment;
+  private final LSPShipment lspShipment;
   private final double time;
 
-  public LspShipmentWithTime(double time, LSPShipment shipment) {
-    this.shipment = shipment;
+  public LspShipmentWithTime(double time, LSPShipment lspShipment) {
+    this.lspShipment = lspShipment;
     this.time = time;
   }
 
-  public LSPShipment getShipment() {
-    return shipment;
+  public LSPShipment getLspShipment() {
+    return lspShipment;
   }
 
   public double getTime() {

--- a/src/main/java/org/matsim/freight/logistics/WaitingShipments.java
+++ b/src/main/java/org/matsim/freight/logistics/WaitingShipments.java
@@ -41,11 +41,11 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
  */
 public interface WaitingShipments {
 
-  void addShipment(double time, LSPShipment shipment);
+  void addShipment(double time, LSPShipment lspShipment);
 
-  Collection<LspShipmentWithTime> getSortedShipments();
+  Collection<LspShipmentWithTime> getSortedLspShipments();
 
-  Collection<LspShipmentWithTime> getShipments();
+  Collection<LspShipmentWithTime> getLspShipmentsWTime();
 
   void clear();
 }

--- a/src/main/java/org/matsim/freight/logistics/WaitingShipmentsImpl.java
+++ b/src/main/java/org/matsim/freight/logistics/WaitingShipmentsImpl.java
@@ -35,14 +35,14 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
   }
 
   @Override
-  public void addShipment(double time, LSPShipment shipment) {
-    LspShipmentWithTime tuple = new LspShipmentWithTime(time, shipment);
+  public void addShipment(double time, LSPShipment lspShipment) {
+    LspShipmentWithTime tuple = new LspShipmentWithTime(time, lspShipment);
     this.shipments.add(tuple);
     shipments.sort(Comparator.comparingDouble(LspShipmentWithTime::getTime));
   }
 
   @Override
-  public Collection<LspShipmentWithTime> getSortedShipments() {
+  public Collection<LspShipmentWithTime> getSortedLspShipments() {
     shipments.sort(Comparator.comparingDouble(LspShipmentWithTime::getTime));
     return shipments;
   }
@@ -52,7 +52,7 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
   }
 
   @Override
-  public Collection<LspShipmentWithTime> getShipments() {
+  public Collection<LspShipmentWithTime> getLspShipmentsWTime() {
     return shipments;
   }
 
@@ -62,8 +62,8 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
     strb.append("WaitingShipmentsImpl{").append("No of Shipments= ").append(shipments.size());
     if (!shipments.isEmpty()) {
       strb.append("; ShipmentIds=");
-      for (LspShipmentWithTime shipment : getSortedShipments()) {
-        strb.append("[").append(shipment.getShipment().getId()).append("]");
+      for (LspShipmentWithTime shipment : getSortedLspShipments()) {
+        strb.append("[").append(shipment.getLspShipment().getId()).append("]");
       }
     }
     strb.append('}');

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfInitialPlan.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfInitialPlan.java
@@ -160,33 +160,33 @@ import org.matsim.vehicles.VehicleType;
         .readFile("scenarios/2regions/2regions-network.xml");
     Network network = scenario.getNetwork();
 
-    // Create LSP and shipments
+    // Create LSP and lspShipments
     LSP lsp = createInitialLSP(network);
-    Collection<LSPShipment> shipments = createInitialLSPShipments(network);
+    Collection<LSPShipment> lspShipments = createInitialLSPShipments(network);
 
-    // assign the shipments to the LSP
-    for (LSPShipment shipment : shipments) {
-      lsp.assignShipmentToLSP(shipment);
+    // assign the lspShipments to the LSP
+    for (LSPShipment lspShipment : lspShipments) {
+      lsp.assignShipmentToLSP(lspShipment);
     }
 
-    // schedule the LSP with the shipments and according to the scheduler of the Resource
+    // schedule the LSP with the lspShipments and according to the scheduler of the Resource
     lsp.scheduleLogisticChains();
 
     // print the schedules for the assigned LSPShipments
-    for (LSPShipment shipment : shipments) {
-      System.out.println("Shipment: " + shipment.getId());
+    for (LSPShipment lspShipment : lspShipments) {
+      System.out.println("Shipment: " + lspShipment.getId());
       ArrayList<ShipmentPlanElement> scheduleElements =
           new ArrayList<>(
-              ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId())
+              ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), lspShipment.getId())
                   .getPlanElements()
                   .values());
       scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
       ArrayList<ShipmentPlanElement> logElements =
-          new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
+          new ArrayList<>(lspShipment.getShipmentLog().getPlanElements().values());
       logElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
 
       for (ShipmentPlanElement element :
-          ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId())
+          ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), lspShipment.getId())
               .getPlanElements()
               .values()) {
         System.out.println(

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChain.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChain.java
@@ -341,25 +341,25 @@ import org.matsim.vehicles.VehicleType;
 
     // Create LSP and shipments
     LSP lsp = createInitialLSP(scenario);
-    Collection<LSPShipment> shipments = createInitialLSPShipments(scenario.getNetwork());
+    Collection<LSPShipment> lspShipments = createInitialLSPShipments(scenario.getNetwork());
 
     // assign the shipments to the LSP
-    for (LSPShipment shipment : shipments) {
-      lsp.assignShipmentToLSP(shipment);
+    for (LSPShipment lspShipment : lspShipments) {
+      lsp.assignShipmentToLSP(lspShipment);
     }
 
     // schedule the LSP with the shipments and according to the scheduler of the Resource
     lsp.scheduleLogisticChains();
 
     // print the schedules for the assigned LSPShipments
-    for (LSPShipment shipment : lsp.getShipments()) {
+    for (LSPShipment lspShipment : lsp.getLspShipments()) {
       ArrayList<ShipmentPlanElement> elementList =
           new ArrayList<>(
-              ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId())
+              ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), lspShipment.getId())
                   .getPlanElements()
                   .values());
       elementList.sort(ShipmentUtils.createShipmentPlanElementComparator());
-      System.out.println("Shipment: " + shipment.getId());
+      System.out.println("Shipment: " + lspShipment.getId());
       for (ShipmentPlanElement element : elementList) {
         System.out.println(
             element.getLogisticChainElement().getId()

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirect.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirect.java
@@ -603,7 +603,7 @@ import org.matsim.vehicles.VehicleType;
     public void handleEvent(CarrierTourEndEvent event) {
       score++;
       // use event handlers to compute score.  In this case, score is incremented by one every time
-      // a service and a tour ends.
+      // a CarrierService and a tour ends.
     }
 
     @Override
@@ -615,7 +615,7 @@ import org.matsim.vehicles.VehicleType;
     public void handleEvent(CarrierServiceEndEvent event) {
       score++;
       // use event handlers to compute score.  In this case, score is incremented by one every time
-      // a service and a tour ends.
+      // a CarrierService and a tour ends.
     }
   }
 }

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirect.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirect.java
@@ -121,8 +121,8 @@ import org.matsim.vehicles.VehicleType;
 
     log.info("create initial LSPShipments");
     log.info("assign the shipments to the LSP");
-    for (LSPShipment shipment : createInitialLSPShipments(scenario.getNetwork())) {
-      lsp.assignShipmentToLSP(shipment);
+    for (LSPShipment lspShipment : createInitialLSPShipments(scenario.getNetwork())) {
+      lsp.assignShipmentToLSP(lspShipment);
     }
 
     log.info("schedule the LSP with the shipments and according to the scheduler of the Resource");
@@ -575,8 +575,8 @@ import org.matsim.vehicles.VehicleType;
       TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
       builder.setStartTimeWindow(startTimeWindow);
       builder.setDeliveryServiceTime(capacityDemand * 60);
-      LSPShipment shipment = builder.build();
-      shipmentList.add(shipment);
+      LSPShipment lspShipment = builder.build();
+      shipmentList.add(lspShipment);
     }
     return shipmentList;
   }

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid.java
@@ -391,8 +391,8 @@ final class ExampleTwoEchelonGrid {
 
     log.info("create initial LSPShipments");
     log.info("assign the shipments to the LSP");
-    for (LSPShipment shipment : createInitialLSPShipments(network)) {
-      lsp.assignShipmentToLSP(shipment);
+    for (LSPShipment lspShipment : createInitialLSPShipments(network)) {
+      lsp.assignShipmentToLSP(lspShipment);
     }
 
     log.info("schedule the LSP with the shipments and according to the scheduler of the Resource");

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid_NR.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid_NR.java
@@ -401,8 +401,8 @@ final class ExampleTwoEchelonGrid_NR {
 
     log.info("create initial LSPShipments");
     log.info("assign the shipments to the LSP");
-    for (LSPShipment shipment : createInitialLSPShipments(network)) {
-      lsp.assignShipmentToLSP(shipment);
+    for (LSPShipment lspShipment : createInitialLSPShipments(network)) {
+      lsp.assignShipmentToLSP(lspShipment);
     }
 
     log.info("schedule the LSP with the shipments and according to the scheduler of the Resource");

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/MyLSPScorer.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/MyLSPScorer.java
@@ -86,9 +86,9 @@ import org.matsim.freight.logistics.resourceImplementations.TransshipmentHubReso
     LSPPlan lspPlan = lsp.getSelectedPlan();
     int lspPlanShipmentCount =
         lspPlan.getLogisticChains().stream()
-            .mapToInt(logisticChain -> logisticChain.getShipmentIds().size())
+            .mapToInt(logisticChain -> logisticChain.getLspShipmentIds().size())
             .sum();
-    if (lspPlanShipmentCount != lsp.getShipments().size()) {
+    if (lspPlanShipmentCount != lsp.getLspShipments().size()) {
       logger.error(
           "LspPlan doesn't contain the same number of shipments as LSP, "
               + "shipments probably lost during replanning.");

--- a/src/main/java/org/matsim/freight/logistics/examples/lspReplanning/AssignmentStrategyFactory.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/lspReplanning/AssignmentStrategyFactory.java
@@ -64,17 +64,17 @@ public class AssignmentStrategyFactory {
           public void handlePlan(LSPPlan lspPlan) {
 
             for (LogisticChain solution : lspPlan.getLogisticChains()) {
-              solution.getShipmentIds().clear();
+              solution.getLspShipmentIds().clear();
               for (LogisticChainElement element : solution.getLogisticChainElements()) {
                 element.getIncomingShipments().clear();
                 element.getOutgoingShipments().clear();
               }
             }
 
-            for (LSPShipment shipment : lspPlan.getLSP().getShipments()) {
-              ShipmentUtils.getOrCreateShipmentPlan(lspPlan, shipment.getId()).clear();
-              shipment.getShipmentLog().clear();
-              lspPlan.getInitialShipmentAssigner().assignToPlan(lspPlan, shipment);
+            for (LSPShipment lspShipment : lspPlan.getLSP().getLspShipments()) {
+              ShipmentUtils.getOrCreateShipmentPlan(lspPlan, lspShipment.getId()).clear();
+              lspShipment.getShipmentLog().clear();
+              lspPlan.getInitialShipmentAssigner().assignToPlan(lspPlan, lspShipment);
             }
           }
 

--- a/src/main/java/org/matsim/freight/logistics/examples/lspReplanning/MaybeTodayAssigner.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/lspReplanning/MaybeTodayAssigner.java
@@ -45,11 +45,11 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
   }
 
   @Override
-  public void assignToPlan(LSPPlan lspPlan, LSPShipment shipment) {
+  public void assignToPlan(LSPPlan lspPlan, LSPShipment lspShipment) {
     boolean assignToday = random.nextBoolean();
     if (assignToday) {
       Gbl.assertIf(lspPlan.getLogisticChains().size() == 1);
-      lspPlan.getLogisticChains().iterator().next().addShipmentToChain(shipment);
+      lspPlan.getLogisticChains().iterator().next().addShipmentToChain(lspShipment);
     }
   }
 

--- a/src/main/java/org/matsim/freight/logistics/examples/lspReplanning/TomorrowShipmentAssignerStrategyFactory.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/lspReplanning/TomorrowShipmentAssignerStrategyFactory.java
@@ -55,27 +55,27 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
 
           @Override
           public void handlePlan(LSPPlan plan) {
-            plan.getLogisticChains().iterator().next().getShipmentIds().clear();
+            plan.getLogisticChains().iterator().next().getLspShipmentIds().clear();
             plan.setInitialShipmentAssigner(assigner);
             //				LSP lsp = assigner.getLSP();
             LSP lsp = plan.getLSP();
-            Collection<LSPShipment> shipments = lsp.getShipments();
-            for (LSPShipment shipment : shipments) {
-              assigner.assignToPlan(plan, shipment);
+            Collection<LSPShipment> lspShipments = lsp.getLspShipments();
+            for (LSPShipment lspShipment : lspShipments) {
+              assigner.assignToPlan(plan, lspShipment);
             }
 
             for (LogisticChain solution : plan.getLogisticChains()) {
-              solution.getShipmentIds().clear();
+              solution.getLspShipmentIds().clear();
               for (LogisticChainElement element : solution.getLogisticChainElements()) {
                 element.getIncomingShipments().clear();
                 element.getOutgoingShipments().clear();
               }
             }
 
-            for (LSPShipment shipment : plan.getLSP().getShipments()) {
-              ShipmentUtils.getOrCreateShipmentPlan(plan, shipment.getId()).clear();
-              shipment.getShipmentLog().clear();
-              plan.getInitialShipmentAssigner().assignToPlan(plan, shipment);
+            for (LSPShipment lspShipment : plan.getLSP().getLspShipments()) {
+              ShipmentUtils.getOrCreateShipmentPlan(plan, lspShipment.getId()).clear();
+              lspShipment.getShipmentLog().clear();
+              plan.getInitialShipmentAssigner().assignToPlan(plan, lspShipment);
             }
           }
 

--- a/src/main/java/org/matsim/freight/logistics/examples/lspScoring/ExampleLSPScoring.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/lspScoring/ExampleLSPScoring.java
@@ -197,16 +197,16 @@ import org.matsim.vehicles.VehicleType;
   static Scenario prepareScenario(Config config) {
     Scenario scenario = ScenarioUtils.loadScenario(config);
 
-    // Create LSP and shipments
+    // Create LSP and lspShipments
     LSP lsp = createLSPWithScorer(scenario.getNetwork());
-    Collection<LSPShipment> shipments = createInitialLSPShipments(scenario.getNetwork());
+    Collection<LSPShipment> lspShipments = createInitialLSPShipments(scenario.getNetwork());
 
-    // assign the shipments to the LSP
-    for (LSPShipment shipment : shipments) {
-      lsp.assignShipmentToLSP(shipment);
+    // assign the lspShipments to the LSP
+    for (LSPShipment lspShipment : lspShipments) {
+      lsp.assignShipmentToLSP(lspShipment);
     }
 
-    // schedule the LSP with the shipments and according to the scheduler of the Resource
+    // schedule the LSP with the lspShipments and according to the scheduler of the Resource
     lsp.scheduleLogisticChains();
 
     // Prepare LSPModule and add the LSP

--- a/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfSimpleLSP.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfSimpleLSP.java
@@ -66,17 +66,17 @@ import org.matsim.vehicles.VehicleType;
     new MatsimNetworkReader(scenario.getNetwork())
         .readFile("scenarios/2regions/2regions-network.xml");
 
-    // Create LSP and shipments
+    // Create LSP and lspShipments
     Network network = scenario.getNetwork();
     LSP lsp = createInitialLSP(network);
-    Collection<LSPShipment> shipments = createInitialLSPShipments(network);
+    Collection<LSPShipment> lspShipments = createInitialLSPShipments(network);
 
-    // assign the shipments to the LSP
-    for (LSPShipment shipment : shipments) {
-      lsp.assignShipmentToLSP(shipment);
+    // assign the lspShipments to the LSP
+    for (LSPShipment lspShipment : lspShipments) {
+      lsp.assignShipmentToLSP(lspShipment);
     }
 
-    // schedule the LSP with the shipments and according to the scheduler of the Resource
+    // schedule the LSP with the lspShipments and according to the scheduler of the Resource
     lsp.scheduleLogisticChains();
 
     // set up simulation controler and LSPModule
@@ -105,21 +105,21 @@ import org.matsim.vehicles.VehicleType;
         .setVspDefaultsCheckingLevel(VspExperimentalConfigGroup.VspDefaultsCheckingLevel.warn);
     controler.run();
 
-    for (LSPShipment shipment : lsp.getShipments()) {
-      System.out.println("Shipment: " + shipment.getId());
+    for (LSPShipment lspShipment : lsp.getLspShipments()) {
+      System.out.println("LspShipment: " + lspShipment.getId());
       ArrayList<ShipmentPlanElement> scheduleElements =
           new ArrayList<>(
-              ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId())
+              ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), lspShipment.getId())
                   .getPlanElements()
                   .values());
       scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
       ArrayList<ShipmentPlanElement> logElements =
-          new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
+          new ArrayList<>(lspShipment.getShipmentLog().getPlanElements().values());
       logElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
 
       for (int i = 0;
           i
-              < ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId())
+              < ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), lspShipment.getId())
                   .getPlanElements()
                   .size();
           i++) {
@@ -136,7 +136,7 @@ import org.matsim.vehicles.VehicleType;
                 + scheduleElements.get(i).getEndTime());
       }
       System.out.println();
-      for (int i = 0; i < shipment.getShipmentLog().getPlanElements().size(); i++) {
+      for (int i = 0; i < lspShipment.getShipmentLog().getPlanElements().size(); i++) {
         System.out.println(
             "Logged: "
                 + logElements.get(i).getLogisticChainElement().getId()

--- a/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfTransportChain.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfTransportChain.java
@@ -334,16 +334,16 @@ import org.matsim.vehicles.VehicleType;
     new MatsimNetworkReader(scenario.getNetwork())
         .readFile("scenarios/2regions/2regions-network.xml");
 
-    // Create LSP and shipments
+    // Create LSP and lspShipments
     LSP lsp = createInitialLSP(scenario);
-    Collection<LSPShipment> shipments = createInitialLSPShipments(scenario.getNetwork());
+    Collection<LSPShipment> lspShipments = createInitialLSPShipments(scenario.getNetwork());
 
-    // assign the shipments to the LSP
-    for (LSPShipment shipment : shipments) {
-      lsp.assignShipmentToLSP(shipment);
+    // assign the lspShipments to the LSP
+    for (LSPShipment lspShipment : lspShipments) {
+      lsp.assignShipmentToLSP(lspShipment);
     }
 
-    // schedule the LSP with the shipments and according to the scheduler of the Resource
+    // schedule the LSP with the lspShipments and according to the scheduler of the Resource
     lsp.scheduleLogisticChains();
 
     // set up simulation controler and LSPModule
@@ -374,21 +374,21 @@ import org.matsim.vehicles.VehicleType;
         .setVspDefaultsCheckingLevel(VspExperimentalConfigGroup.VspDefaultsCheckingLevel.warn);
     controler.run();
 
-    for (LSPShipment shipment : lsp.getShipments()) {
-      System.out.println("Shipment: " + shipment.getId());
+    for (LSPShipment lspShipment : lsp.getLspShipments()) {
+      System.out.println("Shipment: " + lspShipment.getId());
       ArrayList<ShipmentPlanElement> scheduleElements =
           new ArrayList<>(
-              ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId())
+              ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), lspShipment.getId())
                   .getPlanElements()
                   .values());
       scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
       ArrayList<ShipmentPlanElement> logElements =
-          new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
+          new ArrayList<>(lspShipment.getShipmentLog().getPlanElements().values());
       logElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
 
       for (int i = 0;
           i
-              < ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId())
+              < ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), lspShipment.getId())
                   .getPlanElements()
                   .size();
           i++) {
@@ -405,7 +405,7 @@ import org.matsim.vehicles.VehicleType;
                 + scheduleElements.get(i).getEndTime());
       }
       System.out.println();
-      for (int i = 0; i < shipment.getShipmentLog().getPlanElements().size(); i++) {
+      for (int i = 0; i < lspShipment.getShipmentLog().getPlanElements().size(); i++) {
         System.out.println(
             "Logged: "
                 + logElements.get(i).getLogisticChainElement().getId()

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleGroceryDeliveryMultipleChains.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleGroceryDeliveryMultipleChains.java
@@ -320,8 +320,8 @@ final class ExampleGroceryDeliveryMultipleChains {
 
     log.info("create initial LSPShipments");
     log.info("assign the shipments to the LSP");
-    for (LSPShipment shipment : createLSPShipmentsFromCarrierShipments(carrier)) {
-      lsp.assignShipmentToLSP(shipment);
+    for (LSPShipment lspShipment : createLSPShipmentsFromCarrierShipments(carrier)) {
+      lsp.assignShipmentToLSP(lspShipment);
     }
 
     log.info("schedule the LSP with the shipments and according to the scheduler of the Resource");

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleMixedEchelonChains.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleMixedEchelonChains.java
@@ -405,8 +405,8 @@ final class ExampleMultipleMixedEchelonChains {
 
     log.info("create initial LSPShipments");
     log.info("assign the shipments to the LSP");
-    for (LSPShipment shipment : createInitialLSPShipments(network)) {
-      lsp.assignShipmentToLSP(shipment);
+    for (LSPShipment lspShipment : createInitialLSPShipments(network)) {
+      lsp.assignShipmentToLSP(lspShipment);
     }
 
     log.info("schedule the LSP with the shipments and according to the scheduler of the Resource");

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChains.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChains.java
@@ -305,8 +305,8 @@ final class ExampleMultipleOneEchelonChains {
 
     log.info("create initial LSPShipments");
     log.info("assign the shipments to the LSP");
-    for (LSPShipment shipment : createInitialLSPShipments()) {
-      lsp.assignShipmentToLSP(shipment);
+    for (LSPShipment lspShipment : createInitialLSPShipments()) {
+      lsp.assignShipmentToLSP(lspShipment);
     }
 
     log.info("schedule the LSP with the shipments and according to the scheduler of the Resource");
@@ -316,7 +316,7 @@ final class ExampleMultipleOneEchelonChains {
   }
 
   private static Collection<LSPShipment> createInitialLSPShipments() {
-    List<LSPShipment> shipmentList = new ArrayList<>();
+    List<LSPShipment> lspShipmentList = new ArrayList<>();
     int capacityDemand;
 
     switch (demandSetting) {
@@ -339,7 +339,7 @@ final class ExampleMultipleOneEchelonChains {
         builder.setStartTimeWindow(TimeWindow.newInstance(0, (24 * 3600)));
         builder.setDeliveryServiceTime(capacityDemand * 60);
 
-        shipmentList.add(builder.build());
+        lspShipmentList.add(builder.build());
       } else {
         Id<LSPShipment> id = Id.create("ShipmentRight_" + i, LSPShipment.class);
         ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
@@ -353,10 +353,10 @@ final class ExampleMultipleOneEchelonChains {
         builder.setStartTimeWindow(TimeWindow.newInstance(0, (24 * 3600)));
         builder.setDeliveryServiceTime(capacityDemand * 60);
 
-        shipmentList.add(builder.build());
+        lspShipmentList.add(builder.build());
       }
     }
-    return shipmentList;
+    return lspShipmentList;
   }
 
   private static List<LSPResource> createResourcesListFromLSPPlans(List<LSPPlan> lspPlans) {

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChainsReplanning.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChainsReplanning.java
@@ -329,8 +329,8 @@ final class ExampleMultipleOneEchelonChainsReplanning {
 
     log.info("create initial LSPShipments");
     log.info("assign the shipments to the LSP");
-    for (LSPShipment shipment : createInitialLSPShipments()) {
-      lsp.assignShipmentToLSP(shipment);
+    for (LSPShipment lspShipment : createInitialLSPShipments()) {
+      lsp.assignShipmentToLSP(lspShipment);
     }
 
     log.info("schedule the LSP with the shipments and according to the scheduler of the Resource");

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleTwoEchelonChainsReplanning.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleTwoEchelonChainsReplanning.java
@@ -369,8 +369,8 @@ final class ExampleMultipleTwoEchelonChainsReplanning {
 
     log.info("create initial LSPShipments");
     log.info("assign the shipments to the LSP");
-    for (LSPShipment shipment : createInitialLSPShipments()) {
-      lsp.assignShipmentToLSP(shipment);
+    for (LSPShipment lspShipment : createInitialLSPShipments()) {
+      lsp.assignShipmentToLSP(lspShipment);
     }
 
     log.info("schedule the LSP with the shipments and according to the scheduler of the Resource");

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChains.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChains.java
@@ -248,8 +248,8 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChains {
             .build();
 
     log.info("assign the shipments to the LSP");
-    for (LSPShipment shipment : lspShipments) {
-      lsp.assignShipmentToLSP(shipment);
+    for (LSPShipment lspShipment : lspShipments) {
+      lsp.assignShipmentToLSP(lspShipment);
     }
 
     log.info("schedule the LSP with the shipments and according to the scheduler of the Resource");
@@ -385,8 +385,8 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChains {
                     .build();
 
     log.info("assign the shipments to the LSP");
-    for (LSPShipment shipment : lspShipments) {
-      lsp.assignShipmentToLSP(shipment);
+    for (LSPShipment lspShipment : lspShipments) {
+      lsp.assignShipmentToLSP(lspShipment);
     }
 
     log.info("schedule the LSP with the shipments and according to the scheduler of the Resource");

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll.java
@@ -274,8 +274,8 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll {
             .build();
 
     log.info("assign the shipments to the LSP");
-    for (LSPShipment shipment : lspShipments) {
-      lsp.assignShipmentToLSP(shipment);
+    for (LSPShipment lspShipment : lspShipments) {
+      lsp.assignShipmentToLSP(lspShipment);
     }
 
     log.info("schedule the LSP with the shipments and according to the scheduler of the Resource");
@@ -413,8 +413,8 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll {
                     .build();
 
     log.info("assign the shipments to the LSP");
-    for (LSPShipment shipment : lspShipments) {
-      lsp.assignShipmentToLSP(shipment);
+    for (LSPShipment lspShipment : lspShipments) {
+      lsp.assignShipmentToLSP(lspShipment);
     }
 
     log.info("schedule the LSP with the shipments and according to the scheduler of the Resource");

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/MyLSPScorer.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/MyLSPScorer.java
@@ -86,9 +86,9 @@ import org.matsim.freight.logistics.resourceImplementations.TransshipmentHubReso
     LSPPlan lspPlan = lsp.getSelectedPlan();
     int lspPlanShipmentCount =
         lspPlan.getLogisticChains().stream()
-            .mapToInt(logisticChain -> logisticChain.getShipmentIds().size())
+            .mapToInt(logisticChain -> logisticChain.getLspShipmentIds().size())
             .sum();
-    int shipmentCountDifference = lsp.getShipments().size() - lspPlanShipmentCount;
+    int shipmentCountDifference = lsp.getLspShipments().size() - lspPlanShipmentCount;
     if (shipmentCountDifference > 0) {
       logger.error(
           "LspPlan contains less shipments than LSP, "

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/PrimaryLogisticChainShipmentAssigner.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/PrimaryLogisticChainShipmentAssigner.java
@@ -38,9 +38,9 @@ class PrimaryLogisticChainShipmentAssigner implements InitialShipmentAssigner {
   public PrimaryLogisticChainShipmentAssigner() {}
 
   @Override
-  public void assignToPlan(LSPPlan lspPlan, LSPShipment shipment) {
+  public void assignToPlan(LSPPlan lspPlan, LSPShipment lspShipment) {
     Gbl.assertIf(!lspPlan.getLogisticChains().isEmpty());
     LogisticChain firstLogisticChain = lspPlan.getLogisticChains().iterator().next();
-    firstLogisticChain.addShipmentToChain(shipment);
+    firstLogisticChain.addShipmentToChain(lspShipment);
   }
 }

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ProximityStrategyFactory.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ProximityStrategyFactory.java
@@ -76,26 +76,26 @@ final class ProximityStrategyFactory {
             LSPResource minDistanceResource = null;
 
             // get all shipments assigned to the LSP
-            Map<Id<LSPShipment>, LSPShipment> shipmentById = new HashMap<>();
-            for (LSPShipment lspShipment : lsp.getShipments()) {
-              shipmentById.put(lspShipment.getId(), lspShipment);
+            Map<Id<LSPShipment>, LSPShipment> lspShipmentById = new HashMap<>();
+            for (LSPShipment lspShipment : lsp.getLspShipments()) {
+              lspShipmentById.put(lspShipment.getId(), lspShipment);
             }
 
             // Retrieve all shipments in the logistic chains of the plan
             // These should be all shipments of the lsp, but not necessarily if shipments got lost
             ArrayList<LSPShipment> shipments = new ArrayList<>();
             for (LogisticChain logisticChain : lspPlan.getLogisticChains()) {
-              for (Id<LSPShipment> id : logisticChain.getShipmentIds()) {
-                LSPShipment shipment = shipmentById.get(id);
-                if (shipment != null) {
-                  shipments.add(shipment);
+              for (Id<LSPShipment> id : logisticChain.getLspShipmentIds()) {
+                LSPShipment lspShipment = lspShipmentById.get(id);
+                if (lspShipment != null) {
+                  shipments.add(lspShipment);
                 }
               }
             }
 
-            // pick a random shipment from the shipments contained in the plan
+            // pick a random lspShipment from the shipments contained in the plan
             int shipmentIndex = MatsimRandom.getRandom().nextInt(shipments.size());
-            LSPShipment shipment = shipments.get(shipmentIndex);
+            LSPShipment lspShipment = shipments.get(shipmentIndex);
 
             // Collect all resources of the logistic chains of the LSP plan
             ArrayList<LSPResource> resources = new ArrayList<>();
@@ -106,9 +106,9 @@ final class ProximityStrategyFactory {
               }
             }
 
-            // get the resource with the smallest distance to the shipment
+            // get the resource with the smallest distance to the lspShipment
             for (LSPResource resource : resources) {
-              Link shipmentLink = network.getLinks().get(shipment.getTo());
+              Link shipmentLink = network.getLinks().get(lspShipment.getTo());
               Link resourceLink = network.getLinks().get(resource.getStartLinkId());
               double distance =
                   NetworkUtils.getEuclideanDistance(
@@ -119,21 +119,21 @@ final class ProximityStrategyFactory {
               }
             }
 
-            // add randomly picked shipment to chain with resource of the smallest distance
+            // add randomly picked lspShipment to chain with resource of the smallest distance
             for (LogisticChain logisticChain : lspPlan.getLogisticChains()) {
               for (LogisticChainElement logisticChainElement :
                   logisticChain.getLogisticChainElements()) {
                 if (logisticChainElement.getResource().equals(minDistanceResource)) {
-                  logisticChain.getShipmentIds().add(shipment.getId());
+                  logisticChain.getLspShipmentIds().add(lspShipment.getId());
                 }
               }
             }
 
-            // remove the shipment from the previous logistic chain, can be the same as the new
+            // remove the lspShipment from the previous logistic chain, can be the same as the new
             // logistic chain
             for (LogisticChain logisticChain : lspPlan.getLogisticChains()) {
-              if (logisticChain.getShipmentIds().contains(shipment.getId())) {
-                logisticChain.getShipmentIds().remove(shipment.getId());
+              if (logisticChain.getLspShipmentIds().contains(lspShipment.getId())) {
+                logisticChain.getLspShipmentIds().remove(lspShipment.getId());
                 break;
               }
             }

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RandomDistributionAllShipmentsStrategyFactory.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RandomDistributionAllShipmentsStrategyFactory.java
@@ -67,16 +67,16 @@ final class RandomDistributionAllShipmentsStrategyFactory {
                         if (lspPlan.getLogisticChains().size() < 2) return;
 
                         for (LogisticChain logisticChain : lspPlan.getLogisticChains()) {
-                            logisticChain.getShipmentIds().clear();
+                            logisticChain.getLspShipmentIds().clear();
                         }
 
                         LSP lsp = lspPlan.getLSP();
                         List<LogisticChain> logisticChains =
                                 new ArrayList<>(lsp.getSelectedPlan().getLogisticChains());
 
-                        for (LSPShipment shipment : lsp.getShipments()) {
+                        for (LSPShipment lspShipment : lsp.getLspShipments()) {
                             int index = MatsimRandom.getRandom().nextInt(logisticChains.size());
-                            logisticChains.get(index).addShipmentToChain(shipment);
+                            logisticChains.get(index).addShipmentToChain(lspShipment);
                         }
                     }
 

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RandomLogisticChainShipmentAssigner.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RandomLogisticChainShipmentAssigner.java
@@ -46,11 +46,11 @@ class RandomLogisticChainShipmentAssigner implements InitialShipmentAssigner {
   }
 
   @Override
-  public void assignToPlan(LSPPlan lspPlan, LSPShipment shipment) {
+  public void assignToPlan(LSPPlan lspPlan, LSPShipment lspShipment) {
     Gbl.assertIf(!lspPlan.getLogisticChains().isEmpty());
     List<LogisticChain> logisticChains = new ArrayList<>(lspPlan.getLogisticChains());
     int index = random.nextInt(logisticChains.size());
     LogisticChain logisticChain = logisticChains.get(index);
-    logisticChain.addShipmentToChain(shipment);
+    logisticChain.addShipmentToChain(lspShipment);
   }
 }

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RandomShiftingStrategyFactory.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RandomShiftingStrategyFactory.java
@@ -67,26 +67,26 @@ class RandomShiftingStrategyFactory {
             @Override
             public void handlePlan(LSPPlan lspPlan) {
 
-                // Shifting shipments only makes sense for multiple chains
+                // Shifting lspShipments only makes sense for multiple chains
                 if (lspPlan.getLogisticChains().size() < 2) return;
 
                 LSP lsp = lspPlan.getLSP();
 
-                // Make a new list of shipments and pick a random shipment from it
-                List<LSPShipment> shipments = new ArrayList<>(lsp.getShipments());
-                int shipmentIndex = random.nextInt(lsp.getShipments().size());
-                LSPShipment shipment = shipments.get(shipmentIndex);
+                // Make a new list of lspShipments and pick a random lspShipment from it
+                List<LSPShipment> lspShipments = new ArrayList<>(lsp.getLspShipments());
+                int shipmentIndex = random.nextInt(lsp.getLspShipments().size());
+                LSPShipment lspShipment = lspShipments.get(shipmentIndex);
 
-                // Find and remove the random shipment from its current logistic chain
+                // Find and remove the random lspShipment from its current logistic chain
                 LogisticChain sourceLogisticChain = null;
                 for (LogisticChain logisticChain : lsp.getSelectedPlan().getLogisticChains()) {
-                    if (logisticChain.getShipmentIds().remove(shipment.getId())) {
+                    if (logisticChain.getLspShipmentIds().remove(lspShipment.getId())) {
                         sourceLogisticChain = logisticChain;
                         break;
                     }
                 }
 
-                // Find a new logistic chain for the shipment
+                // Find a new logistic chain for the lspShipment
                 // Ensure that the chain selected is not the same as the one it was removed from
                 int chainIndex;
                 LogisticChain targetLogisticChain = null;
@@ -101,9 +101,9 @@ class RandomShiftingStrategyFactory {
                     }
                 } while (targetLogisticChain == sourceLogisticChain);
 
-                // Add the shipment to the new logistic chain
+                // Add the lspShipment to the new logistic chain
                 assert targetLogisticChain != null;
-                targetLogisticChain.addShipmentToChain(shipment);
+                targetLogisticChain.addShipmentToChain(lspShipment);
             }
 
             @Override

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RebalancingStrategyFactory.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RebalancingStrategyFactory.java
@@ -72,7 +72,7 @@ class RebalancingStrategyFactory {
 
             // fill the shipmentCountByChain map with each chain's shipment count
             for (LogisticChain chain : lsp.getSelectedPlan().getLogisticChains()) {
-              shipmentCountByChain.put(chain, chain.getShipmentIds().size());
+              shipmentCountByChain.put(chain, chain.getLspShipmentIds().size());
             }
 
             // find the chains with the minimum and maximum shipment counts
@@ -87,15 +87,15 @@ class RebalancingStrategyFactory {
             if (minChain.equals(maxChain)) return;
 
             // get the first shipment ID from the chain with the maximum shipment count
-            Id<LSPShipment> shipmentIdForReplanning = maxChain.getShipmentIds().iterator().next();
+            Id<LSPShipment> shipmentIdForReplanning = maxChain.getLspShipmentIds().iterator().next();
 
             // iterate through the chains and move the shipment from the max chain to the min chain
             for (LogisticChain logisticChain : lsp.getSelectedPlan().getLogisticChains()) {
               if (logisticChain.equals(maxChain)) {
-                logisticChain.getShipmentIds().remove(shipmentIdForReplanning);
+                logisticChain.getLspShipmentIds().remove(shipmentIdForReplanning);
               }
               if (logisticChain.equals(minChain)) {
-                logisticChain.getShipmentIds().add(shipmentIdForReplanning);
+                logisticChain.getLspShipmentIds().add(shipmentIdForReplanning);
               }
             }
           }

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RoundRobinDistributionAllShipmentsStrategyFactory.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RoundRobinDistributionAllShipmentsStrategyFactory.java
@@ -67,13 +67,13 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
             if (lspPlan.getLogisticChains().size() < 2) return;
 
             for (LogisticChain logisticChain : lspPlan.getLogisticChains()) {
-              logisticChain.getShipmentIds().clear();
+              logisticChain.getLspShipmentIds().clear();
             }
 
             LSP lsp = lspPlan.getLSP();
             Map<LogisticChain, Integer> shipmentCountByChain = new LinkedHashMap<>();
 
-            for (LSPShipment shipment : lsp.getShipments()) {
+            for (LSPShipment lspShipment : lsp.getLspShipments()) {
               if (shipmentCountByChain.isEmpty()) {
                 for (LogisticChain chain : lsp.getSelectedPlan().getLogisticChains()) {
                   shipmentCountByChain.put(chain, 0);
@@ -82,7 +82,7 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
               LogisticChain minChain =
                   Collections.min(shipmentCountByChain.entrySet(), Map.Entry.comparingByValue())
                       .getKey();
-              minChain.addShipmentToChain(shipment);
+              minChain.addShipmentToChain(lspShipment);
               shipmentCountByChain.merge(minChain, 1, Integer::sum);
             }
           }

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RoundRobinLogisticChainShipmentAssigner.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RoundRobinLogisticChainShipmentAssigner.java
@@ -45,7 +45,7 @@ class RoundRobinLogisticChainShipmentAssigner implements InitialShipmentAssigner
   RoundRobinLogisticChainShipmentAssigner() {}
 
   @Override
-  public void assignToPlan(LSPPlan lspPlan, LSPShipment shipment) {
+  public void assignToPlan(LSPPlan lspPlan, LSPShipment lspShipment) {
     Gbl.assertIf(!lspPlan.getLogisticChains().isEmpty());
     // prepare the map if empty for the first time with each number of assigned shipments being zero
     if (shipmentCountByChain.isEmpty()) {
@@ -58,7 +58,7 @@ class RoundRobinLogisticChainShipmentAssigner implements InitialShipmentAssigner
     // its value by one
     LogisticChain minChain =
         Collections.min(shipmentCountByChain.entrySet(), Map.Entry.comparingByValue()).getKey();
-    minChain.addShipmentToChain(shipment);
+    minChain.addShipmentToChain(lspShipment);
     shipmentCountByChain.merge(minChain, 1, Integer::sum);
   }
 }

--- a/src/main/java/org/matsim/freight/logistics/examples/requirementsChecking/ExampleCheckRequirementsOfAssigner.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/requirementsChecking/ExampleCheckRequirementsOfAssigner.java
@@ -226,33 +226,33 @@ class ExampleCheckRequirementsOfAssigner {
         .readFile("scenarios/2regions/2regions-network.xml");
     Network network = scenario.getNetwork();
 
-    // Create LSP and shipments
+    // Create LSP and lspShipments
     LSP lsp = createLSPWithProperties(network);
-    Collection<LSPShipment> shipments = createShipmentsWithRequirements(network);
+    Collection<LSPShipment> lspShipments = createShipmentsWithRequirements(network);
 
-    // assign the shipments to the LSP
-    for (LSPShipment shipment : shipments) {
-      lsp.assignShipmentToLSP(shipment);
+    // assign the lspShipments to the LSP
+    for (LSPShipment lspShipment : lspShipments) {
+      lsp.assignShipmentToLSP(lspShipment);
     }
 
-    for (LogisticChain solution : lsp.getSelectedPlan().getLogisticChains()) {
-      if (solution.getId().toString().equals("RedSolution")) {
-        for (Id<LSPShipment> shipmentId : solution.getShipmentIds()) {
-          LSPShipment shipment = LSPUtils.findLspShipment(lsp, shipmentId);
-            if (shipment != null && !(shipment.getRequirements().iterator().next() instanceof RedRequirement)) {
+    for (LogisticChain logisticChain : lsp.getSelectedPlan().getLogisticChains()) {
+      if (logisticChain.getId().toString().equals("RedSolution")) {
+        for (Id<LSPShipment> lspShipmentId : logisticChain.getLspShipmentIds()) {
+          LSPShipment lspShipment = LSPUtils.findLspShipment(lsp, lspShipmentId);
+            if (lspShipment != null && !(lspShipment.getRequirements().iterator().next() instanceof RedRequirement)) {
                 break;
             }
         }
-        System.out.println("All shipments in " + solution.getId() + " are red");
+        System.out.println("All lspShipments in " + logisticChain.getId() + " are red");
       }
-      if (solution.getId().toString().equals("BlueSolution")) {
-        for (Id<LSPShipment> shipmentId : solution.getShipmentIds()) {
-          LSPShipment shipment = LSPUtils.findLspShipment(lsp, shipmentId);
+      if (logisticChain.getId().toString().equals("BlueSolution")) {
+        for (Id<LSPShipment> lspShipmentId : logisticChain.getLspShipmentIds()) {
+          LSPShipment shipment = LSPUtils.findLspShipment(lsp, lspShipmentId);
             if (shipment != null && !(shipment.getRequirements().iterator().next() instanceof BlueRequirement)) {
                 break;
             }
         }
-        System.out.println("All shipments in " + solution.getId() + " are blue");
+        System.out.println("All lspShipments in " + logisticChain.getId() + " are blue");
       }
     }
   }

--- a/src/main/java/org/matsim/freight/logistics/examples/requirementsChecking/RequirementsAssigner.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/requirementsChecking/RequirementsAssigner.java
@@ -59,12 +59,12 @@ class RequirementsAssigner implements InitialShipmentAssigner {
   }
 
   @Override
-  public void assignToPlan(LSPPlan lspPlan, LSPShipment shipment) {
+  public void assignToPlan(LSPPlan lspPlan, LSPShipment lspShipment) {
     feasibleLogisticChains.clear();
 
     label:
     for (LogisticChain solution : lspPlan.getLogisticChains()) {
-      for (LSPShipmentRequirement requirement : shipment.getRequirements()) {
+      for (LSPShipmentRequirement requirement : lspShipment.getRequirements()) {
         if (!requirement.checkRequirement(solution)) {
 
           continue label;
@@ -73,7 +73,7 @@ class RequirementsAssigner implements InitialShipmentAssigner {
       feasibleLogisticChains.add(solution);
     }
     LogisticChain chosenSolution = feasibleLogisticChains.iterator().next();
-    chosenSolution.addShipmentToChain(shipment);
+    chosenSolution.addShipmentToChain(lspShipment);
   }
 
 }

--- a/src/main/java/org/matsim/freight/logistics/examples/simulationTrackers/ExampleSimulationTrackers.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/simulationTrackers/ExampleSimulationTrackers.java
@@ -174,16 +174,16 @@ import org.matsim.vehicles.VehicleType;
         .readFile("scenarios/2regions/2regions-network.xml");
     Network network = scenario.getNetwork();
 
-    // Create LSP and shipments
+    // Create LSP and lspShipments
     LSP lsp = createLSPWithTracker(scenario);
-    Collection<LSPShipment> shipments = createInitialLSPShipments(network);
+    Collection<LSPShipment> lspShipments = createInitialLSPShipments(network);
 
-    // assign the shipments to the LSP
-    for (LSPShipment shipment : shipments) {
-      lsp.assignShipmentToLSP(shipment);
+    // assign the lspShipments to the LSP
+    for (LSPShipment lspShipment : lspShipments) {
+      lsp.assignShipmentToLSP(lspShipment);
     }
 
-    // schedule the LSP with the shipments and according to the scheduler of the Resource
+    // schedule the LSP with the lspShipments and according to the scheduler of the Resource
     lsp.scheduleLogisticChains();
 
     // Prepare LSPModule and add the LSP

--- a/src/main/java/org/matsim/freight/logistics/io/LSPPlanXmlParserV1.java
+++ b/src/main/java/org/matsim/freight/logistics/io/LSPPlanXmlParserV1.java
@@ -216,7 +216,7 @@ class LSPPlanXmlParserV1 extends MatsimXmlParser {
           shipmentBuilder.setDeliveryServiceTime(parseTimeToDouble(deliveryServiceTime));
 
         currentShipment = shipmentBuilder.build();
-        currentLsp.getShipments().add(currentShipment);
+        currentLsp.getLspShipments().add(currentShipment);
       }
       case LSP_PLAN -> {
         currentLspPlan = LSPUtils.createLSPPlan();
@@ -405,19 +405,19 @@ class LSPPlanXmlParserV1 extends MatsimXmlParser {
       }
 
       case SHIPMENT_PLAN -> {
-        for (LSPShipment shipment : currentLsp.getShipments()) {
-          if (shipment.getId().toString().equals(shipmentPlanId)) {
+        for (LSPShipment lspShipment : currentLsp.getLspShipments()) {
+          if (lspShipment.getId().toString().equals(shipmentPlanId)) {
             for (Map.Entry<String, ShipmentPlanElement> planElement : planElements.entrySet()) {
-              ShipmentUtils.getOrCreateShipmentPlan(currentLspPlan, shipment.getId())
+              ShipmentUtils.getOrCreateShipmentPlan(currentLspPlan, lspShipment.getId())
                   .addPlanElement(
                       Id.create(planElement.getKey(), ShipmentPlanElement.class),
                       planElement.getValue());
             }
           }
-          for (LogisticChain chain : currentLspPlan.getLogisticChains()) {
-            if (chain.getId().toString().equals(shipmentChainId)
-                && shipment.getId().toString().equals(shipmentPlanId)) {
-              chain.addShipmentToChain(shipment);
+          for (LogisticChain logisticChain : currentLspPlan.getLogisticChains()) {
+            if (logisticChain.getId().toString().equals(shipmentChainId)
+                && lspShipment.getId().toString().equals(shipmentPlanId)) {
+              logisticChain.addShipmentToChain(lspShipment);
             }
           }
         }

--- a/src/main/java/org/matsim/freight/logistics/io/LSPPlanXmlWriter.java
+++ b/src/main/java/org/matsim/freight/logistics/io/LSPPlanXmlWriter.java
@@ -128,22 +128,22 @@ public class LSPPlanXmlWriter extends MatsimXmlWriter {
   }
 
   private void writeShipments(LSP lsp) throws IOException {
-    if (lsp.getShipments().isEmpty()) return;
+    if (lsp.getLspShipments().isEmpty()) return;
     this.writeStartTag(SHIPMENTS, null);
-    for (LSPShipment shipment : lsp.getShipments()) {
+    for (LSPShipment lspShipment : lsp.getLspShipments()) {
       this.writeStartTag(
           SHIPMENT,
           List.of(
-              createTuple(ID, shipment.getId().toString()),
-              createTuple(FROM, shipment.getFrom().toString()),
-              createTuple(TO, shipment.getTo().toString()),
-              createTuple(SIZE, shipment.getSize()),
-              createTuple(START_PICKUP, shipment.getPickupTimeWindow().getStart()),
-              createTuple(END_PICKUP, shipment.getPickupTimeWindow().getEnd()),
-              createTuple(START_DELIVERY, shipment.getDeliveryTimeWindow().getStart()),
-              createTuple(END_DELIVERY, shipment.getDeliveryTimeWindow().getEnd()),
-              createTuple(PICKUP_SERVICE_TIME, shipment.getPickupServiceTime()),
-              createTuple(DELIVERY_SERVICE_TIME, shipment.getDeliveryServiceTime())),
+              createTuple(ID, lspShipment.getId().toString()),
+              createTuple(FROM, lspShipment.getFrom().toString()),
+              createTuple(TO, lspShipment.getTo().toString()),
+              createTuple(SIZE, lspShipment.getSize()),
+              createTuple(START_PICKUP, lspShipment.getPickupTimeWindow().getStart()),
+              createTuple(END_PICKUP, lspShipment.getPickupTimeWindow().getEnd()),
+              createTuple(START_DELIVERY, lspShipment.getDeliveryTimeWindow().getStart()),
+              createTuple(END_DELIVERY, lspShipment.getDeliveryTimeWindow().getEnd()),
+              createTuple(PICKUP_SERVICE_TIME, lspShipment.getPickupServiceTime()),
+              createTuple(DELIVERY_SERVICE_TIME, lspShipment.getDeliveryServiceTime())),
           true);
     }
     this.writeEndTag(SHIPMENTS);
@@ -185,18 +185,18 @@ public class LSPPlanXmlWriter extends MatsimXmlWriter {
 
       writeStartTag(SHIPMENT_PLANS, null);
       for (LogisticChain chain : plan.getLogisticChains()) {
-        for (Id<LSPShipment> shipmentId : chain.getShipmentIds()) {
-          if (chain.getShipmentIds().contains(shipmentId)) {
+        for (Id<LSPShipment> shipmentId : chain.getLspShipmentIds()) {
+          if (chain.getLspShipmentIds().contains(shipmentId)) {
             this.writeStartTag(
                 SHIPMENT_PLAN,
                 List.of(
                     createTuple(SHIPMENT_ID, shipmentId.toString()),
                     createTuple(CHAIN_ID, chain.getId().toString())));
           }
-          LSPShipment shipment = LSPUtils.findLspShipment(lsp, shipmentId);
-          assert shipment != null;
+          LSPShipment lspShipment = LSPUtils.findLspShipment(lsp, shipmentId);
+          assert lspShipment != null;
           final Map<Id<ShipmentPlanElement>, ShipmentPlanElement> planElements =
-              ShipmentUtils.getOrCreateShipmentPlan(plan, shipment.getId()).getPlanElements();
+              ShipmentUtils.getOrCreateShipmentPlan(plan, lspShipment.getId()).getPlanElements();
           for (Id<ShipmentPlanElement> elementId : planElements.keySet()) {
             ShipmentPlanElement element = planElements.get(elementId);
             this.writeStartTag(

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
@@ -94,9 +94,9 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
     builder.setServiceStartTimeWindow(tuple.getLspShipment().getPickupTimeWindow());
     builder.setCapacityDemand(tuple.getLspShipment().getSize());
     builder.setServiceDuration(tuple.getLspShipment().getDeliveryServiceTime());
-    CarrierService service = builder.build();
-    pairs.add(new LSPCarrierPair(tuple, service));
-    return service;
+    CarrierService carrierService = builder.build();
+    pairs.add(new LSPCarrierPair(tuple, carrierService));
+    return carrierService;
   }
 
   @Override
@@ -109,12 +109,12 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
             LSPCarrierPair carrierPair = new LSPCarrierPair(tuple, serviceActivity.getService());
             for (LSPCarrierPair pair : pairs) {
               if (pair.tuple == carrierPair.tuple
-                  && pair.service.getId() == carrierPair.service.getId()) {
+                  && pair.carrierService.getId() == carrierPair.carrierService.getId()) {
                 addShipmentLoadElement(tuple, tour, serviceActivity);
                 addShipmentTransportElement(tuple, tour, serviceActivity);
                 addShipmentUnloadElement(tuple, tour, serviceActivity);
-                addCollectionTourEndEventHandler(pair.service, tuple, resource, tour);
-                addCollectionServiceEventHandler(pair.service, tuple, resource);
+                addCollectionTourEndEventHandler(pair.carrierService, tuple, resource, tour);
+                addCollectionServiceEventHandler(pair.carrierService, tuple, resource);
               }
             }
           }
@@ -246,5 +246,5 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
     return unloadEndTime;
   }
 
-  private record LSPCarrierPair(LspShipmentWithTime tuple, CarrierService service) {}
+  private record LSPCarrierPair(LspShipmentWithTime tuple, CarrierService carrierService) {}
 }

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
@@ -88,12 +88,12 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
 
   private CarrierService convertToCarrierService(LspShipmentWithTime tuple) {
     Id<CarrierService> serviceId =
-        Id.create(tuple.getShipment().getId().toString(), CarrierService.class);
+        Id.create(tuple.getLspShipment().getId().toString(), CarrierService.class);
     CarrierService.Builder builder =
-        CarrierService.Builder.newInstance(serviceId, tuple.getShipment().getFrom());
-    builder.setServiceStartTimeWindow(tuple.getShipment().getPickupTimeWindow());
-    builder.setCapacityDemand(tuple.getShipment().getSize());
-    builder.setServiceDuration(tuple.getShipment().getDeliveryServiceTime());
+        CarrierService.Builder.newInstance(serviceId, tuple.getLspShipment().getFrom());
+    builder.setServiceStartTimeWindow(tuple.getLspShipment().getPickupTimeWindow());
+    builder.setCapacityDemand(tuple.getLspShipment().getSize());
+    builder.setServiceDuration(tuple.getLspShipment().getDeliveryServiceTime());
     CarrierService service = builder.build();
     pairs.add(new LSPCarrierPair(tuple, service));
     return service;
@@ -129,7 +129,7 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
         ShipmentUtils.ScheduledShipmentLoadBuilder.newInstance();
     builder.setResourceId(resource.getId());
     for (LogisticChainElement element : resource.getClientElements()) {
-      if (element.getIncomingShipments().getShipments().contains(tuple)) {
+      if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
         builder.setLogisticChainElement(element);
       }
     }
@@ -138,13 +138,13 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
     double startTimeOfLoading =
         legBeforeService.getExpectedDepartureTime() + legBeforeService.getExpectedTransportTime();
     builder.setStartTime(startTimeOfLoading);
-    builder.setEndTime(startTimeOfLoading + tuple.getShipment().getDeliveryServiceTime());
+    builder.setEndTime(startTimeOfLoading + tuple.getLspShipment().getDeliveryServiceTime());
 
     ShipmentPlanElement load = builder.build();
     String idString =
         load.getResourceId() + "" + load.getLogisticChainElement().getId() + load.getElementType();
     Id<ShipmentPlanElement> id = Id.create(idString, ShipmentPlanElement.class);
-    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getShipment().getId())
+    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
         .addPlanElement(id, load);
   }
 
@@ -154,7 +154,7 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
         ShipmentUtils.ScheduledShipmentTransportBuilder.newInstance();
     builder.setResourceId(resource.getId());
     for (LogisticChainElement element : resource.getClientElements()) {
-      if (element.getIncomingShipments().getShipments().contains(tuple)) {
+      if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
         builder.setLogisticChainElement(element);
       }
     }
@@ -177,18 +177,18 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
             + transport.getLogisticChainElement().getId()
             + transport.getElementType();
     Id<ShipmentPlanElement> id = Id.create(idString, ShipmentPlanElement.class);
-    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getShipment().getId())
+    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
         .addPlanElement(id, transport);
   }
 
   private void addCollectionServiceEventHandler(
       CarrierService carrierService, LspShipmentWithTime tuple, LSPCarrierResource resource) {
     for (LogisticChainElement element : this.resource.getClientElements()) {
-      if (element.getIncomingShipments().getShipments().contains(tuple)) {
+      if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
         CollectionServiceEndEventHandler endHandler =
             new CollectionServiceEndEventHandler(
-                carrierService, tuple.getShipment(), element, resource);
-        tuple.getShipment().addSimulationTracker(endHandler);
+                carrierService, tuple.getLspShipment(), element, resource);
+        tuple.getLspShipment().addSimulationTracker(endHandler);
         break;
       }
     }
@@ -200,11 +200,11 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
       LSPCarrierResource resource,
       Tour tour) {
     for (LogisticChainElement element : this.resource.getClientElements()) {
-      if (element.getIncomingShipments().getShipments().contains(tuple)) {
+      if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
         LSPTourEndEventHandler handler =
             new LSPTourEndEventHandler(
-					tuple.getShipment(), carrierService, element, resource, tour);
-        tuple.getShipment().addSimulationTracker(handler);
+					tuple.getLspShipment(), carrierService, element, resource, tour);
+        tuple.getLspShipment().addSimulationTracker(handler);
         break;
       }
     }
@@ -216,7 +216,7 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
         ShipmentUtils.ScheduledShipmentUnloadBuilder.newInstance();
     builder.setResourceId(resource.getId());
     for (LogisticChainElement element : resource.getClientElements()) {
-      if (element.getIncomingShipments().getShipments().contains(tuple)) {
+      if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
         builder.setLogisticsChainElement(element);
       }
     }
@@ -232,7 +232,7 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
             + unload.getLogisticChainElement().getId()
             + unload.getElementType();
     Id<ShipmentPlanElement> id = Id.create(idString, ShipmentPlanElement.class);
-    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getShipment().getId())
+    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
         .addPlanElement(id, unload);
   }
 

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
@@ -181,9 +181,9 @@ import org.matsim.vehicles.VehicleType;
         CarrierService.Builder.newInstance(serviceId, tuple.getLspShipment().getTo());
     builder.setCapacityDemand(tuple.getLspShipment().getSize());
     builder.setServiceDuration(tuple.getLspShipment().getDeliveryServiceTime());
-    CarrierService service = builder.build();
-    pairs.add(new LSPCarrierPair(tuple, service));
-    return service;
+    CarrierService carrierService = builder.build();
+    pairs.add(new LSPCarrierPair(tuple, carrierService));
+    return carrierService;
   }
 
   @Override
@@ -196,12 +196,12 @@ import org.matsim.vehicles.VehicleType;
             LSPCarrierPair carrierPair = new LSPCarrierPair(tuple, serviceActivity.getService());
             for (LSPCarrierPair pair : pairs) {
               if (pair.tuple == carrierPair.tuple
-                  && pair.service.getId() == carrierPair.service.getId()) {
+                  && pair.carrierService.getId() == carrierPair.carrierService.getId()) {
                 addShipmentLoadElement(tuple, tour, serviceActivity);
                 addShipmentTransportElement(tuple, tour, serviceActivity);
                 addShipmentUnloadElement(tuple, tour, serviceActivity);
-                addDistributionTourStartEventHandler(pair.service, tuple, resource, tour);
-                addDistributionServiceEventHandler(pair.service, tuple, resource);
+                addDistributionTourStartEventHandler(pair.carrierService, tuple, resource, tour);
+                addDistributionServiceEventHandler(pair.carrierService, tuple, resource);
               }
             }
           }
@@ -294,10 +294,10 @@ import org.matsim.vehicles.VehicleType;
       }
     }
     int serviceIndex = tour.getTourElements().indexOf(serviceActivity);
-    ServiceActivity service = (ServiceActivity) tour.getTourElements().get(serviceIndex);
+    ServiceActivity serviceAct = (ServiceActivity) tour.getTourElements().get(serviceIndex);
 
-    final double startTime = service.getExpectedArrival();
-    final double endTime = startTime + service.getDuration();
+    final double startTime = serviceAct.getExpectedArrival();
+    final double endTime = startTime + serviceAct.getDuration();
     Assert.isTrue(
         endTime >= startTime,
         "latest End must be later than earliest start. start: " + startTime + " ; end: " + endTime);
@@ -369,13 +369,5 @@ import org.matsim.vehicles.VehicleType;
     }
   }
 
-  static class LSPCarrierPair {
-    private final LspShipmentWithTime tuple;
-    private final CarrierService service;
-
-    public LSPCarrierPair(LspShipmentWithTime tuple, CarrierService service) {
-      this.tuple = tuple;
-      this.service = service;
-    }
-  }
+  private record LSPCarrierPair(LspShipmentWithTime tuple, CarrierService carrierService) {}
 }

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
@@ -98,7 +98,7 @@ import org.matsim.vehicles.VehicleType;
       // gibt???
       VehicleType vehicleType =
           ResourceImplementationUtils.getVehicleTypeCollection(carrier).iterator().next();
-      if ((load + tuple.getShipment().getSize())
+      if ((load + tuple.getLspShipment().getSize())
           > vehicleType.getCapacity().getOther().intValue()) {
         load = 0;
         Carrier auxiliaryCarrier =
@@ -112,8 +112,8 @@ import org.matsim.vehicles.VehicleType;
         shipmentsInCurrentTour.clear();
       }
       shipmentsInCurrentTour.add(tuple);
-      load = load + tuple.getShipment().getSize();
-      cumulatedLoadingTime = cumulatedLoadingTime + tuple.getShipment().getDeliveryServiceTime();
+      load = load + tuple.getLspShipment().getSize();
+      cumulatedLoadingTime = cumulatedLoadingTime + tuple.getLspShipment().getDeliveryServiceTime();
       availabilityTimeOfLastShipment = tuple.getTime();
     }
 
@@ -176,11 +176,11 @@ import org.matsim.vehicles.VehicleType;
 
   private CarrierService convertToCarrierService(LspShipmentWithTime tuple) {
     Id<CarrierService> serviceId =
-        Id.create(tuple.getShipment().getId().toString(), CarrierService.class);
+        Id.create(tuple.getLspShipment().getId().toString(), CarrierService.class);
     CarrierService.Builder builder =
-        CarrierService.Builder.newInstance(serviceId, tuple.getShipment().getTo());
-    builder.setCapacityDemand(tuple.getShipment().getSize());
-    builder.setServiceDuration(tuple.getShipment().getDeliveryServiceTime());
+        CarrierService.Builder.newInstance(serviceId, tuple.getLspShipment().getTo());
+    builder.setCapacityDemand(tuple.getLspShipment().getSize());
+    builder.setServiceDuration(tuple.getLspShipment().getDeliveryServiceTime());
     CarrierService service = builder.build();
     pairs.add(new LSPCarrierPair(tuple, service));
     return service;
@@ -216,7 +216,7 @@ import org.matsim.vehicles.VehicleType;
         ShipmentUtils.ScheduledShipmentLoadBuilder.newInstance();
     builder.setResourceId(resource.getId());
     for (LogisticChainElement element : resource.getClientElements()) {
-      if (element.getIncomingShipments().getShipments().contains(tuple)) {
+      if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
         builder.setLogisticChainElement(element);
       }
     }
@@ -237,7 +237,7 @@ import org.matsim.vehicles.VehicleType;
     String idString =
         load.getResourceId() + "" + load.getLogisticChainElement().getId() + load.getElementType();
     Id<ShipmentPlanElement> id = Id.create(idString, ShipmentPlanElement.class);
-    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getShipment().getId())
+    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
         .addPlanElement(id, load);
   }
 
@@ -247,7 +247,7 @@ import org.matsim.vehicles.VehicleType;
         ShipmentUtils.ScheduledShipmentTransportBuilder.newInstance();
     builder.setResourceId(resource.getId());
     for (LogisticChainElement element : resource.getClientElements()) {
-      if (element.getIncomingShipments().getShipments().contains(tuple)) {
+      if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
         builder.setLogisticChainElement(element);
       }
     }
@@ -279,7 +279,7 @@ import org.matsim.vehicles.VehicleType;
             + transport.getLogisticChainElement().getId()
             + transport.getElementType();
     Id<ShipmentPlanElement> id = Id.create(idString, ShipmentPlanElement.class);
-    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getShipment().getId())
+    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
         .addPlanElement(id, transport);
   }
 
@@ -289,7 +289,7 @@ import org.matsim.vehicles.VehicleType;
         ShipmentUtils.ScheduledShipmentUnloadBuilder.newInstance();
     builder.setResourceId(resource.getId());
     for (LogisticChainElement element : resource.getClientElements()) {
-      if (element.getIncomingShipments().getShipments().contains(tuple)) {
+      if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
         builder.setLogisticsChainElement(element);
       }
     }
@@ -311,7 +311,7 @@ import org.matsim.vehicles.VehicleType;
             + String.valueOf(unload.getLogisticChainElement().getId())
             + unload.getElementType();
     Id<ShipmentPlanElement> id = Id.create(idString, ShipmentPlanElement.class);
-    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getShipment().getId())
+    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
         .addPlanElement(id, unload);
   }
 
@@ -343,11 +343,11 @@ import org.matsim.vehicles.VehicleType;
   private void addDistributionServiceEventHandler(
       CarrierService carrierService, LspShipmentWithTime tuple, LSPCarrierResource resource) {
     for (LogisticChainElement element : this.resource.getClientElements()) {
-      if (element.getIncomingShipments().getShipments().contains(tuple)) {
+      if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
         DistributionServiceStartEventHandler handler =
             new DistributionServiceStartEventHandler(
-                carrierService, tuple.getShipment(), element, resource);
-        tuple.getShipment().addSimulationTracker(handler);
+                carrierService, tuple.getLspShipment(), element, resource);
+        tuple.getLspShipment().addSimulationTracker(handler);
         break;
       }
     }
@@ -359,11 +359,11 @@ import org.matsim.vehicles.VehicleType;
       LSPCarrierResource resource,
       Tour tour) {
     for (LogisticChainElement element : this.resource.getClientElements()) {
-      if (element.getIncomingShipments().getShipments().contains(tuple)) {
+      if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
         LSPTourStartEventHandler handler =
             new LSPTourStartEventHandler(
-                tuple.getShipment(), carrierService, element, resource, tour);
-        tuple.getShipment().addSimulationTracker(handler);
+                tuple.getLspShipment(), carrierService, element, resource, tour);
+        tuple.getLspShipment().addSimulationTracker(handler);
         break;
       }
     }

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/MainRunCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/MainRunCarrierScheduler.java
@@ -86,7 +86,7 @@ import org.matsim.vehicles.VehicleType;
 
       VehicleType vehicleType =
           ResourceImplementationUtils.getVehicleTypeCollection(carrier).iterator().next();
-      if ((load + tuple.getShipment().getSize())
+      if ((load + tuple.getLspShipment().getSize())
           > vehicleType.getCapacity().getOther().intValue()) {
         load = 0;
         CarrierPlan plan = createPlan(carrier, shipmentsInCurrentTour);
@@ -94,7 +94,7 @@ import org.matsim.vehicles.VehicleType;
         shipmentsInCurrentTour.clear();
       }
       shipmentsInCurrentTour.add(tuple);
-      load = load + tuple.getShipment().getSize();
+      load = load + tuple.getLspShipment().getSize();
     }
     if (!shipmentsInCurrentTour.isEmpty()) {
       CarrierPlan plan = createPlan(carrier, shipmentsInCurrentTour);
@@ -130,7 +130,7 @@ import org.matsim.vehicles.VehicleType;
     double latestTupleTime = 0;
 
     for (LspShipmentWithTime tuple : tuples) {
-      totalLoadingTime = totalLoadingTime + tuple.getShipment().getDeliveryServiceTime();
+      totalLoadingTime = totalLoadingTime + tuple.getLspShipment().getDeliveryServiceTime();
       if (tuple.getTime() > latestTupleTime) {
         latestTupleTime = tuple.getTime();
       }
@@ -221,11 +221,11 @@ import org.matsim.vehicles.VehicleType;
 
   private CarrierService convertToCarrierService(LspShipmentWithTime tuple) {
     Id<CarrierService> serviceId =
-        Id.create(tuple.getShipment().getId().toString(), CarrierService.class);
+        Id.create(tuple.getLspShipment().getId().toString(), CarrierService.class);
     CarrierService.Builder builder =
         CarrierService.Builder.newInstance(serviceId, resource.getEndLinkId());
-    builder.setCapacityDemand(tuple.getShipment().getSize());
-    builder.setServiceDuration(tuple.getShipment().getDeliveryServiceTime());
+    builder.setCapacityDemand(tuple.getLspShipment().getSize());
+    builder.setServiceDuration(tuple.getLspShipment().getDeliveryServiceTime());
     return builder.build();
   }
 
@@ -261,7 +261,7 @@ import org.matsim.vehicles.VehicleType;
         ShipmentUtils.ScheduledShipmentLoadBuilder.newInstance();
     builder.setResourceId(resource.getId());
     for (LogisticChainElement element : resource.getClientElements()) {
-      if (element.getIncomingShipments().getShipments().contains(tuple)) {
+      if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
         builder.setLogisticChainElement(element);
       }
     }
@@ -284,7 +284,7 @@ import org.matsim.vehicles.VehicleType;
             + String.valueOf(load.getLogisticChainElement().getId())
             + load.getElementType();
     Id<ShipmentPlanElement> id = Id.create(idString, ShipmentPlanElement.class);
-    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getShipment().getId())
+    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
         .addPlanElement(id, load);
   }
 
@@ -294,7 +294,7 @@ import org.matsim.vehicles.VehicleType;
         ShipmentUtils.ScheduledShipmentTransportBuilder.newInstance();
     builder.setResourceId(resource.getId());
     for (LogisticChainElement element : resource.getClientElements()) {
-      if (element.getIncomingShipments().getShipments().contains(tuple)) {
+      if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
         builder.setLogisticChainElement(element);
       }
     }
@@ -314,7 +314,7 @@ import org.matsim.vehicles.VehicleType;
             + String.valueOf(transport.getLogisticChainElement().getId())
             + transport.getElementType();
     Id<ShipmentPlanElement> id = Id.create(idString, ShipmentPlanElement.class);
-    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getShipment().getId())
+    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
         .addPlanElement(id, transport);
   }
 
@@ -324,7 +324,7 @@ import org.matsim.vehicles.VehicleType;
         ShipmentUtils.ScheduledShipmentUnloadBuilder.newInstance();
     builder.setResourceId(resource.getId());
     for (LogisticChainElement element : resource.getClientElements()) {
-      if (element.getIncomingShipments().getShipments().contains(tuple)) {
+      if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
         builder.setLogisticsChainElement(element);
       }
     }
@@ -350,7 +350,7 @@ import org.matsim.vehicles.VehicleType;
             + String.valueOf(unload.getLogisticChainElement().getId())
             + unload.getElementType();
     Id<ShipmentPlanElement> id = Id.create(idString, ShipmentPlanElement.class);
-    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getShipment().getId())
+    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
         .addPlanElement(id, unload);
   }
 
@@ -360,11 +360,11 @@ import org.matsim.vehicles.VehicleType;
       LSPCarrierResource resource,
       Tour tour) {
     for (LogisticChainElement element : this.resource.getClientElements()) {
-      if (element.getIncomingShipments().getShipments().contains(tuple)) {
+      if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
         LSPTourStartEventHandler handler =
             new LSPTourStartEventHandler(
-                tuple.getShipment(), carrierService, element, resource, tour);
-        tuple.getShipment().addSimulationTracker(handler);
+                tuple.getLspShipment(), carrierService, element, resource, tour);
+        tuple.getLspShipment().addSimulationTracker(handler);
         break;
       }
     }
@@ -376,11 +376,11 @@ import org.matsim.vehicles.VehicleType;
       LSPCarrierResource resource,
       Tour tour) {
     for (LogisticChainElement element : this.resource.getClientElements()) {
-      if (element.getIncomingShipments().getShipments().contains(tuple)) {
+      if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
         LSPTourEndEventHandler handler =
             new LSPTourEndEventHandler(
-					 tuple.getShipment(),carrierService, element, resource, tour);
-        tuple.getShipment().addSimulationTracker(handler);
+					 tuple.getLspShipment(),carrierService, element, resource, tour);
+        tuple.getLspShipment().addSimulationTracker(handler);
         break;
       }
     }

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/MainRunCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/MainRunCarrierScheduler.java
@@ -241,12 +241,12 @@ import org.matsim.vehicles.VehicleType;
                     lspShipmentWithTime, serviceActivity.getService());
             for (LSPShipmentCarrierServicePair pair : pairs) {
               if (pair.tuple == carrierPair.tuple
-                  && pair.service.getId() == carrierPair.service.getId()) {
+                  && pair.carrierService.getId() == carrierPair.carrierService.getId()) {
                 addShipmentLoadElement(lspShipmentWithTime, tour);
                 addShipmentTransportElement(lspShipmentWithTime, tour, serviceActivity);
                 addShipmentUnloadElement(lspShipmentWithTime, tour, serviceActivity);
-                addMainTourRunStartEventHandler(pair.service, lspShipmentWithTime, resource, tour);
-                addMainRunTourEndEventHandler(pair.service, lspShipmentWithTime, resource, tour);
+                addMainTourRunStartEventHandler(pair.carrierService, lspShipmentWithTime, resource, tour);
+                addMainRunTourEndEventHandler(pair.carrierService, lspShipmentWithTime, resource, tour);
               }
             }
           }
@@ -386,5 +386,5 @@ import org.matsim.vehicles.VehicleType;
     }
   }
 
-  private record LSPShipmentCarrierServicePair(LspShipmentWithTime tuple, CarrierService service) {}
+  private record LSPShipmentCarrierServicePair(LspShipmentWithTime tuple, CarrierService carrierService) {}
 }

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/ResourceImplementationUtils.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/ResourceImplementationUtils.java
@@ -84,8 +84,8 @@ public class ResourceImplementationUtils {
       final String str0 = "LSP: " + lsp.getId();
       System.out.println(str0);
       writer.write(str0 + "\n");
-      for (LSPShipment shipment : lsp.getShipments()) {
-        final String str1 = "Shipment: " + shipment;
+      for (LSPShipment lspShipment : lsp.getLspShipments()) {
+        final String str1 = "Shipment: " + lspShipment;
         System.out.println(str1);
         writer.write(str1 + "\n");
       }
@@ -101,7 +101,7 @@ public class ResourceImplementationUtils {
       final String str0 = "LSP: " + lsp.getId();
       System.out.println(str0);
       writer.write(str0 + "\n");
-      for (LSPShipment shipment : lsp.getShipments()) {
+      for (LSPShipment shipment : lsp.getLspShipments()) {
         ArrayList<ShipmentPlanElement> elementList =
             new ArrayList<>(
                 ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId())
@@ -116,9 +116,9 @@ public class ResourceImplementationUtils {
   }
 
   private static void writeShipmentWithPlanElements(
-      BufferedWriter writer, LSPShipment shipment, ArrayList<ShipmentPlanElement> elementList)
+      BufferedWriter writer, LSPShipment lspShipment, ArrayList<ShipmentPlanElement> elementList)
       throws IOException {
-    final String str1 = "Shipment: " + shipment;
+    final String str1 = "Shipment: " + lspShipment;
     System.out.println(str1);
     writer.write(str1 + "\n");
     for (ShipmentPlanElement element : elementList) {
@@ -153,11 +153,11 @@ public class ResourceImplementationUtils {
       final String str0 = "LSP: " + lsp.getId();
       System.out.println(str0);
       writer.write(str0 + "\n");
-      for (LSPShipment shipment : lsp.getShipments()) {
+      for (LSPShipment lspShipment : lsp.getLspShipments()) {
         ArrayList<ShipmentPlanElement> elementList =
-            new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
+            new ArrayList<>(lspShipment.getShipmentLog().getPlanElements().values());
         elementList.sort(ShipmentUtils.createShipmentPlanElementComparator());
-        writeShipmentWithPlanElements(writer, shipment, elementList);
+        writeShipmentWithPlanElements(writer, lspShipment, elementList);
       }
     } catch (IOException e) {
       e.printStackTrace();

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/SimpleForwardLogisticChainScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/SimpleForwardLogisticChainScheduler.java
@@ -76,7 +76,7 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
     for (LogisticChain solution : lsp.getSelectedPlan().getLogisticChains()) {
       LogisticChainElement firstElement = getFirstElement(solution);
       assert firstElement != null;
-      for (Id<LSPShipment> lspShipmentId : solution.getShipmentIds()) {
+      for (Id<LSPShipment> lspShipmentId : solution.getLspShipmentIds()) {
         var shipment = LSPUtils.findLspShipment(lsp, lspShipmentId);
         assert shipment != null;
         firstElement

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/SingleLogisticChainShipmentAssigner.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/SingleLogisticChainShipmentAssigner.java
@@ -40,9 +40,9 @@ class SingleLogisticChainShipmentAssigner implements InitialShipmentAssigner {
   SingleLogisticChainShipmentAssigner() {}
 
   @Override
-  public void assignToPlan(LSPPlan lspPlan, LSPShipment shipment) {
+  public void assignToPlan(LSPPlan lspPlan, LSPShipment lspShipment) {
     Gbl.assertIf(lspPlan.getLogisticChains().size() == 1);
     LogisticChain singleSolution = lspPlan.getLogisticChains().iterator().next();
-    singleSolution.addShipmentToChain(shipment);
+    singleSolution.addShipmentToChain(lspShipment);
   }
 }

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/TransshipmentHubScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/TransshipmentHubScheduler.java
@@ -76,10 +76,10 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
         ShipmentUtils.ScheduledShipmentHandleBuilder.newInstance();
     builder.setStartTime(tuple.getTime());
     builder.setEndTime(
-        tuple.getTime() + capacityNeedFixed + capacityNeedLinear * tuple.getShipment().getSize());
+        tuple.getTime() + capacityNeedFixed + capacityNeedLinear * tuple.getLspShipment().getSize());
     builder.setResourceId(transshipmentHubResource.getId());
     for (LogisticChainElement element : transshipmentHubResource.getClientElements()) {
-      if (element.getIncomingShipments().getShipments().contains(tuple)) {
+      if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
         builder.setLogisticsChainElement(element);
       }
     }
@@ -89,16 +89,16 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
             + String.valueOf(handle.getLogisticChainElement().getId())
             + handle.getElementType();
     Id<ShipmentPlanElement> id = Id.create(idString, ShipmentPlanElement.class);
-    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getShipment().getId())
+    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
         .addPlanElement(id, handle);
   }
 
   private void addShipmentToEventHandler(LspShipmentWithTime tuple) {
     for (LogisticChainElement element : transshipmentHubResource.getClientElements()) {
-      if (element.getIncomingShipments().getShipments().contains(tuple)) {
+      if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
         ShipmentPlan shipmentPlan =
-            ShipmentUtils.getOrCreateShipmentPlan(lspPlan, tuple.getShipment().getId());
-        eventHandler.addShipment(tuple.getShipment(), element, shipmentPlan);
+            ShipmentUtils.getOrCreateShipmentPlan(lspPlan, tuple.getLspShipment().getId());
+        eventHandler.addShipment(tuple.getLspShipment(), element, shipmentPlan);
         break;
       }
     }

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/TransshipmentHubTourEndEventHandler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/TransshipmentHubTourEndEventHandler.java
@@ -96,9 +96,9 @@ import org.matsim.freight.logistics.shipment.*;
   }
 
   public void addShipment(
-      LSPShipment shipment, LogisticChainElement logisticChainElement, ShipmentPlan shipmentPlan) {
+      LSPShipment lspShipment, LogisticChainElement logisticChainElement, ShipmentPlan shipmentPlan) {
     TransshipmentHubEventHandlerPair pair =
-        new TransshipmentHubEventHandlerPair(shipment, logisticChainElement);
+        new TransshipmentHubEventHandlerPair(lspShipment, logisticChainElement);
 
     for (ShipmentPlanElement planElement : shipmentPlan.getPlanElements().values()) {
       if (planElement instanceof ShipmentLeg transport) {
@@ -133,7 +133,7 @@ import org.matsim.freight.logistics.shipment.*;
                   && (tour.getStartLinkId() != transshipmentHubResource.getStartLinkId())) {
 
                 final CarrierService carrierService = serviceActivity.getService();
-                final LSPShipment lspShipment = servicesWaitedFor.get(carrierService).shipment;
+                final LSPShipment lspShipment = servicesWaitedFor.get(carrierService).lspShipment;
                 // NOTE: Do NOT add time vor unloading all goods, because they are included for the
                 // main run (Service activity at end of tour)
                 final double expHandlingDuration =
@@ -156,7 +156,7 @@ import org.matsim.freight.logistics.shipment.*;
             if (tour.getEndLinkId() == transshipmentHubResource.getStartLinkId()) {
 
               final CarrierService carrierService = serviceActivity.getService();
-              final LSPShipment lspShipment = servicesWaitedFor.get(carrierService).shipment;
+              final LSPShipment lspShipment = servicesWaitedFor.get(carrierService).lspShipment;
 
               // TODO: Adding this here to be more in line with the schedule and have the shipment
               // log fitting to it.
@@ -204,7 +204,7 @@ import org.matsim.freight.logistics.shipment.*;
   private void logHandlingInHub(
           CarrierService carrierService, double startTime, double endTime) {
 
-    LSPShipment lspShipment = servicesWaitedFor.get(carrierService).shipment;
+    LSPShipment lspShipment = servicesWaitedFor.get(carrierService).lspShipment;
 
     { // Old logging approach - will be removed at some point in time
       ShipmentPlanElement handle =
@@ -267,11 +267,11 @@ import org.matsim.freight.logistics.shipment.*;
   }
 
   public static class TransshipmentHubEventHandlerPair {
-    public final LSPShipment shipment;
+    public final LSPShipment lspShipment;
     public final LogisticChainElement element;
 
-    public TransshipmentHubEventHandlerPair(LSPShipment shipment, LogisticChainElement element) {
-      this.shipment = shipment;
+    public TransshipmentHubEventHandlerPair(LSPShipment lspShipment, LogisticChainElement element) {
+      this.lspShipment = lspShipment;
       this.element = element;
     }
   }

--- a/src/test/java/org/matsim/freight/logistics/examples/lspReplanning/CollectionLSPReplanningTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/lspReplanning/CollectionLSPReplanningTest.java
@@ -231,8 +231,8 @@ public class CollectionLSPReplanningTest {
 
 	@Test
 	public void testCollectionLSPReplanning() {
-		System.out.println(collectionLSP.getSelectedPlan().getLogisticChains().iterator().next().getShipmentIds().size());
-		assertTrue(collectionLSP.getSelectedPlan().getLogisticChains().iterator().next().getShipmentIds().size() < 20);
+		System.out.println(collectionLSP.getSelectedPlan().getLogisticChains().iterator().next().getLspShipmentIds().size());
+		assertTrue(collectionLSP.getSelectedPlan().getLogisticChains().iterator().next().getLspShipmentIds().size() < 20);
 	}
 
 	@Test

--- a/src/test/java/org/matsim/freight/logistics/examples/lspScoring/CollectionLSPScoringTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/lspScoring/CollectionLSPScoringTest.java
@@ -165,8 +165,8 @@ public class CollectionLSPScoringTest {
 	@Test
 	public void testCollectionLSPScoring() {
 		System.out.println(collectionLSP.getSelectedPlan().getScore());
-		assertEquals(numberOfShipments, collectionLSP.getShipments().size());
-		assertEquals(numberOfShipments, collectionLSP.getSelectedPlan().getLogisticChains().iterator().next().getShipmentIds()
+		assertEquals(numberOfShipments, collectionLSP.getLspShipments().size());
+		assertEquals(numberOfShipments, collectionLSP.getSelectedPlan().getLogisticChains().iterator().next().getLspShipmentIds()
 				.size());
 		assertTrue(collectionLSP.getSelectedPlan().getScore() > 0);
 		assertTrue(collectionLSP.getSelectedPlan().getScore() <= (numberOfShipments * 5));

--- a/src/test/java/org/matsim/freight/logistics/examples/lspScoring/MultipleIterationsCollectionLSPScoringTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/lspScoring/MultipleIterationsCollectionLSPScoringTest.java
@@ -196,8 +196,8 @@ public class MultipleIterationsCollectionLSPScoringTest {
 	@Test
 	public void testCollectionLSPScoring() {
 		System.out.println("score=" + collectionLSP.getSelectedPlan().getScore());
-		assertEquals(numberOfShipments, collectionLSP.getShipments().size());
-		assertEquals(numberOfShipments, collectionLSP.getSelectedPlan().getLogisticChains().iterator().next().getShipmentIds().size());
+		assertEquals(numberOfShipments, collectionLSP.getLspShipments().size());
+		assertEquals(numberOfShipments, collectionLSP.getSelectedPlan().getLogisticChains().iterator().next().getLspShipmentIds().size());
 		assertTrue(collectionLSP.getSelectedPlan().getScore() > 0);
 		assertTrue(collectionLSP.getSelectedPlan().getScore() <= (numberOfShipments * 5));
 	}

--- a/src/test/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsReplanningTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsReplanningTest.java
@@ -256,7 +256,7 @@ public class MultipleChainsReplanningTest {
 		updatedPlanCount = lsp.getPlans().size();
 		innovatedPlanShipmentPlanCount = lsp.getPlans().get(1).getShipmentPlans().size();
 
-		innovatedPlanFirstLogisticChainShipmentCount = lsp.getPlans().get(1).getLogisticChains().iterator().next().getShipmentIds().size();
+		innovatedPlanFirstLogisticChainShipmentCount = lsp.getPlans().get(1).getLogisticChains().iterator().next().getLspShipmentIds().size();
 		for (ShipmentPlan shipmentPlan : lsp.getPlans().get(1).getShipmentPlans()) {
 			if (shipmentPlan.getPlanElements().isEmpty()) {
 				innovatedPlanHasEmptyShipmentPlanElements = true;

--- a/src/test/java/org/matsim/freight/logistics/examples/requirementsChecking/AssignerRequirementsTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/requirementsChecking/AssignerRequirementsTest.java
@@ -201,11 +201,11 @@ public class AssignerRequirementsTest {
 
 	@Test
 	public void testAssignerRequirements() {
-		for (Id<LSPShipment> shipmentId : blueChain.getShipmentIds()) {
+		for (Id<LSPShipment> shipmentId : blueChain.getLspShipmentIds()) {
 			LSPShipment shipment = LSPUtils.findLspShipment(blueChain.getLSP(), shipmentId);
 			assertTrue(shipment.getRequirements().iterator().next() instanceof BlueRequirement);
 		}
-		for (Id<LSPShipment> shipmentId : redChain.getShipmentIds()) {
+		for (Id<LSPShipment> shipmentId : redChain.getLspShipmentIds()) {
 			LSPShipment shipment = LSPUtils.findLspShipment(redChain.getLSP(), shipmentId);
 			assertTrue(shipment.getRequirements().iterator().next() instanceof RedRequirement);
 		}

--- a/src/test/java/org/matsim/freight/logistics/logisticChainElementTests/CollectionElementTest.java
+++ b/src/test/java/org/matsim/freight/logistics/logisticChainElementTests/CollectionElementTest.java
@@ -87,15 +87,15 @@ public class CollectionElementTest {
 	@Test
 	public void testCollectionElement() {
 		assertNotNull(collectionElement.getIncomingShipments());
-		assertNotNull(collectionElement.getIncomingShipments().getShipments());
-		assertTrue(collectionElement.getIncomingShipments().getSortedShipments().isEmpty());
+		assertNotNull(collectionElement.getIncomingShipments().getLspShipmentsWTime());
+		assertTrue(collectionElement.getIncomingShipments().getSortedLspShipments().isEmpty());
 		assertNotNull(collectionElement.getAttributes());
 		assertTrue(collectionElement.getAttributes().isEmpty());
 //		assertNull(collectionElement.getEmbeddingContainer() );
 		assertNull(collectionElement.getNextElement());
 		assertNotNull(collectionElement.getOutgoingShipments());
-		assertNotNull(collectionElement.getOutgoingShipments().getShipments());
-		assertTrue(collectionElement.getOutgoingShipments().getSortedShipments().isEmpty());
+		assertNotNull(collectionElement.getOutgoingShipments().getLspShipmentsWTime());
+		assertTrue(collectionElement.getOutgoingShipments().getSortedLspShipments().isEmpty());
 		assertNull(collectionElement.getPreviousElement());
 		assertSame(collectionElement.getResource(), carrierResource);
 		assertSame(collectionElement.getResource().getClientElements().iterator().next(), collectionElement);

--- a/src/test/java/org/matsim/freight/logistics/logisticChainElementTests/DistributionElementTest.java
+++ b/src/test/java/org/matsim/freight/logistics/logisticChainElementTests/DistributionElementTest.java
@@ -93,15 +93,15 @@ public class DistributionElementTest {
 	@Test
 	public void testDistributionElement() {
 		assertNotNull(distributionElement.getIncomingShipments());
-		assertNotNull(distributionElement.getIncomingShipments().getShipments());
-		assertTrue(distributionElement.getIncomingShipments().getSortedShipments().isEmpty());
+		assertNotNull(distributionElement.getIncomingShipments().getLspShipmentsWTime());
+		assertTrue(distributionElement.getIncomingShipments().getSortedLspShipments().isEmpty());
 		assertNotNull(distributionElement.getAttributes());
 		assertTrue(distributionElement.getAttributes().isEmpty());
 //		assertNull(distributionElement.getEmbeddingContainer() );
 		assertNull(distributionElement.getNextElement());
 		assertNotNull(distributionElement.getOutgoingShipments());
-		assertNotNull(distributionElement.getOutgoingShipments().getShipments());
-		assertTrue(distributionElement.getOutgoingShipments().getSortedShipments().isEmpty());
+		assertNotNull(distributionElement.getOutgoingShipments().getLspShipmentsWTime());
+		assertTrue(distributionElement.getOutgoingShipments().getSortedLspShipments().isEmpty());
 		assertNull(distributionElement.getPreviousElement());
 		assertSame(distributionElement.getResource(), adapter);
 		assertSame(distributionElement.getResource().getClientElements().iterator().next(), distributionElement);

--- a/src/test/java/org/matsim/freight/logistics/logisticChainElementTests/MainRunElementTest.java
+++ b/src/test/java/org/matsim/freight/logistics/logisticChainElementTests/MainRunElementTest.java
@@ -92,15 +92,15 @@ public class MainRunElementTest {
 	@Test
 	public void testDistributionElement() {
 		assertNotNull(mainRunElement.getIncomingShipments());
-		assertNotNull(mainRunElement.getIncomingShipments().getShipments());
-		assertTrue(mainRunElement.getIncomingShipments().getSortedShipments().isEmpty());
+		assertNotNull(mainRunElement.getIncomingShipments().getLspShipmentsWTime());
+		assertTrue(mainRunElement.getIncomingShipments().getSortedLspShipments().isEmpty());
 		assertNotNull(mainRunElement.getAttributes());
 		assertTrue(mainRunElement.getAttributes().isEmpty());
 //		assertNull(mainRunElement.getEmbeddingContainer() );
 		assertNull(mainRunElement.getNextElement());
 		assertNotNull(mainRunElement.getOutgoingShipments());
-		assertNotNull(mainRunElement.getOutgoingShipments().getShipments());
-		assertTrue(mainRunElement.getOutgoingShipments().getSortedShipments().isEmpty());
+		assertNotNull(mainRunElement.getOutgoingShipments().getLspShipmentsWTime());
+		assertTrue(mainRunElement.getOutgoingShipments().getSortedLspShipments().isEmpty());
 		assertNull(mainRunElement.getPreviousElement());
 		assertSame(mainRunElement.getResource(), mainRunResource);
 		assertSame(mainRunElement.getResource().getClientElements().iterator().next(), mainRunElement);

--- a/src/test/java/org/matsim/freight/logistics/logisticChainElementTests/SecondHubElementTest.java
+++ b/src/test/java/org/matsim/freight/logistics/logisticChainElementTests/SecondHubElementTest.java
@@ -57,15 +57,15 @@ public class SecondHubElementTest {
 	@Test
 	public void testDistributionElement() {
 		assertNotNull(hubElement.getIncomingShipments());
-		assertNotNull(hubElement.getIncomingShipments().getShipments());
-		assertTrue(hubElement.getIncomingShipments().getSortedShipments().isEmpty());
+		assertNotNull(hubElement.getIncomingShipments().getLspShipmentsWTime());
+		assertTrue(hubElement.getIncomingShipments().getSortedLspShipments().isEmpty());
 		assertNotNull(hubElement.getAttributes());
 		assertTrue(hubElement.getAttributes().isEmpty());
 //		assertNull(hubElement.getEmbeddingContainer() );
 		assertNull(hubElement.getNextElement());
 		assertNotNull(hubElement.getOutgoingShipments());
-		assertNotNull(hubElement.getOutgoingShipments().getShipments());
-		assertTrue(hubElement.getOutgoingShipments().getSortedShipments().isEmpty());
+		assertNotNull(hubElement.getOutgoingShipments().getLspShipmentsWTime());
+		assertTrue(hubElement.getOutgoingShipments().getSortedLspShipments().isEmpty());
 		assertNull(hubElement.getPreviousElement());
 		assertSame(hubElement.getResource(), point);
 		assertSame(hubElement.getResource().getClientElements().iterator().next(), hubElement);

--- a/src/test/java/org/matsim/freight/logistics/logisticChainTests/CollectionChainTest.java
+++ b/src/test/java/org/matsim/freight/logistics/logisticChainTests/CollectionChainTest.java
@@ -101,8 +101,8 @@ public class CollectionChainTest {
 		assertNotNull(logisticChain.getAttributes());
 		assertTrue(logisticChain.getAttributes().isEmpty());
 		assertNull(logisticChain.getLSP());
-		assertNotNull(logisticChain.getShipmentIds());
-		assertTrue(logisticChain.getShipmentIds().isEmpty());
+		assertNotNull(logisticChain.getLspShipmentIds());
+		assertTrue(logisticChain.getLspShipmentIds().isEmpty());
 		assertEquals(1, logisticChain.getLogisticChainElements().size());
 		ArrayList<LogisticChainElement> elements = new ArrayList<>(logisticChain.getLogisticChainElements());
 		for (LogisticChainElement element : elements) {

--- a/src/test/java/org/matsim/freight/logistics/logisticChainTests/CompleteLogisticChainTest.java
+++ b/src/test/java/org/matsim/freight/logistics/logisticChainTests/CompleteLogisticChainTest.java
@@ -222,8 +222,8 @@ public class CompleteLogisticChainTest {
 		assertNotNull(logisticChain.getAttributes());
 		assertTrue(logisticChain.getAttributes().isEmpty());
 		assertNull(logisticChain.getLSP());
-		assertNotNull(logisticChain.getShipmentIds());
-		assertTrue(logisticChain.getShipmentIds().isEmpty());
+		assertNotNull(logisticChain.getLspShipmentIds());
+		assertTrue(logisticChain.getLspShipmentIds().isEmpty());
 		assertEquals(5, logisticChain.getLogisticChainElements().size());
 		ArrayList<LogisticChainElement> elements = new ArrayList<>(logisticChain.getLogisticChainElements());
 		for (LogisticChainElement element : elements) {

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CollectionLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CollectionLSPMobsimTest.java
@@ -205,7 +205,7 @@ public class CollectionLSPMobsimTest {
 
 	@Test
 	public void testCollectionLSPMobsim() {
-		for (LSPShipment shipment : collectionLSP.getShipments()) {
+		for (LSPShipment shipment : collectionLSP.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
 
 			log.warn("");

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CompleteLSPMobsimTest.java
@@ -310,7 +310,7 @@ public class CompleteLSPMobsimTest {
 
 	@Test
 	public void testFirstReloadLSPMobsim() {
-		for (LSPShipment shipment : completeLSP.getShipments()) {
+		for (LSPShipment shipment : completeLSP.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
 			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(completeLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstAndSecondReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstAndSecondReloadLSPMobsimTest.java
@@ -279,7 +279,7 @@ public class FirstAndSecondReloadLSPMobsimTest {
 
 	@Test
 	public void testFirstReloadLSPMobsim() {
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
 			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
 			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstReloadLSPMobsimTest.java
@@ -223,7 +223,7 @@ public class FirstReloadLSPMobsimTest {
 	@Test
 	public void testFirstReloadLSPMobsim() {
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
 			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
 			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunLSPMobsimTest.java
@@ -255,7 +255,7 @@ public class MainRunLSPMobsimTest {
 
 	@Test
 	public void testFirstReloadLSPMobsim() {
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
 			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
 			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunOnlyLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunOnlyLSPMobsimTest.java
@@ -201,7 +201,7 @@ public class MainRunOnlyLSPMobsimTest {
 
 	@Test
 	public void testFirstReloadLSPMobsim() {
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
 			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
 			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCollectionLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCollectionLSPMobsimTest.java
@@ -200,7 +200,7 @@ public class MultipleIterationsCollectionLSPMobsimTest {
 	@Test
 	public void testCollectionLSPMobsim() {
 
-		for (LSPShipment shipment : collectionLSP.getShipments()) {
+		for (LSPShipment shipment : collectionLSP.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
 			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
 			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCompleteLSPMobsimTest.java
@@ -334,7 +334,7 @@ public class MultipleIterationsCompleteLSPMobsimTest {
 
 	@Test
 	public void testCompleteLSPMobsim() {
-		for (LSPShipment shipment : completeLSP.getShipments()) {
+		for (LSPShipment shipment : completeLSP.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
 			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(completeLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstAndSecondReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstAndSecondReloadLSPMobsimTest.java
@@ -293,7 +293,7 @@ public class MultipleIterationsFirstAndSecondReloadLSPMobsimTest {
 
 	@Test
 	public void testFirstReloadLSPMobsim() {
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
 			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
 			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstReloadLSPMobsimTest.java
@@ -236,7 +236,7 @@ public class MultipleIterationsFirstReloadLSPMobsimTest {
 	@Test
 	public void testFirstReloadLSPMobsim() {
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
 			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
 			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
@@ -277,7 +277,7 @@ public class MultipleIterationsMainRunLSPMobsimTest {
 
 	@Test
 	public void testFirstReloadLSPMobsim() {
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
 			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
 			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCollectionLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCollectionLSPMobsimTest.java
@@ -185,7 +185,7 @@ public class MultipleShipmentsCollectionLSPMobsimTest {
 	@Test
 	public void testCollectionLSPMobsim() {
 
-		for (LSPShipment shipment : collectionLSP.getShipments()) {
+		for (LSPShipment shipment : collectionLSP.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
 			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
 			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
@@ -337,7 +337,7 @@ public class MultipleShipmentsCompleteLSPMobsimTest {
 
 	@Test
 	public void testCompleteLSPMobsim() {
-		for (LSPShipment shipment : completeLSP.getShipments()) {
+		for (LSPShipment shipment : completeLSP.getLspShipments()) {
 			log.info("comparing shipment: " + shipment.getId());
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
 			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(completeLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstAndSecondReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstAndSecondReloadLSPMobsimTest.java
@@ -292,7 +292,7 @@ public class MultipleShipmentsFirstAndSecondReloadLSPMobsimTest {
 
 	@Test
 	public void testFirstReloadLSPMobsim() {
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
 			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
 			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstReloadLSPMobsimTest.java
@@ -228,7 +228,7 @@ public class MultipleShipmentsFirstReloadLSPMobsimTest {
 	@Test
 	public void testFirstReloadLSPMobsim() {
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
 			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
 			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsMainRunLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsMainRunLSPMobsimTest.java
@@ -261,7 +261,7 @@ public class MultipleShipmentsMainRunLSPMobsimTest {
 
 	@Test
 	public void testFirstReloadLSPMobsim() {
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
 			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
 			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/RepeatedMultipleShipmentsCompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/RepeatedMultipleShipmentsCompleteLSPMobsimTest.java
@@ -317,7 +317,7 @@ public class RepeatedMultipleShipmentsCompleteLSPMobsimTest {
 		int numberOfIterations = 1 + MatsimRandom.getRandom().nextInt(10);
 		for (int i = 0; i < numberOfIterations; i++) {
 			initialize();
-			for (LSPShipment shipment : completeLSP.getShipments()) {
+			for (LSPShipment shipment : completeLSP.getLspShipments()) {
 				assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
 				ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(completeLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 				scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());

--- a/src/test/java/org/matsim/freight/logistics/lspShipmentAssignmentTests/CollectionLSPShipmentAssigmentTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspShipmentAssignmentTests/CollectionLSPShipmentAssigmentTest.java
@@ -144,20 +144,20 @@ public class CollectionLSPShipmentAssigmentTest {
 	@Test
 	public void testCollectionLSPShipmentAssignment() {
 		assertSame(collectionLSP.getSelectedPlan(), collectionPlan);
-		assertFalse(collectionLSP.getShipments().isEmpty());
+		assertFalse(collectionLSP.getLspShipments().isEmpty());
 		ArrayList<LogisticChain> solutions = new ArrayList<>(collectionLSP.getSelectedPlan().getLogisticChains());
 
 		for (LogisticChain solution : solutions) {
 			if (solutions.indexOf(solution) == 0) {
-				assertEquals(10, solution.getShipmentIds().size());
+				assertEquals(10, solution.getLspShipmentIds().size());
 				for (LogisticChainElement element : solution.getLogisticChainElements()) {
 					if (element.getPreviousElement() == null) {
-						assertTrue(element.getIncomingShipments().getShipments().isEmpty());
-						assertTrue(element.getOutgoingShipments().getShipments().isEmpty());
+						assertTrue(element.getIncomingShipments().getLspShipmentsWTime().isEmpty());
+						assertTrue(element.getOutgoingShipments().getLspShipmentsWTime().isEmpty());
 					}
 				}
 			} else {
-				assertTrue(solution.getShipmentIds().isEmpty());
+				assertTrue(solution.getLspShipmentIds().isEmpty());
 			}
 		}
 

--- a/src/test/java/org/matsim/freight/logistics/lspShipmentAssignmentTests/CompleteLSPShipmentAssignerTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspShipmentAssignmentTests/CompleteLSPShipmentAssignerTest.java
@@ -275,15 +275,15 @@ public class CompleteLSPShipmentAssignerTest {
 
 		for (LogisticChain solution : solutions) {
 			if (solutions.indexOf(solution) == 0) {
-				assertEquals(10, solution.getShipmentIds().size());
+				assertEquals(10, solution.getLspShipmentIds().size());
 				for (LogisticChainElement element : solution.getLogisticChainElements()) {
 					if (element.getPreviousElement() == null) {
-						assertTrue(element.getIncomingShipments().getShipments().isEmpty());
-						assertTrue(element.getOutgoingShipments().getShipments().isEmpty());
+						assertTrue(element.getIncomingShipments().getLspShipmentsWTime().isEmpty());
+						assertTrue(element.getOutgoingShipments().getLspShipmentsWTime().isEmpty());
 					}
 				}
 			} else {
-				assertTrue(solution.getShipmentIds().isEmpty());
+				assertTrue(solution.getLspShipmentIds().isEmpty());
 			}
 		}
 

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/CollectionLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/CollectionLSPSchedulingTest.java
@@ -149,7 +149,7 @@ public class CollectionLSPSchedulingTest {
 	@Test
 	public void testCollectionLSPScheduling() {
 
-		for (LSPShipment shipment : collectionLSP.getShipments()) {
+		for (LSPShipment shipment : collectionLSP.getLspShipments()) {
 			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
 
@@ -160,7 +160,7 @@ public class CollectionLSPSchedulingTest {
 			System.out.println();
 		}
 
-		for (LSPShipment shipment : collectionLSP.getShipments()) {
+		for (LSPShipment shipment : collectionLSP.getLspShipments()) {
 			assertEquals(3, ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().size());
 			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 			assertEquals("UNLOAD", planElements.get(2).getElementType());
@@ -219,13 +219,13 @@ public class CollectionLSPSchedulingTest {
 		}
 
 		for (LogisticChain solution : collectionLSP.getSelectedPlan().getLogisticChains()) {
-			assertEquals(1, solution.getShipmentIds().size());
+			assertEquals(1, solution.getLspShipmentIds().size());
 			for (LogisticChainElement element : solution.getLogisticChainElements()) {
-				assertTrue(element.getIncomingShipments().getShipments().isEmpty());
+				assertTrue(element.getIncomingShipments().getLspShipmentsWTime().isEmpty());
 				if (element.getNextElement() != null) {
-					assertTrue(element.getOutgoingShipments().getShipments().isEmpty());
+					assertTrue(element.getOutgoingShipments().getLspShipmentsWTime().isEmpty());
 				} else {
-					assertFalse(element.getOutgoingShipments().getShipments().isEmpty());
+					assertFalse(element.getOutgoingShipments().getLspShipmentsWTime().isEmpty());
 				}
 			}
 		}

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
@@ -288,7 +288,7 @@ public class CompleteLSPSchedulingTest {
 	@Test
 	public void testCompletedLSPScheduling() {
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			ArrayList<ShipmentPlanElement> elementList = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 			elementList.sort(ShipmentUtils.createShipmentPlanElementComparator());
 			System.out.println();
@@ -301,7 +301,7 @@ public class CompleteLSPSchedulingTest {
 		ArrayList<LogisticChainElement> solutionElements = new ArrayList<>(lsp.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements());
 		ArrayList<LSPResource> resources = new ArrayList<>(lsp.getResources());
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertEquals(11, ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
 			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 			planElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
@@ -435,7 +435,7 @@ public class CompleteLSPSchedulingTest {
 		while (iter.hasNext()) {
 			Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry = iter.next();
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().shipment;
+			LSPShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), shipment.getFrom());
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -449,8 +449,8 @@ public class CompleteLSPSchedulingTest {
 			}
 			assertTrue(handledByTranshipmentHub);
 
-			assertFalse(element.getOutgoingShipments().getShipments().contains(shipment));
-			assertFalse(element.getIncomingShipments().getShipments().contains(shipment));
+			assertFalse(element.getOutgoingShipments().getLspShipmentsWTime().contains(shipment));
+			assertFalse(element.getIncomingShipments().getLspShipmentsWTime().contains(shipment));
 		}
 
 		assertEquals(1, secondTranshipmentHubResource.getSimulationTrackers().size());
@@ -462,7 +462,7 @@ public class CompleteLSPSchedulingTest {
 		while (iter.hasNext()) {
 			Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry = iter.next();
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().shipment;
+			LSPShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), toLinkId);
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -476,11 +476,11 @@ public class CompleteLSPSchedulingTest {
 			}
 			assertTrue(handledByTranshipmentHub);
 
-			assertFalse(element.getOutgoingShipments().getShipments().contains(shipment));
-			assertFalse(element.getIncomingShipments().getShipments().contains(shipment));
+			assertFalse(element.getOutgoingShipments().getLspShipmentsWTime().contains(shipment));
+			assertFalse(element.getIncomingShipments().getLspShipmentsWTime().contains(shipment));
 		}
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertEquals(6, shipment.getSimulationTrackers().size());
 			eventHandlers = new ArrayList<>(shipment.getSimulationTrackers());
 			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
@@ -594,13 +594,13 @@ public class CompleteLSPSchedulingTest {
 		}
 
 		for (LogisticChain solution : lsp.getSelectedPlan().getLogisticChains()) {
-			assertEquals(1, solution.getShipmentIds().size());
+			assertEquals(1, solution.getLspShipmentIds().size());
 			for (LogisticChainElement element : solution.getLogisticChainElements()) {
-				assertTrue(element.getIncomingShipments().getShipments().isEmpty());
+				assertTrue(element.getIncomingShipments().getLspShipmentsWTime().isEmpty());
 				if (element.getNextElement() != null) {
-					assertTrue(element.getOutgoingShipments().getShipments().isEmpty());
+					assertTrue(element.getOutgoingShipments().getLspShipmentsWTime().isEmpty());
 				} else {
-					assertFalse(element.getOutgoingShipments().getShipments().isEmpty());
+					assertFalse(element.getOutgoingShipments().getLspShipmentsWTime().isEmpty());
 				}
 			}
 		}

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/FirstHubElementTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/FirstHubElementTest.java
@@ -56,15 +56,15 @@ public class FirstHubElementTest {
 	@Test
 	public void testDistributionElement() {
 		assertNotNull(reloadingElement.getIncomingShipments());
-		assertNotNull(reloadingElement.getIncomingShipments().getShipments());
-		assertTrue(reloadingElement.getIncomingShipments().getSortedShipments().isEmpty());
+		assertNotNull(reloadingElement.getIncomingShipments().getLspShipmentsWTime());
+		assertTrue(reloadingElement.getIncomingShipments().getSortedLspShipments().isEmpty());
 		assertNotNull(reloadingElement.getAttributes());
 		assertTrue(reloadingElement.getAttributes().isEmpty());
 //		assertNull(reloadingElement.getEmbeddingContainer() );
 		assertNull(reloadingElement.getNextElement());
 		assertNotNull(reloadingElement.getOutgoingShipments());
-		assertNotNull(reloadingElement.getOutgoingShipments().getShipments());
-		assertTrue(reloadingElement.getOutgoingShipments().getSortedShipments().isEmpty());
+		assertNotNull(reloadingElement.getOutgoingShipments().getLspShipmentsWTime());
+		assertTrue(reloadingElement.getOutgoingShipments().getSortedLspShipments().isEmpty());
 		assertNull(reloadingElement.getPreviousElement());
 		assertSame(reloadingElement.getResource(), point);
 		assertSame(reloadingElement.getResource().getClientElements().iterator().next(), reloadingElement);

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/FirstReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/FirstReloadLSPSchedulingTest.java
@@ -190,7 +190,7 @@ public class FirstReloadLSPSchedulingTest {
 	@Test
 	public void testFirstReloadLSPScheduling() {
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
 
@@ -202,7 +202,7 @@ public class FirstReloadLSPSchedulingTest {
 		}
 
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertEquals(4, ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
 			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 			planElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
@@ -257,7 +257,7 @@ public class FirstReloadLSPSchedulingTest {
 
 		for (Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry : reloadEventHandler.getServicesWaitedFor().entrySet()) {
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().shipment;
+			LSPShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), shipment.getFrom());
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -271,12 +271,12 @@ public class FirstReloadLSPSchedulingTest {
 			}
 			assertTrue(handledByTranshipmentHub);
 			//This asserts that the shipments waiting for handling have been handled and the queues have been cleared
-			assertFalse(element.getOutgoingShipments().getShipments().contains(shipment));
-			assertFalse(element.getIncomingShipments().getShipments().contains(shipment));
+			assertFalse(element.getOutgoingShipments().getLspShipmentsWTime().contains(shipment));
+			assertFalse(element.getIncomingShipments().getLspShipmentsWTime().contains(shipment));
 		}
 
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertEquals(2, shipment.getSimulationTrackers().size());
 			eventHandlers = new ArrayList<>(shipment.getSimulationTrackers());
 			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
@@ -307,13 +307,13 @@ public class FirstReloadLSPSchedulingTest {
 		}
 
 		for (LogisticChain solution : lsp.getSelectedPlan().getLogisticChains()) {
-			assertEquals(1, solution.getShipmentIds().size());
+			assertEquals(1, solution.getLspShipmentIds().size());
 			for (LogisticChainElement element : solution.getLogisticChainElements()) {
-				assertTrue(element.getIncomingShipments().getShipments().isEmpty());
+				assertTrue(element.getIncomingShipments().getLspShipmentsWTime().isEmpty());
 				if (element.getNextElement() != null) {
-					assertTrue(element.getOutgoingShipments().getShipments().isEmpty());
+					assertTrue(element.getOutgoingShipments().getLspShipmentsWTime().isEmpty());
 				} else {
-					assertFalse(element.getOutgoingShipments().getShipments().isEmpty());
+					assertFalse(element.getOutgoingShipments().getLspShipmentsWTime().isEmpty());
 				}
 			}
 		}

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MainRunLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MainRunLSPSchedulingTest.java
@@ -225,7 +225,7 @@ public class MainRunLSPSchedulingTest {
 	@Test
 	public void testMainRunLSPScheduling() {
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
 
@@ -237,7 +237,7 @@ public class MainRunLSPSchedulingTest {
 		}
 
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertEquals(7, ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
 			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 			planElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
@@ -324,7 +324,7 @@ public class MainRunLSPSchedulingTest {
 
 		for (Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry : reloadEventHandler.getServicesWaitedFor().entrySet()) {
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().shipment;
+			LSPShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), shipment.getFrom());
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -338,11 +338,11 @@ public class MainRunLSPSchedulingTest {
 			}
 			assertTrue(handledByTranshipmentHub);
 
-			assertFalse(element.getOutgoingShipments().getShipments().contains(shipment));
-			assertFalse(element.getIncomingShipments().getShipments().contains(shipment));
+			assertFalse(element.getOutgoingShipments().getLspShipmentsWTime().contains(shipment));
+			assertFalse(element.getIncomingShipments().getLspShipmentsWTime().contains(shipment));
 		}
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertEquals(4, shipment.getSimulationTrackers().size());
 			eventHandlers = new ArrayList<>(shipment.getSimulationTrackers());
 			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
@@ -421,13 +421,13 @@ public class MainRunLSPSchedulingTest {
 		}
 
 		for (LogisticChain solution : lsp.getSelectedPlan().getLogisticChains()) {
-			assertEquals(1, solution.getShipmentIds().size());
+			assertEquals(1, solution.getLspShipmentIds().size());
 			for (LogisticChainElement element : solution.getLogisticChainElements()) {
-				assertTrue(element.getIncomingShipments().getShipments().isEmpty());
+				assertTrue(element.getIncomingShipments().getLspShipmentsWTime().isEmpty());
 				if (element.getNextElement() != null) {
-					assertTrue(element.getOutgoingShipments().getShipments().isEmpty());
+					assertTrue(element.getOutgoingShipments().getLspShipmentsWTime().isEmpty());
 				} else {
-					assertFalse(element.getOutgoingShipments().getShipments().isEmpty());
+					assertFalse(element.getOutgoingShipments().getLspShipmentsWTime().isEmpty());
 				}
 			}
 		}

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCollectionLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCollectionLSPSchedulingTest.java
@@ -152,7 +152,7 @@ public class MultipleShipmentsCollectionLSPSchedulingTest {
 	@Test
 	public void testCollectionLSPScheduling() {
 
-		for (LSPShipment shipment : collectionLSP.getShipments()) {
+		for (LSPShipment shipment : collectionLSP.getLspShipments()) {
 			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
 
@@ -163,7 +163,7 @@ public class MultipleShipmentsCollectionLSPSchedulingTest {
 			System.out.println();
 		}
 
-		for (LSPShipment shipment : collectionLSP.getShipments()) {
+		for (LSPShipment shipment : collectionLSP.getLspShipments()) {
 			assertEquals(3, ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().size());
 			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 			assertEquals("UNLOAD", planElements.get(2).getElementType());
@@ -223,11 +223,11 @@ public class MultipleShipmentsCollectionLSPSchedulingTest {
 
 		for (LogisticChain solution : collectionLSP.getSelectedPlan().getLogisticChains()) {
 			for (LogisticChainElement element : solution.getLogisticChainElements()) {
-				assertTrue(element.getIncomingShipments().getShipments().isEmpty());
+				assertTrue(element.getIncomingShipments().getLspShipmentsWTime().isEmpty());
 				if (element.getNextElement() != null) {
-					assertTrue(element.getOutgoingShipments().getShipments().isEmpty());
+					assertTrue(element.getOutgoingShipments().getLspShipmentsWTime().isEmpty());
 				} else {
-					assertFalse(element.getOutgoingShipments().getShipments().isEmpty());
+					assertFalse(element.getOutgoingShipments().getLspShipmentsWTime().isEmpty());
 				}
 			}
 		}

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
@@ -291,7 +291,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 	@Test
 	public void testCompletedLSPScheduling() {
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			ArrayList<ShipmentPlanElement> elementList = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 			elementList.sort(ShipmentUtils.createShipmentPlanElementComparator());
 			System.out.println();
@@ -304,7 +304,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 		ArrayList<LogisticChainElement> solutionElements = new ArrayList<>(lsp.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements());
 		ArrayList<LSPResource> resources = new ArrayList<>(lsp.getResources());
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertEquals(11, ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
 			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 			planElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
@@ -438,7 +438,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 		while (iter.hasNext()) {
 			Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry = iter.next();
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().shipment;
+			LSPShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), shipment.getFrom());
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -452,8 +452,8 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			}
 			assertTrue(handledByTranshipmentHub);
 
-			assertFalse(element.getOutgoingShipments().getShipments().contains(shipment));
-			assertFalse(element.getIncomingShipments().getShipments().contains(shipment));
+			assertFalse(element.getOutgoingShipments().getLspShipmentsWTime().contains(shipment));
+			assertFalse(element.getIncomingShipments().getLspShipmentsWTime().contains(shipment));
 		}
 
 		assertEquals(1, secondTranshipmentHubResource.getSimulationTrackers().size());
@@ -465,7 +465,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 		while (iter.hasNext()) {
 			Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry = iter.next();
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().shipment;
+			LSPShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), toLinkId);
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -479,11 +479,11 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			}
 			assertTrue(handledByTranshipmentHub);
 
-			assertFalse(element.getOutgoingShipments().getShipments().contains(shipment));
-			assertFalse(element.getIncomingShipments().getShipments().contains(shipment));
+			assertFalse(element.getOutgoingShipments().getLspShipmentsWTime().contains(shipment));
+			assertFalse(element.getIncomingShipments().getLspShipmentsWTime().contains(shipment));
 		}
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertEquals(6, shipment.getSimulationTrackers().size());
 			eventHandlers = new ArrayList<>(shipment.getSimulationTrackers());
 			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
@@ -598,11 +598,11 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 
 		for (LogisticChain solution : lsp.getSelectedPlan().getLogisticChains()) {
 			for (LogisticChainElement element : solution.getLogisticChainElements()) {
-				assertTrue(element.getIncomingShipments().getShipments().isEmpty());
+				assertTrue(element.getIncomingShipments().getLspShipmentsWTime().isEmpty());
 				if (element.getNextElement() != null) {
-					assertTrue(element.getOutgoingShipments().getShipments().isEmpty());
+					assertTrue(element.getOutgoingShipments().getLspShipmentsWTime().isEmpty());
 				} else {
-					assertFalse(element.getOutgoingShipments().getShipments().isEmpty());
+					assertFalse(element.getOutgoingShipments().getLspShipmentsWTime().isEmpty());
 				}
 			}
 		}

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsFirstReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsFirstReloadLSPSchedulingTest.java
@@ -189,7 +189,7 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 	@Test
 	public void testFirstReloadLSPScheduling() {
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
 
@@ -201,7 +201,7 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 		}
 
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertEquals(4, ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
 			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 			planElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
@@ -256,7 +256,7 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 
 		for (Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry : reloadEventHandler.getServicesWaitedFor().entrySet()) {
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().shipment;
+			LSPShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), shipment.getFrom());
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -270,12 +270,12 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 			}
 			assertTrue(handledByTranshipmentHub);
 			//This asserts that the shipments waiting for handling have been handled and the queues have been cleared
-			assertFalse(element.getOutgoingShipments().getShipments().contains(shipment));
-			assertFalse(element.getIncomingShipments().getShipments().contains(shipment));
+			assertFalse(element.getOutgoingShipments().getLspShipmentsWTime().contains(shipment));
+			assertFalse(element.getIncomingShipments().getLspShipmentsWTime().contains(shipment));
 		}
 
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertEquals(2, shipment.getSimulationTrackers().size());
 			eventHandlers = new ArrayList<>(shipment.getSimulationTrackers());
 			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
@@ -307,11 +307,11 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 
 		for (LogisticChain solution : lsp.getSelectedPlan().getLogisticChains()) {
 			for (LogisticChainElement element : solution.getLogisticChainElements()) {
-				assertTrue(element.getIncomingShipments().getShipments().isEmpty());
+				assertTrue(element.getIncomingShipments().getLspShipmentsWTime().isEmpty());
 				if (element.getNextElement() != null) {
-					assertTrue(element.getOutgoingShipments().getShipments().isEmpty());
+					assertTrue(element.getOutgoingShipments().getLspShipmentsWTime().isEmpty());
 				} else {
-					assertFalse(element.getOutgoingShipments().getShipments().isEmpty());
+					assertFalse(element.getOutgoingShipments().getLspShipmentsWTime().isEmpty());
 				}
 			}
 		}

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsMainRunLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsMainRunLSPSchedulingTest.java
@@ -237,7 +237,7 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 		}*/
 
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertEquals(7, ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
 			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 			planElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
@@ -324,7 +324,7 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 
 		for (Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry : reloadEventHandler.getServicesWaitedFor().entrySet()) {
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().shipment;
+			LSPShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), shipment.getFrom());
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -338,11 +338,11 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 			}
 			assertTrue(handledByTranshipmentHub);
 
-			assertFalse(element.getOutgoingShipments().getShipments().contains(shipment));
-			assertFalse(element.getIncomingShipments().getShipments().contains(shipment));
+			assertFalse(element.getOutgoingShipments().getLspShipmentsWTime().contains(shipment));
+			assertFalse(element.getIncomingShipments().getLspShipmentsWTime().contains(shipment));
 		}
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertEquals(4, shipment.getSimulationTrackers().size());
 			eventHandlers = new ArrayList<>(shipment.getSimulationTrackers());
 			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
@@ -422,11 +422,11 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 
 		for (LogisticChain solution : lsp.getSelectedPlan().getLogisticChains()) {
 			for (LogisticChainElement element : solution.getLogisticChainElements()) {
-				assertTrue(element.getIncomingShipments().getShipments().isEmpty());
+				assertTrue(element.getIncomingShipments().getLspShipmentsWTime().isEmpty());
 				if (element.getNextElement() != null) {
-					assertTrue(element.getOutgoingShipments().getShipments().isEmpty());
+					assertTrue(element.getOutgoingShipments().getLspShipmentsWTime().isEmpty());
 				} else {
-					assertFalse(element.getOutgoingShipments().getShipments().isEmpty());
+					assertFalse(element.getOutgoingShipments().getLspShipmentsWTime().isEmpty());
 				}
 			}
 		}

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsSecondReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsSecondReloadLSPSchedulingTest.java
@@ -264,7 +264,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			System.out.println();
 		}*/
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertEquals(8, ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
 			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 			planElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
@@ -365,7 +365,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 		while (iter.hasNext()) {
 			Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry = iter.next();
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().shipment;
+			LSPShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), shipment.getFrom());
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -379,8 +379,8 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			}
 			assertTrue(handledByTranshipmentHub);
 
-			assertFalse(element.getOutgoingShipments().getShipments().contains(shipment));
-			assertFalse(element.getIncomingShipments().getShipments().contains(shipment));
+			assertFalse(element.getOutgoingShipments().getLspShipmentsWTime().contains(shipment));
+			assertFalse(element.getIncomingShipments().getLspShipmentsWTime().contains(shipment));
 		}
 
 		assertEquals(1, secondTranshipmentHubResource.getSimulationTrackers().size());
@@ -392,7 +392,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 		while (iter.hasNext()) {
 			Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry = iter.next();
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().shipment;
+			LSPShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), toLinkId);
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -406,11 +406,11 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			}
 			assertTrue(handledByTranshipmentHub);
 
-			assertFalse(element.getOutgoingShipments().getShipments().contains(shipment));
-			assertFalse(element.getIncomingShipments().getShipments().contains(shipment));
+			assertFalse(element.getOutgoingShipments().getLspShipmentsWTime().contains(shipment));
+			assertFalse(element.getIncomingShipments().getLspShipmentsWTime().contains(shipment));
 		}
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertEquals(4, shipment.getSimulationTrackers().size());
 			eventHandlers = new ArrayList<>(shipment.getSimulationTrackers());
 			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
@@ -491,11 +491,11 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 
 		for (LogisticChain solution : lsp.getSelectedPlan().getLogisticChains()) {
 			for (LogisticChainElement element : solution.getLogisticChainElements()) {
-				assertTrue(element.getIncomingShipments().getShipments().isEmpty());
+				assertTrue(element.getIncomingShipments().getLspShipmentsWTime().isEmpty());
 				if (element.getNextElement() != null) {
-					assertTrue(element.getOutgoingShipments().getShipments().isEmpty());
+					assertTrue(element.getOutgoingShipments().getLspShipmentsWTime().isEmpty());
 				} else {
-					assertFalse(element.getOutgoingShipments().getShipments().isEmpty());
+					assertFalse(element.getOutgoingShipments().getLspShipmentsWTime().isEmpty());
 				}
 			}
 		}

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/SecondReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/SecondReloadLSPSchedulingTest.java
@@ -254,7 +254,7 @@ public class SecondReloadLSPSchedulingTest {
 	@Test
 	public void testSecondReloadLSPScheduling() {
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			ArrayList<ShipmentPlanElement> elementList = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 			elementList.sort(ShipmentUtils.createShipmentPlanElementComparator());
 			System.out.println();
@@ -264,7 +264,7 @@ public class SecondReloadLSPSchedulingTest {
 			System.out.println();
 		}
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertEquals(8, ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
 			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 			planElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
@@ -365,7 +365,7 @@ public class SecondReloadLSPSchedulingTest {
 		while (iter.hasNext()) {
 			Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry = iter.next();
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().shipment;
+			LSPShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), shipment.getFrom());
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -379,8 +379,8 @@ public class SecondReloadLSPSchedulingTest {
 			}
 			assertTrue(handledByTranshipmentHub);
 
-			assertFalse(element.getOutgoingShipments().getShipments().contains(shipment));
-			assertFalse(element.getIncomingShipments().getShipments().contains(shipment));
+			assertFalse(element.getOutgoingShipments().getLspShipmentsWTime().contains(shipment));
+			assertFalse(element.getIncomingShipments().getLspShipmentsWTime().contains(shipment));
 		}
 
 		assertEquals(1, secondTranshipmentHubResource.getSimulationTrackers().size());
@@ -392,7 +392,7 @@ public class SecondReloadLSPSchedulingTest {
 		while (iter.hasNext()) {
 			Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry = iter.next();
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().shipment;
+			LSPShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), toLinkId);
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -406,11 +406,11 @@ public class SecondReloadLSPSchedulingTest {
 			}
 			assertTrue(handledByTranshipmentHub);
 
-			assertFalse(element.getOutgoingShipments().getShipments().contains(shipment));
-			assertFalse(element.getIncomingShipments().getShipments().contains(shipment));
+			assertFalse(element.getOutgoingShipments().getLspShipmentsWTime().contains(shipment));
+			assertFalse(element.getIncomingShipments().getLspShipmentsWTime().contains(shipment));
 		}
 
-		for (LSPShipment shipment : lsp.getShipments()) {
+		for (LSPShipment shipment : lsp.getLspShipments()) {
 			assertEquals(4, shipment.getSimulationTrackers().size());
 			eventHandlers = new ArrayList<>(shipment.getSimulationTrackers());
 			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
@@ -491,11 +491,11 @@ public class SecondReloadLSPSchedulingTest {
 
 		for (LogisticChain solution : lsp.getSelectedPlan().getLogisticChains()) {
 			for (LogisticChainElement element : solution.getLogisticChainElements()) {
-				assertTrue(element.getIncomingShipments().getShipments().isEmpty());
+				assertTrue(element.getIncomingShipments().getLspShipmentsWTime().isEmpty());
 				if (element.getNextElement() != null) {
-					assertTrue(element.getOutgoingShipments().getShipments().isEmpty());
+					assertTrue(element.getOutgoingShipments().getLspShipmentsWTime().isEmpty());
 				} else {
-					assertFalse(element.getOutgoingShipments().getShipments().isEmpty());
+					assertFalse(element.getOutgoingShipments().getLspShipmentsWTime().isEmpty());
 				}
 			}
 		}


### PR DESCRIPTION
`shipment`(s) ->` **lsp**Shipment`(s)  -->avoid confusion with `CarrierShipment` (see also #45)
service -> carrierService --> show that it is on the `Carrier`s level