### PR TITLE
make the scenario available

### DIFF
--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfInitialPlan.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfInitialPlan.java
@@ -44,7 +44,7 @@ import org.matsim.vehicles.VehicleType;
 
 /*package-private*/ class ExampleSchedulingOfInitialPlan {
 
-  private static LSP createInitialLSP(Network network) {
+  private static LSP createInitialLSP(Scenario scenario) {
 
     // The Carrier for the resource of the sole LogisticsSolutionElement of the LSP is created
     Id<Carrier> carrierId = Id.create("CollectionCarrier", Carrier.class);
@@ -73,9 +73,10 @@ import org.matsim.vehicles.VehicleType;
 
     // The Resource i.e. the Resource is created
     LSPResource collectionResource =
-        ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network)
+        ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(
+                carrier, scenario.getNetwork())
             .setCollectionScheduler(
-                ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+                ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
             .setLocationLinkId(collectionLinkId)
             .build();
 
@@ -161,7 +162,7 @@ import org.matsim.vehicles.VehicleType;
     Network network = scenario.getNetwork();
 
     // Create LSP and lspShipments
-    LSP lsp = createInitialLSP(network);
+    LSP lsp = createInitialLSP(scenario);
     Collection<LSPShipment> lspShipments = createInitialLSPShipments(network);
 
     // assign the lspShipments to the LSP

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfInitialPlan.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfInitialPlan.java
@@ -74,7 +74,7 @@ import org.matsim.vehicles.VehicleType;
     // The Resource i.e. the Resource is created
     LSPResource collectionResource =
         ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(
-                carrier, scenario.getNetwork())
+                carrier)
             .setCollectionScheduler(
                 ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
             .setLocationLinkId(collectionLinkId)

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChain.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChain.java
@@ -84,7 +84,7 @@ import org.matsim.vehicles.VehicleType;
         ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(
                 collectionCarrier, network)
             .setCollectionScheduler(
-                ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+                ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
             .setLocationLinkId(collectionLinkId)
             .build();
 
@@ -222,7 +222,7 @@ import org.matsim.vehicles.VehicleType;
 
     // The scheduler for the Resource is created and added. This is where jsprit comes into play.
     distributionResourceBuilder.setDistributionScheduler(
-        ResourceImplementationUtils.createDefaultDistributionCarrierScheduler());
+        ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario));
     LSPResource distributionResource = distributionResourceBuilder.build();
 
     // The adapter is now inserted into the corresponding LogisticsSolutionElement of the only

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChain.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChain.java
@@ -217,7 +217,7 @@ import org.matsim.vehicles.VehicleType;
     // The distribution adapter i.e. the Resource is created
     DistributionCarrierResourceBuilder distributionResourceBuilder =
         ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-            distributionCarrier, network);
+            distributionCarrier);
     distributionResourceBuilder.setLocationLinkId(distributionLinkId);
 
     // The scheduler for the Resource is created and added. This is where jsprit comes into play.

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChain.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChain.java
@@ -82,7 +82,7 @@ import org.matsim.vehicles.VehicleType;
     // The collection adapter i.e. the Resource is created
     LSPResource collectionResource =
         ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(
-                collectionCarrier, network)
+                collectionCarrier)
             .setCollectionScheduler(
                 ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
             .setLocationLinkId(collectionLinkId)

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChain.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChain.java
@@ -152,7 +152,7 @@ import org.matsim.vehicles.VehicleType;
         ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
             .setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
             .setToLinkId(Id.createLinkId("(14 2) (14 3)"))
-            .setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+            .setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
             .build();
 
     // The LogisticsSolutionElement for the main run Resource is created

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChain.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChain.java
@@ -149,7 +149,7 @@ import org.matsim.vehicles.VehicleType;
 
     // The adapter i.e. the main run resource is created
     LSPResource mainRunResource =
-        ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+        ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
             .setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
             .setToLinkId(Id.createLinkId("(14 2) (14 3)"))
             .setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirect.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirect.java
@@ -263,7 +263,7 @@ import org.matsim.vehicles.VehicleType;
 
       // The scheduler for the main run Resource is created and added to the Resource
       LSPResource mainRunResource =
-          ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+          ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
               .setFromLinkId(depotLinkId)
               .setToLinkId(hubLinkId)
               .setMainRunCarrierScheduler(

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirect.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirect.java
@@ -331,7 +331,7 @@ import org.matsim.vehicles.VehicleType;
                   distributionCarrier, network)
               .setLocationLinkId(hubLinkId)
               .setDistributionScheduler(
-                  ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                  ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
               .build();
       // (The scheduler is where jsprit comes into play.)
 
@@ -374,7 +374,7 @@ import org.matsim.vehicles.VehicleType;
                   directDistributionCarrier, network)
               .setLocationLinkId(depotLinkId)
               .setDistributionScheduler(
-                  ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                  ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
               .build();
       // (The scheduler is where jsprit comes into play.)
 

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirect.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirect.java
@@ -267,7 +267,7 @@ import org.matsim.vehicles.VehicleType;
               .setFromLinkId(depotLinkId)
               .setToLinkId(hubLinkId)
               .setMainRunCarrierScheduler(
-                  ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+                  ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
               .build();
 
       mainRunElement =

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirect.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirect.java
@@ -328,7 +328,7 @@ import org.matsim.vehicles.VehicleType;
       // The distribution adapter i.e. the Resource is created
       LSPResource distributionResource =
           ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                  distributionCarrier, network)
+                  distributionCarrier)
               .setLocationLinkId(hubLinkId)
               .setDistributionScheduler(
                   ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
@@ -371,7 +371,7 @@ import org.matsim.vehicles.VehicleType;
       // The distribution adapter i.e. the Resource is created
       LSPResource directDistributionResource =
           ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                  directDistributionCarrier, network)
+                  directDistributionCarrier)
               .setLocationLinkId(depotLinkId)
               .setDistributionScheduler(
                   ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid.java
@@ -286,7 +286,7 @@ final class ExampleTwoEchelonGrid {
           CarrierVehicle.newInstance(
               Id.createVehicleId("mainTruck"), DEPOT_LINK_ID, VEH_TYPE_LARGE_50));
       LSPResource mainCarrierRessource =
-          ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainCarrier, network)
+          ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainCarrier)
               .setFromLinkId(DEPOT_LINK_ID)
               .setMainRunCarrierScheduler(
                   ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid.java
@@ -289,7 +289,7 @@ final class ExampleTwoEchelonGrid {
           ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainCarrier, network)
               .setFromLinkId(DEPOT_LINK_ID)
               .setMainRunCarrierScheduler(
-                  ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+                  ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
               .setToLinkId(HUB_LINK_ID)
               .setVehicleReturn(ResourceImplementationUtils.VehicleReturn.returnToFromLink)
               .build();

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid.java
@@ -249,7 +249,7 @@ final class ExampleTwoEchelonGrid {
               Id.createVehicleId("directTruck"), DEPOT_LINK_ID, VEH_TYPE_LARGE_50));
       LSPResource directCarrierRessource =
           ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                  directCarrier, network)
+                  directCarrier)
               .setDistributionScheduler(
                   ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
               .build();
@@ -342,7 +342,7 @@ final class ExampleTwoEchelonGrid {
               Id.createVehicleId("distributionTruck"), HUB_LINK_ID, vehType));
       LSPResource distributionCarrierRessource =
           ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                  distributionCarrier, network)
+                  distributionCarrier)
               .setDistributionScheduler(
                   ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
               .build();

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid.java
@@ -251,7 +251,7 @@ final class ExampleTwoEchelonGrid {
           ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
                   directCarrier, network)
               .setDistributionScheduler(
-                  ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                  ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
               .build();
 
       LogisticChainElement directCarrierElement =
@@ -344,7 +344,7 @@ final class ExampleTwoEchelonGrid {
           ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
                   distributionCarrier, network)
               .setDistributionScheduler(
-                  ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                  ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
               .build();
 
       LogisticChainElement distributionCarrierElement =

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid_NR.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid_NR.java
@@ -299,7 +299,7 @@ final class ExampleTwoEchelonGrid_NR {
           ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainCarrier, network)
               .setFromLinkId(DEPOT_LINK_ID)
               .setMainRunCarrierScheduler(
-                  ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+                  ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
               .setToLinkId(HUB_LINK_ID)
               .setVehicleReturn(ResourceImplementationUtils.VehicleReturn.returnToFromLink)
               .build();

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid_NR.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid_NR.java
@@ -296,7 +296,7 @@ final class ExampleTwoEchelonGrid_NR {
           CarrierVehicle.newInstance(
               Id.createVehicleId("mainTruck"), DEPOT_LINK_ID, VEH_TYPE_LARGE_50));
       LSPResource mainCarrierRessource =
-          ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainCarrier, network)
+          ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainCarrier)
               .setFromLinkId(DEPOT_LINK_ID)
               .setMainRunCarrierScheduler(
                   ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid_NR.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid_NR.java
@@ -261,7 +261,7 @@ final class ExampleTwoEchelonGrid_NR {
           ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
                   directCarrier, network)
               .setDistributionScheduler(
-                  ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                  ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
               .build();
 
       LogisticChainElement directCarrierElement =
@@ -354,7 +354,7 @@ final class ExampleTwoEchelonGrid_NR {
           ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
                   distributionCarrier, network)
               .setDistributionScheduler(
-                  ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                  ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
               .build();
 
       LogisticChainElement distributionCarrierElement =

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid_NR.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid_NR.java
@@ -259,7 +259,7 @@ final class ExampleTwoEchelonGrid_NR {
               Id.createVehicleId("directTruck"), DEPOT_LINK_ID, VEH_TYPE_LARGE_50));
       LSPResource directCarrierRessource =
           ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                  directCarrier, network)
+                  directCarrier)
               .setDistributionScheduler(
                   ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
               .build();
@@ -352,7 +352,7 @@ final class ExampleTwoEchelonGrid_NR {
               Id.createVehicleId("distributionTruck"), HUB_LINK_ID, vehType));
       LSPResource distributionCarrierRessource =
           ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                  distributionCarrier, network)
+                  distributionCarrier)
               .setDistributionScheduler(
                   ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
               .build();

--- a/src/main/java/org/matsim/freight/logistics/examples/lspScoring/ExampleLSPScoring.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/lspScoring/ExampleLSPScoring.java
@@ -54,7 +54,7 @@ import org.matsim.vehicles.VehicleType;
 
   private ExampleLSPScoring() {}
 
-  private static LSP createLSPWithScorer(Network network) {
+  private static LSP createLSPWithScorer(Scenario scenario) {
 
     // The Carrier for the resource of the sole LogisticsSolutionElement of the LSP is created
     var carrierVehicleType =
@@ -84,9 +84,10 @@ import org.matsim.vehicles.VehicleType;
     // The Resource i.e. the Resource is created
     // The scheduler for the Resource is created and added. This is where jsprit comes into play.
     LSPResource lspResource =
-        ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network)
+        ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(
+                carrier, scenario.getNetwork())
             .setCollectionScheduler(
-                ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+                ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
             .setLocationLinkId(collectionLinkId)
             .build();
 
@@ -198,7 +199,7 @@ import org.matsim.vehicles.VehicleType;
     Scenario scenario = ScenarioUtils.loadScenario(config);
 
     // Create LSP and lspShipments
-    LSP lsp = createLSPWithScorer(scenario.getNetwork());
+    LSP lsp = createLSPWithScorer(scenario);
     Collection<LSPShipment> lspShipments = createInitialLSPShipments(scenario.getNetwork());
 
     // assign the lspShipments to the LSP

--- a/src/main/java/org/matsim/freight/logistics/examples/lspScoring/ExampleLSPScoring.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/lspScoring/ExampleLSPScoring.java
@@ -85,7 +85,7 @@ import org.matsim.vehicles.VehicleType;
     // The scheduler for the Resource is created and added. This is where jsprit comes into play.
     LSPResource lspResource =
         ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(
-                carrier, scenario.getNetwork())
+                carrier)
             .setCollectionScheduler(
                 ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
             .setLocationLinkId(collectionLinkId)

--- a/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfSimpleLSP.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfSimpleLSP.java
@@ -67,9 +67,8 @@ import org.matsim.vehicles.VehicleType;
         .readFile("scenarios/2regions/2regions-network.xml");
 
     // Create LSP and lspShipments
-    Network network = scenario.getNetwork();
-    LSP lsp = createInitialLSP(network);
-    Collection<LSPShipment> lspShipments = createInitialLSPShipments(network);
+    LSP lsp = createInitialLSP(scenario);
+    Collection<LSPShipment> lspShipments = createInitialLSPShipments(scenario.getNetwork());
 
     // assign the lspShipments to the LSP
     for (LSPShipment lspShipment : lspShipments) {
@@ -153,7 +152,7 @@ import org.matsim.vehicles.VehicleType;
     }
   }
 
-  private static LSP createInitialLSP(Network network) {
+  private static LSP createInitialLSP(Scenario scenario) {
 
     // The Carrier for the resource of the sole LogisticsSolutionElement of the LSP is created
     Id<Carrier> carrierId = Id.create("CollectionCarrier", Carrier.class);
@@ -182,9 +181,9 @@ import org.matsim.vehicles.VehicleType;
 
     // The Resource i.e. the Resource is created
     LSPResource collectionResource =
-        ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network)
+        ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, scenario.getNetwork())
             .setCollectionScheduler(
-                ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+                ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
             .setLocationLinkId(collectionLinkId)
             .build();
 

--- a/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfSimpleLSP.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfSimpleLSP.java
@@ -181,7 +181,7 @@ import org.matsim.vehicles.VehicleType;
 
     // The Resource i.e. the Resource is created
     LSPResource collectionResource =
-        ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, scenario.getNetwork())
+        ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier)
             .setCollectionScheduler(
                 ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
             .setLocationLinkId(collectionLinkId)

--- a/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfTransportChain.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfTransportChain.java
@@ -219,7 +219,7 @@ import org.matsim.vehicles.VehicleType;
     // The distribution adapter i.e. the Resource is created
     LSPResource distributionResource =
         ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                distributionCarrier, network)
+                distributionCarrier)
             .setLocationLinkId(distributionLinkId)
             // The scheduler for the Resource is created and added. This is where jsprit comes into
             // play.

--- a/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfTransportChain.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfTransportChain.java
@@ -150,7 +150,7 @@ import org.matsim.vehicles.VehicleType;
 
     // The adapter i.e. the main run resource is created
     LSPResource mainRunResource =
-        ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+        ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
             .setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
             .setToLinkId(Id.createLinkId("(14 2) (14 3)"))
             .setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))

--- a/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfTransportChain.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfTransportChain.java
@@ -82,7 +82,7 @@ import org.matsim.vehicles.VehicleType;
     // The collection adapter i.e. the Resource is created
     LSPResource collectionResource =
         ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(
-                collectionCarrier, network)
+                collectionCarrier)
             .setCollectionScheduler(
                 ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
             .setLocationLinkId(collectionLinkId)

--- a/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfTransportChain.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfTransportChain.java
@@ -84,7 +84,7 @@ import org.matsim.vehicles.VehicleType;
         ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(
                 collectionCarrier, network)
             .setCollectionScheduler(
-                ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+                ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
             .setLocationLinkId(collectionLinkId)
             .build();
 
@@ -224,7 +224,7 @@ import org.matsim.vehicles.VehicleType;
             // The scheduler for the Resource is created and added. This is where jsprit comes into
             // play.
             .setDistributionScheduler(
-                ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
             .build();
 
     // The adapter is now inserted into the corresponding LogisticsSolutionElement of the only

--- a/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfTransportChain.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfTransportChain.java
@@ -153,7 +153,7 @@ import org.matsim.vehicles.VehicleType;
         ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
             .setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
             .setToLinkId(Id.createLinkId("(14 2) (14 3)"))
-            .setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+            .setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
             .build();
 
     // The LogisticsSolutionElement for the main run Resource is created

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleGroceryDeliveryMultipleChains.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleGroceryDeliveryMultipleChains.java
@@ -200,7 +200,7 @@ final class ExampleGroceryDeliveryMultipleChains {
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
                     singleCarrier, scenario.getNetwork())
                 .setDistributionScheduler(
-                    ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                    ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                 .build();
 
         LogisticChainElement singleCarrierElement =
@@ -280,7 +280,7 @@ final class ExampleGroceryDeliveryMultipleChains {
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
                     distributionCarrier, scenario.getNetwork())
                 .setDistributionScheduler(
-                    ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                    ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                 .build();
 
         LogisticChainElement distributionCarrierElement =

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleGroceryDeliveryMultipleChains.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleGroceryDeliveryMultipleChains.java
@@ -231,7 +231,7 @@ final class ExampleGroceryDeliveryMultipleChains {
                     mainCarrier, scenario.getNetwork())
                 .setFromLinkId(depotLinkFromVehicles)
                 .setMainRunCarrierScheduler(
-                    ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+                    ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
                 .setToLinkId(HUB_LINK_ID)
                 .setVehicleReturn(ResourceImplementationUtils.VehicleReturn.returnToFromLink)
                 .build();

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleGroceryDeliveryMultipleChains.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleGroceryDeliveryMultipleChains.java
@@ -228,7 +228,7 @@ final class ExampleGroceryDeliveryMultipleChains {
                 vehicleTypes.getVehicleTypes().get(Id.create("heavy40t", VehicleType.class))));
         LSPResource mainCarrierResource =
             ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(
-                    mainCarrier, scenario.getNetwork())
+                    mainCarrier)
                 .setFromLinkId(depotLinkFromVehicles)
                 .setMainRunCarrierScheduler(
                     ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleGroceryDeliveryMultipleChains.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleGroceryDeliveryMultipleChains.java
@@ -198,7 +198,7 @@ final class ExampleGroceryDeliveryMultipleChains {
                 vehicleTypes.getVehicleTypes().get(Id.create("heavy40t", VehicleType.class))));
         LSPResource singleCarrierResource =
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                    singleCarrier, scenario.getNetwork())
+                    singleCarrier)
                 .setDistributionScheduler(
                     ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                 .build();
@@ -278,7 +278,7 @@ final class ExampleGroceryDeliveryMultipleChains {
                     .get(Id.create("heavy40t_electro", VehicleType.class))));
         LSPResource distributionCarrierResource =
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                    distributionCarrier, scenario.getNetwork())
+                    distributionCarrier)
                 .setDistributionScheduler(
                     ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                 .build();

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleMixedEchelonChains.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleMixedEchelonChains.java
@@ -199,7 +199,7 @@ final class ExampleMultipleMixedEchelonChains {
                 Id.createVehicleId("mainTruck"), DEPOT_LINK_ID, VEH_TYPE_LARGE_50));
         LSPResource mainCarrierResource1 =
             ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(
-                    mainCarrier1, network)
+                    mainCarrier1)
                 .setFromLinkId(DEPOT_LINK_ID)
                 .setMainRunCarrierScheduler(
                     ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
@@ -316,7 +316,7 @@ final class ExampleMultipleMixedEchelonChains {
                 Id.createVehicleId("mainTruck"), DEPOT_LINK_ID, VEH_TYPE_LARGE_50));
         LSPResource mainCarrierResource =
             ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(
-                    mainCarrier, network)
+                    mainCarrier)
                 .setFromLinkId(DEPOT_LINK_ID)
                 .setMainRunCarrierScheduler(
                     ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleMixedEchelonChains.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleMixedEchelonChains.java
@@ -246,7 +246,7 @@ final class ExampleMultipleMixedEchelonChains {
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
                     distributionCarrier1, network)
                 .setDistributionScheduler(
-                    ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                    ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                 .build();
 
         LogisticChainElement distributionCarrierElement1 =
@@ -290,7 +290,7 @@ final class ExampleMultipleMixedEchelonChains {
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
                     singleCarrier, network)
                 .setDistributionScheduler(
-                    ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                    ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                 .build();
 
         LogisticChainElement singleCarrierElement =
@@ -363,7 +363,7 @@ final class ExampleMultipleMixedEchelonChains {
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
                     distributionCarrier, network)
                 .setDistributionScheduler(
-                    ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                    ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                 .build();
 
         LogisticChainElement distributionCarrierElement =

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleMixedEchelonChains.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleMixedEchelonChains.java
@@ -202,7 +202,7 @@ final class ExampleMultipleMixedEchelonChains {
                     mainCarrier1, network)
                 .setFromLinkId(DEPOT_LINK_ID)
                 .setMainRunCarrierScheduler(
-                    ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+                    ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
                 .setToLinkId(HUB_LINK_ID)
                 .setVehicleReturn(ResourceImplementationUtils.VehicleReturn.returnToFromLink)
                 .build();
@@ -319,7 +319,7 @@ final class ExampleMultipleMixedEchelonChains {
                     mainCarrier, network)
                 .setFromLinkId(DEPOT_LINK_ID)
                 .setMainRunCarrierScheduler(
-                    ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+                    ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
                 .setToLinkId(HUB_LINK_ID)
                 .setVehicleReturn(ResourceImplementationUtils.VehicleReturn.returnToFromLink)
                 .build();

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleMixedEchelonChains.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleMixedEchelonChains.java
@@ -244,7 +244,7 @@ final class ExampleMultipleMixedEchelonChains {
                 Id.createVehicleId("distributionTruck"), HUB_LINK_ID, VEH_TYPE_SMALL_05));
         LSPResource distributionCarrierResource1 =
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                    distributionCarrier1, network)
+                    distributionCarrier1)
                 .setDistributionScheduler(
                     ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                 .build();
@@ -288,7 +288,7 @@ final class ExampleMultipleMixedEchelonChains {
                 Id.createVehicleId("singleCarrier"), DEPOT_LINK_ID, VEH_TYPE_SMALL_05));
         LSPResource singleCarrierResource =
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                    singleCarrier, network)
+                    singleCarrier)
                 .setDistributionScheduler(
                     ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                 .build();
@@ -361,7 +361,7 @@ final class ExampleMultipleMixedEchelonChains {
                 Id.createVehicleId("distributionTruck"), HUB_LINK_ID, VEH_TYPE_SMALL_05));
         LSPResource distributionCarrierResource =
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                    distributionCarrier, network)
+                    distributionCarrier)
                 .setDistributionScheduler(
                     ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                 .build();

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChains.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChains.java
@@ -198,7 +198,7 @@ final class ExampleMultipleOneEchelonChains {
           ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
                   singleCarrier, network)
               .setDistributionScheduler(
-                  ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                  ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
               .build();
 
       LogisticChainElement singleCarrierElement =
@@ -237,7 +237,7 @@ final class ExampleMultipleOneEchelonChains {
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
                     carrierLeft, network)
                 .setDistributionScheduler(
-                    ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                    ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                 .build();
 
         leftCarrierElement =
@@ -261,7 +261,7 @@ final class ExampleMultipleOneEchelonChains {
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
                     carrierRight, network)
                 .setDistributionScheduler(
-                    ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                    ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                 .build();
 
         rightCarrierElement =

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChains.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChains.java
@@ -196,7 +196,7 @@ final class ExampleMultipleOneEchelonChains {
               Id.createVehicleId("veh_large"), DEPOT_LINK_ID, VEH_TYPE_LARGE_50));
       LSPResource singleCarrierResource =
           ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                  singleCarrier, network)
+                  singleCarrier)
               .setDistributionScheduler(
                   ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
               .build();
@@ -235,7 +235,7 @@ final class ExampleMultipleOneEchelonChains {
                 Id.createVehicleId("veh_small"), DEPOT_LINK_ID, VEH_TYPE_SMALL_05));
         LSPResource carrierLeftResource =
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                    carrierLeft, network)
+                    carrierLeft)
                 .setDistributionScheduler(
                     ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                 .build();
@@ -259,7 +259,7 @@ final class ExampleMultipleOneEchelonChains {
                 Id.createVehicleId("veh_small"), DEPOT_LINK_ID, VEH_TYPE_SMALL_05));
         LSPResource carrierRightResource =
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                    carrierRight, network)
+                    carrierRight)
                 .setDistributionScheduler(
                     ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                 .build();

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChainsReplanning.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChainsReplanning.java
@@ -216,7 +216,7 @@ final class ExampleMultipleOneEchelonChainsReplanning {
           ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
                   singleCarrier, network)
               .setDistributionScheduler(
-                  ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                  ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
               .build();
 
       LogisticChainElement singleCarrierElement =
@@ -258,7 +258,7 @@ final class ExampleMultipleOneEchelonChainsReplanning {
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
                     carrierLeft, network)
                 .setDistributionScheduler(
-                    ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                    ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                 .build();
 
         leftCarrierElement =
@@ -282,7 +282,7 @@ final class ExampleMultipleOneEchelonChainsReplanning {
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
                     carrierRight, network)
                 .setDistributionScheduler(
-                    ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                    ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                 .build();
 
         rightCarrierElement =

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChainsReplanning.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChainsReplanning.java
@@ -214,7 +214,7 @@ final class ExampleMultipleOneEchelonChainsReplanning {
               Id.createVehicleId("veh_large"), DEPOT_LINK_ID, VEH_TYPE_LARGE_50));
       LSPResource singleCarrierResource =
           ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                  singleCarrier, network)
+                  singleCarrier)
               .setDistributionScheduler(
                   ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
               .build();
@@ -256,7 +256,7 @@ final class ExampleMultipleOneEchelonChainsReplanning {
                 Id.createVehicleId("veh_small"), DEPOT_LINK_ID, VEH_TYPE_SMALL_05));
         LSPResource carrierLeftResource =
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                    carrierLeft, network)
+                    carrierLeft)
                 .setDistributionScheduler(
                     ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                 .build();
@@ -280,7 +280,7 @@ final class ExampleMultipleOneEchelonChainsReplanning {
                 Id.createVehicleId("veh_small"), DEPOT_LINK_ID, VEH_TYPE_SMALL_05));
         LSPResource carrierRightResource =
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                    carrierRight, network)
+                    carrierRight)
                 .setDistributionScheduler(
                     ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                 .build();

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleTwoEchelonChainsReplanning.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleTwoEchelonChainsReplanning.java
@@ -203,7 +203,7 @@ final class ExampleMultipleTwoEchelonChainsReplanning {
             CarrierVehicle.newInstance(
                 Id.createVehicleId("mainTruck"), DEPOT_LINK_ID, VEH_TYPE_LARGE_50));
         LSPResource mainCarrierResourceLeft =
-            ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainCarrierLeft, network)
+            ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainCarrierLeft)
                 .setFromLinkId(DEPOT_LINK_ID)
                 .setMainRunCarrierScheduler(
                     ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
@@ -281,7 +281,7 @@ final class ExampleMultipleTwoEchelonChainsReplanning {
             CarrierVehicle.newInstance(
                 Id.createVehicleId("mainTruck"), DEPOT_LINK_ID, VEH_TYPE_LARGE_50));
         LSPResource mainCarrierResource =
-            ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainCarrier, network)
+            ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainCarrier)
                 .setFromLinkId(DEPOT_LINK_ID)
                 .setMainRunCarrierScheduler(
                     ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleTwoEchelonChainsReplanning.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleTwoEchelonChainsReplanning.java
@@ -248,7 +248,7 @@ final class ExampleMultipleTwoEchelonChainsReplanning {
                 Id.createVehicleId("distributionTruck"), HUB_LEFT_LINK_ID, VEH_TYPE_SMALL_05));
         LSPResource distributionCarrierResourceLeft =
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                    distributionCarrierLeft, network)
+                    distributionCarrierLeft)
                 .setDistributionScheduler(
                     ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                 .build();
@@ -326,7 +326,7 @@ final class ExampleMultipleTwoEchelonChainsReplanning {
                 Id.createVehicleId("distributionTruck"), HUB_RIGHT_LINK_ID, VEH_TYPE_SMALL_05));
         LSPResource distributionCarrierResource =
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                    distributionCarrier, network)
+                    distributionCarrier)
                 .setDistributionScheduler(
                     ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                 .build();

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleTwoEchelonChainsReplanning.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleTwoEchelonChainsReplanning.java
@@ -206,7 +206,7 @@ final class ExampleMultipleTwoEchelonChainsReplanning {
             ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainCarrierLeft, network)
                 .setFromLinkId(DEPOT_LINK_ID)
                 .setMainRunCarrierScheduler(
-                    ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+                    ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
                 .setToLinkId(HUB_LEFT_LINK_ID)
                 .setVehicleReturn(ResourceImplementationUtils.VehicleReturn.returnToFromLink)
                 .build();
@@ -284,7 +284,7 @@ final class ExampleMultipleTwoEchelonChainsReplanning {
             ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainCarrier, network)
                 .setFromLinkId(DEPOT_LINK_ID)
                 .setMainRunCarrierScheduler(
-                    ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+                    ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
                 .setToLinkId(HUB_RIGHT_LINK_ID)
                 .setVehicleReturn(ResourceImplementationUtils.VehicleReturn.returnToFromLink)
                 .build();

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleTwoEchelonChainsReplanning.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleTwoEchelonChainsReplanning.java
@@ -250,7 +250,7 @@ final class ExampleMultipleTwoEchelonChainsReplanning {
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
                     distributionCarrierLeft, network)
                 .setDistributionScheduler(
-                    ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                    ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                 .build();
 
         LogisticChainElement distributionCarrierElementLeft =
@@ -328,7 +328,7 @@ final class ExampleMultipleTwoEchelonChainsReplanning {
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
                     distributionCarrier, network)
                 .setDistributionScheduler(
-                    ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                    ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                 .build();
 
         LogisticChainElement distributionCarrierElement =

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChains.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChains.java
@@ -289,7 +289,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChains {
                             mainCarrier, scenario.getNetwork())
                     .setFromLinkId(depotLinkFromVehicles)
                     .setMainRunCarrierScheduler(
-                            ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+                            ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
                     .setToLinkId(hubLinkId)
                     .setVehicleReturn(ResourceImplementationUtils.VehicleReturn.returnToFromLink)
                     .build();

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChains.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChains.java
@@ -286,7 +286,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChains {
                     vehicleTypesMainRun.getVehicleTypes().get(Id.create("heavy40t", VehicleType.class))));
     LSPResource mainCarrierResource =
             ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(
-                            mainCarrier, scenario.getNetwork())
+                            mainCarrier)
                     .setFromLinkId(depotLinkFromVehicles)
                     .setMainRunCarrierScheduler(
                             ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChains.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChains.java
@@ -338,7 +338,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChains {
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
                             distributionCarrier, scenario.getNetwork())
                     .setDistributionScheduler(
-                            ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                            ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                     .build();
 
     LogisticChainElement distributionCarrierElement =
@@ -410,7 +410,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChains {
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
                             directCarrier, scenario.getNetwork())
                     .setDistributionScheduler(
-                            ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                            ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                     .build();
 
     LogisticChainElement singleCarrierElement =

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChains.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChains.java
@@ -336,7 +336,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChains {
                             .get(Id.create("heavy40t_electro", VehicleType.class))));
     LSPResource distributionCarrierResource =
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                            distributionCarrier, scenario.getNetwork())
+                            distributionCarrier)
                     .setDistributionScheduler(
                             ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                     .build();
@@ -408,7 +408,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChains {
                     vehicleTypes.getVehicleTypes().get(Id.create("heavy40t", VehicleType.class))));
     LSPResource singleCarrierResource =
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                            directCarrier, scenario.getNetwork())
+                            directCarrier)
                     .setDistributionScheduler(
                             ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                     .build();

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll.java
@@ -364,9 +364,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll {
     LSPResource distributionCarrierResource =
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
                             distributionCarrier, scenario.getNetwork())
-                    .setDistributionScheduler(
-//                            ResourceImplementationUtils.createDefaultDistributionCarrierSchedulerWithRoadPricing(RoadPricingUtils.getRoadPricingScheme(scenario)))
-                              ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
+                    .setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                     .build();
 
     LogisticChainElement distributionCarrierElement =
@@ -438,7 +436,6 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll {
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
                             directCarrier, scenario.getNetwork())
                     .setDistributionScheduler(
-//                            ResourceImplementationUtils.createDefaultDistributionCarrierSchedulerWithRoadPricing(RoadPricingUtils.getRoadPricingScheme(scenario)))
                               ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                     .build();
 

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll.java
@@ -366,7 +366,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll {
                             distributionCarrier, scenario.getNetwork())
                     .setDistributionScheduler(
 //                            ResourceImplementationUtils.createDefaultDistributionCarrierSchedulerWithRoadPricing(RoadPricingUtils.getRoadPricingScheme(scenario)))
-                              ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                              ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                     .build();
 
     LogisticChainElement distributionCarrierElement =
@@ -439,7 +439,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll {
                             directCarrier, scenario.getNetwork())
                     .setDistributionScheduler(
 //                            ResourceImplementationUtils.createDefaultDistributionCarrierSchedulerWithRoadPricing(RoadPricingUtils.getRoadPricingScheme(scenario)))
-                              ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                              ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                     .build();
 
     LogisticChainElement singleCarrierElement =

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll.java
@@ -312,7 +312,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll {
                     vehicleTypesMainRun.getVehicleTypes().get(Id.create("heavy40t", VehicleType.class))));
     LSPResource mainCarrierResource =
             ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(
-                            mainCarrier, scenario.getNetwork())
+                            mainCarrier)
                     .setFromLinkId(depotLinkFromVehicles)
                     .setMainRunCarrierScheduler(
                             ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll.java
@@ -315,7 +315,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll {
                             mainCarrier, scenario.getNetwork())
                     .setFromLinkId(depotLinkFromVehicles)
                     .setMainRunCarrierScheduler(
-                            ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+                            ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
                     .setToLinkId(hubLinkId)
                     .setVehicleReturn(ResourceImplementationUtils.VehicleReturn.returnToFromLink)
                     .build();

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll.java
@@ -363,7 +363,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll {
                             .get(Id.create("heavy40t_electro", VehicleType.class))));
     LSPResource distributionCarrierResource =
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                            distributionCarrier, scenario.getNetwork())
+                            distributionCarrier)
                     .setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                     .build();
 
@@ -434,7 +434,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll {
                     vehicleTypes.getVehicleTypes().get(Id.create("heavy40t", VehicleType.class))));
     LSPResource singleCarrierResource =
             ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                            directCarrier, scenario.getNetwork())
+                            directCarrier)
                     .setDistributionScheduler(
                               ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
                     .build();

--- a/src/main/java/org/matsim/freight/logistics/examples/requirementsChecking/ExampleCheckRequirementsOfAssigner.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/requirementsChecking/ExampleCheckRequirementsOfAssigner.java
@@ -96,7 +96,7 @@ class ExampleCheckRequirementsOfAssigner {
     redCarrier.setCarrierCapabilities(redCapabilities);
 
     LSPResource redResource =
-        ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(redCarrier, network)
+        ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(redCarrier)
             .setCollectionScheduler(
                 ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
             .setLocationLinkId(collectionLinkId)
@@ -132,7 +132,7 @@ class ExampleCheckRequirementsOfAssigner {
     blueCarrier.setCarrierCapabilities(blueCapabilities);
 
     LSPResource blueResource =
-        ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(blueCarrier, network)
+        ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(blueCarrier)
             .setCollectionScheduler(
                 ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
             .setLocationLinkId(collectionLinkId)

--- a/src/main/java/org/matsim/freight/logistics/examples/requirementsChecking/ExampleCheckRequirementsOfAssigner.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/requirementsChecking/ExampleCheckRequirementsOfAssigner.java
@@ -66,7 +66,9 @@ class ExampleCheckRequirementsOfAssigner {
 
   static final String ATTRIBUTE_COLOR = "color";
 
-  public static LSP createLSPWithProperties(Network network) {
+  private static LSP createLSPWithProperties(Scenario scenario) {
+
+    final Network network = scenario.getNetwork();
 
     // Create red LogisticsSolution which has the corresponding info
     final Id<Carrier> redCarrierId = Id.create("RedCarrier", Carrier.class);
@@ -96,7 +98,7 @@ class ExampleCheckRequirementsOfAssigner {
     LSPResource redResource =
         ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(redCarrier, network)
             .setCollectionScheduler(
-                ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+                ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
             .setLocationLinkId(collectionLinkId)
             .build();
 
@@ -132,7 +134,7 @@ class ExampleCheckRequirementsOfAssigner {
     LSPResource blueResource =
         ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(blueCarrier, network)
             .setCollectionScheduler(
-                ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+                ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
             .setLocationLinkId(collectionLinkId)
             .build();
 
@@ -227,7 +229,7 @@ class ExampleCheckRequirementsOfAssigner {
     Network network = scenario.getNetwork();
 
     // Create LSP and lspShipments
-    LSP lsp = createLSPWithProperties(network);
+    LSP lsp = createLSPWithProperties(scenario);
     Collection<LSPShipment> lspShipments = createShipmentsWithRequirements(network);
 
     // assign the lspShipments to the LSP

--- a/src/main/java/org/matsim/freight/logistics/examples/simulationTrackers/ExampleSimulationTrackers.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/simulationTrackers/ExampleSimulationTrackers.java
@@ -80,7 +80,7 @@ import org.matsim.vehicles.VehicleType;
         ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(
                 carrier, scenario.getNetwork())
             .setCollectionScheduler(
-                ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+                ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
             .setLocationLinkId(collectionLinkId)
             .build();
 

--- a/src/main/java/org/matsim/freight/logistics/examples/simulationTrackers/ExampleSimulationTrackers.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/simulationTrackers/ExampleSimulationTrackers.java
@@ -78,7 +78,7 @@ import org.matsim.vehicles.VehicleType;
 
     LSPResource collectionResource =
         ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(
-                carrier, scenario.getNetwork())
+                carrier)
             .setCollectionScheduler(
                 ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
             .setLocationLinkId(collectionLinkId)

--- a/src/main/java/org/matsim/freight/logistics/io/LSPPlanXmlParserV1.java
+++ b/src/main/java/org/matsim/freight/logistics/io/LSPPlanXmlParserV1.java
@@ -320,7 +320,7 @@ class LSPPlanXmlParserV1 extends MatsimXmlParser {
                       ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(null))
                   .build();
           case mainRunCarrier -> lspResource =
-              ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(currentCarrier, null)
+              ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(currentCarrier)
                   .setMainRunCarrierScheduler(
                       ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(null))
                   .build();

--- a/src/main/java/org/matsim/freight/logistics/io/LSPPlanXmlParserV1.java
+++ b/src/main/java/org/matsim/freight/logistics/io/LSPPlanXmlParserV1.java
@@ -317,7 +317,7 @@ class LSPPlanXmlParserV1 extends MatsimXmlParser {
               ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(
                       currentCarrier, null)
                   .setCollectionScheduler(
-                      ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+                      ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(null))
                   .build();
           case mainRunCarrier -> lspResource =
               ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(currentCarrier, null)
@@ -328,7 +328,7 @@ class LSPPlanXmlParserV1 extends MatsimXmlParser {
               ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
                       currentCarrier, null)
                   .setDistributionScheduler(
-                      ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+                      ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(null))
                   .build();
           default -> throw new IllegalStateException(
               "Unexpected value: " + currentCarrier.getAttributes().toString());

--- a/src/main/java/org/matsim/freight/logistics/io/LSPPlanXmlParserV1.java
+++ b/src/main/java/org/matsim/freight/logistics/io/LSPPlanXmlParserV1.java
@@ -326,7 +326,7 @@ class LSPPlanXmlParserV1 extends MatsimXmlParser {
                   .build();
           case distributionCarrier -> lspResource =
               ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(
-                      currentCarrier, null)
+                      currentCarrier)
                   .setDistributionScheduler(
                       ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(null))
                   .build();

--- a/src/main/java/org/matsim/freight/logistics/io/LSPPlanXmlParserV1.java
+++ b/src/main/java/org/matsim/freight/logistics/io/LSPPlanXmlParserV1.java
@@ -322,7 +322,7 @@ class LSPPlanXmlParserV1 extends MatsimXmlParser {
           case mainRunCarrier -> lspResource =
               ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(currentCarrier, null)
                   .setMainRunCarrierScheduler(
-                      ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+                      ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(null))
                   .build();
           case distributionCarrier -> lspResource =
               ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(

--- a/src/main/java/org/matsim/freight/logistics/io/LSPPlanXmlParserV1.java
+++ b/src/main/java/org/matsim/freight/logistics/io/LSPPlanXmlParserV1.java
@@ -315,7 +315,7 @@ class LSPPlanXmlParserV1 extends MatsimXmlParser {
         switch (ResourceImplementationUtils.getCarrierType(currentCarrier)) {
           case collectionCarrier -> lspResource =
               ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(
-                      currentCarrier, null)
+                      currentCarrier)
                   .setCollectionScheduler(
                       ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(null))
                   .build();

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/CarrierSchedulerUtils.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/CarrierSchedulerUtils.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.roadpricing.RoadPricingScheme;
+import org.matsim.contrib.roadpricing.RoadPricingUtils;
 import org.matsim.freight.carriers.Carrier;
 import org.matsim.freight.carriers.CarrierPlan;
 import org.matsim.freight.carriers.CarriersUtils;
@@ -30,36 +31,24 @@ public class CarrierSchedulerUtils {
 
   /**
    * Creates a VehicleRoutingProblem from a carrier and a network and solves it with Jsprit.
-   * <p>
-   * This looks for me (KMT) similar to what is done in {@link org.matsim.freight.carriers.CarriersUtils#runJsprit(Scenario)}.
-   * So, maybe this can be more simplify.
-   *
-   * @deprecated please inline; use #solveVrpWithJsprit(Carrier, Network, RoadPricingScheme) instead.
-   *
-   * @param carrier               Carrier for which the problem should be solved
-   * @param network               the underlying network to create the network based transport costs
-   * @return Carrier  with the solution of the VehicleRoutingProblem and the routed plan.
-   */
-  @Deprecated
-  public static Carrier solveVrpWithJsprit(Carrier carrier, Network network) {
-    return solveVrpWithJsprit(carrier, network, null);
-  }
-
-  /**
-   * Creates a VehicleRoutingProblem from a carrier and a network and solves it with Jsprit.
    * If a roadPricingScheme is given, the tolls are considered in the routing costs.
    * <p>
    * This looks for me (KMT) similar to what is done in {@link org.matsim.freight.carriers.CarriersUtils#runJsprit(Scenario)}.
    * So, maybe this can be more simplify.
    *
-   * @param carrier           Carrier for which the problem should be solved
-   * @param network           the underlying network to create the network based transport costs
-   * @param roadPricingScheme (MATSim's) road pricing scheme from the roadpricing contrib. If null, no tolls are considered.
+   * @param carrier  Carrier for which the problem should be solved
+   * @param scenario the scenario
    * @return Carrier  with the solution of the VehicleRoutingProblem and the routed plan.
    */
-  public static Carrier solveVrpWithJsprit(
-          Carrier carrier, Network network, RoadPricingScheme roadPricingScheme) {
+  public static Carrier solveVrpWithJsprit(Carrier carrier, Scenario scenario) {
     NetworkBasedTransportCosts netbasedTransportCosts;
+    Network network = scenario.getNetwork();
+    RoadPricingScheme roadPricingScheme = null;
+    try {
+      roadPricingScheme = RoadPricingUtils.getRoadPricingScheme(scenario);
+    } catch (Exception e) {
+      log.info("Was not able getting RoadPricingScheme. Tolls cannot be considered.", e);
+    }
     if (roadPricingScheme != null) {
       netbasedTransportCosts = NetworkBasedTransportCosts.Builder.newInstance(network, ResourceImplementationUtils.getVehicleTypeCollection(carrier))
               .setRoadPricingScheme(roadPricingScheme)

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierResource.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierResource.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.List;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.api.core.v01.network.Network;
 import org.matsim.freight.carriers.Carrier;
 import org.matsim.freight.carriers.CarrierVehicle;
 import org.matsim.freight.logistics.*;
@@ -37,14 +36,12 @@ import org.matsim.freight.logistics.resourceImplementations.ResourceImplementati
   private final Carrier carrier;
   private final List<LogisticChainElement> clientElements;
   private final CollectionCarrierScheduler collectionScheduler;
-  private final Network network;
 
   CollectionCarrierResource(CollectionCarrierResourceBuilder builder) {
     super(builder.id);
     this.collectionScheduler = builder.collectionScheduler;
     this.clientElements = builder.clientElements;
     this.carrier = builder.carrier;
-    this.network = builder.network;
   }
 
   @Override
@@ -85,7 +82,4 @@ import org.matsim.freight.logistics.resourceImplementations.ResourceImplementati
     return carrier;
   }
 
-  public Network getNetwork() {
-    return network;
-  }
 }

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
@@ -24,8 +24,6 @@ package org.matsim.freight.logistics.resourceImplementations;
 import java.util.ArrayList;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
-import org.matsim.contrib.roadpricing.RoadPricingScheme;
-import org.matsim.contrib.roadpricing.RoadPricingUtils;
 import org.matsim.freight.carriers.Carrier;
 import org.matsim.freight.carriers.CarrierService;
 import org.matsim.freight.carriers.ScheduledTour;
@@ -51,16 +49,11 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
   private ArrayList<LSPCarrierPair> pairs;
   private Scenario scenario;
 
-  CollectionCarrierScheduler() {
-    this.pairs = new ArrayList<>();
-  }
-
   /**
    * Constructor for the CollectionCarrierScheduler.
    * TODO: In the future, the road pricing scheme should come from some the scenario: RoadPricingUtils.getRoadPricingScheme(scenario). This here is only a dirty workaround. KMT'Aug'24
    *
    * @param scenario the road pricing scheme
-   * @deprecated This is only a dirty workaround. KMT'Aug'24
    */
   @Deprecated
   CollectionCarrierScheduler(Scenario scenario) {
@@ -86,7 +79,7 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
       CarrierService carrierService = convertToCarrierService(tupleToBeAssigned);
       carrier.getServices().put(carrierService.getId(), carrierService);
     }
-    carrier = CarrierSchedulerUtils.solveVrpWithJsprit(carrier, resource.getNetwork(),  RoadPricingUtils.getRoadPricingScheme(scenario));
+    carrier = CarrierSchedulerUtils.solveVrpWithJsprit(carrier, scenario);
   }
 
   private CarrierService convertToCarrierService(LspShipmentWithTime tuple) {

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
@@ -47,15 +47,14 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
   private Carrier carrier;
   private CollectionCarrierResource resource;
   private ArrayList<LSPCarrierPair> pairs;
-  private Scenario scenario;
+  private final Scenario scenario;
 
   /**
    * Constructor for the CollectionCarrierScheduler.
-   * TODO: In the future, the road pricing scheme should come from some the scenario: RoadPricingUtils.getRoadPricingScheme(scenario). This here is only a dirty workaround. KMT'Aug'24
+   * TODO: In the future, the scenario should come via injection(?) This here is only a dirty workaround. KMT'Aug'24
    *
    * @param scenario the road pricing scheme
    */
-  @Deprecated
   CollectionCarrierScheduler(Scenario scenario) {
     this.pairs = new ArrayList<>();
     this.scenario = scenario;

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
@@ -78,7 +78,7 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
       CarrierService carrierService = convertToCarrierService(tupleToBeAssigned);
       carrier.getServices().put(carrierService.getId(), carrierService);
     }
-    carrier = CarrierSchedulerUtils.solveVrpWithJsprit(carrier, scenario);
+    CarrierSchedulerUtils.solveVrpWithJsprit(carrier, scenario);
   }
 
   private CarrierService convertToCarrierService(LspShipmentWithTime tuple) {

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
@@ -23,7 +23,9 @@ package org.matsim.freight.logistics.resourceImplementations;
 
 import java.util.ArrayList;
 import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.roadpricing.RoadPricingScheme;
+import org.matsim.contrib.roadpricing.RoadPricingUtils;
 import org.matsim.freight.carriers.Carrier;
 import org.matsim.freight.carriers.CarrierService;
 import org.matsim.freight.carriers.ScheduledTour;
@@ -47,7 +49,7 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
   private Carrier carrier;
   private CollectionCarrierResource resource;
   private ArrayList<LSPCarrierPair> pairs;
-  private RoadPricingScheme rpscheme = null;
+  private Scenario scenario;
 
   CollectionCarrierScheduler() {
     this.pairs = new ArrayList<>();
@@ -56,13 +58,14 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
   /**
    * Constructor for the CollectionCarrierScheduler.
    * TODO: In the future, the road pricing scheme should come from some the scenario: RoadPricingUtils.getRoadPricingScheme(scenario). This here is only a dirty workaround. KMT'Aug'24
+   *
+   * @param scenario the road pricing scheme
    * @deprecated This is only a dirty workaround. KMT'Aug'24
-   * @param rpscheme the road pricing scheme
    */
   @Deprecated
-  CollectionCarrierScheduler(RoadPricingScheme rpscheme) {
+  CollectionCarrierScheduler(Scenario scenario) {
     this.pairs = new ArrayList<>();
-    this.rpscheme = rpscheme;
+    this.scenario = scenario;
   }
 
   @Override
@@ -83,7 +86,7 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
       CarrierService carrierService = convertToCarrierService(tupleToBeAssigned);
       carrier.getServices().put(carrierService.getId(), carrierService);
     }
-    carrier = CarrierSchedulerUtils.solveVrpWithJsprit(carrier, resource.getNetwork(), rpscheme);
+    carrier = CarrierSchedulerUtils.solveVrpWithJsprit(carrier, resource.getNetwork(),  RoadPricingUtils.getRoadPricingScheme(scenario));
   }
 
   private CarrierService convertToCarrierService(LspShipmentWithTime tuple) {

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierResource.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierResource.java
@@ -24,7 +24,6 @@ package org.matsim.freight.logistics.resourceImplementations;
 import java.util.Collection;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.api.core.v01.network.Network;
 import org.matsim.freight.carriers.Carrier;
 import org.matsim.freight.carriers.CarrierVehicle;
 import org.matsim.freight.logistics.*;
@@ -36,14 +35,12 @@ import org.matsim.freight.logistics.resourceImplementations.ResourceImplementati
   private final Carrier carrier;
   private final Collection<LogisticChainElement> clientElements;
   private final DistributionCarrierScheduler distributionHandler;
-  private final Network network;
 
   DistributionCarrierResource(DistributionCarrierResourceBuilder builder) {
     super(builder.id);
     this.distributionHandler = builder.distributionHandler;
     this.clientElements = builder.clientElements;
     this.carrier = builder.carrier;
-    this.network = builder.network;
   }
 
   @Override
@@ -78,10 +75,6 @@ import org.matsim.freight.logistics.resourceImplementations.ResourceImplementati
   @Override
   public void schedule(int bufferTime, LSPPlan lspPlan) {
     distributionHandler.scheduleShipments(lspPlan, this, bufferTime);
-  }
-
-  public Network getNetwork() {
-    return network;
   }
 
   public Carrier getCarrier() {

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
@@ -28,9 +28,6 @@ import java.util.List;
 import org.locationtech.jts.util.Assert;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
-import org.matsim.contrib.roadpricing.RoadPricingScheme;
-import org.matsim.contrib.roadpricing.RoadPricingUtils;
-import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.freight.carriers.*;
 import org.matsim.freight.carriers.CarrierCapabilities.FleetSize;
 import org.matsim.freight.carriers.Tour.Leg;
@@ -58,16 +55,12 @@ import org.matsim.vehicles.VehicleType;
   private int carrierCnt = 1;
   private Scenario scenario;
 
-  DistributionCarrierScheduler() {
-    this.pairs = new ArrayList<>();
-  }
 
   /**
    * Constructor for the DistributionCarrierScheduler.
-   * TODO: In the future, the road pricing scheme should come from some the scenario: RoadPricingUtils.getRoadPricingScheme(scenario). This here is only a dirty workaround. KMT'Aug'24
+   * TODO: In the future, the scenario shpuld come via injection(?) This here is only a dirty workaround. KMT'Aug'24
    *
    * @param scenario the scenario
-   * @deprecated This is only a dirty workaround. KMT'Aug'24
    */
   @Deprecated
   DistributionCarrierScheduler(Scenario scenario) {
@@ -107,9 +100,8 @@ import org.matsim.vehicles.VehicleType;
         load = 0;
         Carrier auxiliaryCarrier =
             CarrierSchedulerUtils.solveVrpWithJsprit(
-                createAuxiliaryCarrier(
-                    shipmentsInCurrentTour, availabilityTimeOfLastShipment + cumulatedLoadingTime),
-                resource.getNetwork(), RoadPricingUtils.getRoadPricingScheme(scenario));
+                    createAuxiliaryCarrier(shipmentsInCurrentTour, availabilityTimeOfLastShipment + cumulatedLoadingTime),
+                    scenario);
         scheduledPlans.add(auxiliaryCarrier.getSelectedPlan());
         carrier.getServices().putAll(auxiliaryCarrier.getServices());
         cumulatedLoadingTime = 0;
@@ -126,7 +118,7 @@ import org.matsim.vehicles.VehicleType;
           CarrierSchedulerUtils.solveVrpWithJsprit(
               createAuxiliaryCarrier(
                   shipmentsInCurrentTour, availabilityTimeOfLastShipment + cumulatedLoadingTime),
-              resource.getNetwork(),  RoadPricingUtils.getRoadPricingScheme(scenario));
+                  scenario);
       scheduledPlans.add(auxiliaryCarrier.getSelectedPlan());
       carrier.getServices().putAll(auxiliaryCarrier.getServices());
       shipmentsInCurrentTour.clear();
@@ -319,8 +311,7 @@ import org.matsim.vehicles.VehicleType;
         .addPlanElement(id, unload);
   }
 
-  private Carrier createAuxiliaryCarrier(
-      ArrayList<LspShipmentWithTime> shipmentsInCurrentTour, double startTime) {
+  private Carrier createAuxiliaryCarrier(ArrayList<LspShipmentWithTime> shipmentsInCurrentTour, double startTime) {
     final Id<Carrier> carrierId = Id.create(carrier.getId().toString() + carrierCnt, Carrier.class);
     carrierCnt++;
     Carrier auxiliaryCarrier = CarriersUtils.createCarrier(carrierId);

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
@@ -27,7 +27,10 @@ import java.util.LinkedList;
 import java.util.List;
 import org.locationtech.jts.util.Assert;
 import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.roadpricing.RoadPricingScheme;
+import org.matsim.contrib.roadpricing.RoadPricingUtils;
+import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.freight.carriers.*;
 import org.matsim.freight.carriers.CarrierCapabilities.FleetSize;
 import org.matsim.freight.carriers.Tour.Leg;
@@ -53,7 +56,7 @@ import org.matsim.vehicles.VehicleType;
   private DistributionCarrierResource resource;
   private ArrayList<LSPCarrierPair> pairs;
   private int carrierCnt = 1;
-  private RoadPricingScheme rpscheme = null;
+  private Scenario scenario;
 
   DistributionCarrierScheduler() {
     this.pairs = new ArrayList<>();
@@ -62,13 +65,14 @@ import org.matsim.vehicles.VehicleType;
   /**
    * Constructor for the DistributionCarrierScheduler.
    * TODO: In the future, the road pricing scheme should come from some the scenario: RoadPricingUtils.getRoadPricingScheme(scenario). This here is only a dirty workaround. KMT'Aug'24
+   *
+   * @param scenario the scenario
    * @deprecated This is only a dirty workaround. KMT'Aug'24
-   * @param rpscheme the road pricing scheme
    */
   @Deprecated
-  DistributionCarrierScheduler(RoadPricingScheme rpscheme) {
+  DistributionCarrierScheduler(Scenario scenario) {
     this.pairs = new ArrayList<>();
-    this.rpscheme = rpscheme;
+    this.scenario = scenario;
   }
 
   @Override
@@ -105,7 +109,7 @@ import org.matsim.vehicles.VehicleType;
             CarrierSchedulerUtils.solveVrpWithJsprit(
                 createAuxiliaryCarrier(
                     shipmentsInCurrentTour, availabilityTimeOfLastShipment + cumulatedLoadingTime),
-                resource.getNetwork(), rpscheme);
+                resource.getNetwork(), RoadPricingUtils.getRoadPricingScheme(scenario));
         scheduledPlans.add(auxiliaryCarrier.getSelectedPlan());
         carrier.getServices().putAll(auxiliaryCarrier.getServices());
         cumulatedLoadingTime = 0;
@@ -122,7 +126,7 @@ import org.matsim.vehicles.VehicleType;
           CarrierSchedulerUtils.solveVrpWithJsprit(
               createAuxiliaryCarrier(
                   shipmentsInCurrentTour, availabilityTimeOfLastShipment + cumulatedLoadingTime),
-              resource.getNetwork(), rpscheme);
+              resource.getNetwork(),  RoadPricingUtils.getRoadPricingScheme(scenario));
       scheduledPlans.add(auxiliaryCarrier.getSelectedPlan());
       carrier.getServices().putAll(auxiliaryCarrier.getServices());
       shipmentsInCurrentTour.clear();

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
@@ -53,16 +53,15 @@ import org.matsim.vehicles.VehicleType;
   private DistributionCarrierResource resource;
   private ArrayList<LSPCarrierPair> pairs;
   private int carrierCnt = 1;
-  private Scenario scenario;
+  private final Scenario scenario;
 
 
   /**
    * Constructor for the DistributionCarrierScheduler.
-   * TODO: In the future, the scenario shpuld come via injection(?) This here is only a dirty workaround. KMT'Aug'24
+   * TODO: In the future, the scenario should come via injection(?) This here is only a dirty workaround. KMT'Aug'24
    *
    * @param scenario the scenario
    */
-  @Deprecated
   DistributionCarrierScheduler(Scenario scenario) {
     this.pairs = new ArrayList<>();
     this.scenario = scenario;

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/MainRunCarrierResource.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/MainRunCarrierResource.java
@@ -26,7 +26,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.api.core.v01.network.Network;
 import org.matsim.freight.carriers.Carrier;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.MainRunCarrierResourceBuilder;
@@ -43,7 +42,6 @@ import org.matsim.freight.logistics.resourceImplementations.ResourceImplementati
   private final MainRunCarrierScheduler mainRunScheduler;
 
   private final ResourceImplementationUtils.VehicleReturn vehicleReturn;
-  private final Network network;
 
   MainRunCarrierResource(MainRunCarrierResourceBuilder builder) {
     super(builder.getId());
@@ -58,7 +56,6 @@ import org.matsim.freight.logistics.resourceImplementations.ResourceImplementati
       log.warn("Return behaviour was not specified. Using the following setting as default: {}", ResourceImplementationUtils.VehicleReturn.endAtToLink);
       this.vehicleReturn = ResourceImplementationUtils.VehicleReturn.endAtToLink;
     }
-    this.network = builder.getNetwork();
   }
 
   @Override
@@ -83,10 +80,6 @@ import org.matsim.freight.logistics.resourceImplementations.ResourceImplementati
 
   public Carrier getCarrier() {
     return carrier;
-  }
-
-  public Network getNetwork() {
-    return network;
   }
 
   public ResourceImplementationUtils.VehicleReturn getVehicleReturn() {

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/MainRunCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/MainRunCarrierScheduler.java
@@ -23,6 +23,7 @@ package org.matsim.freight.logistics.resourceImplementations;
 
 import java.util.*;
 import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.freight.carriers.*;
@@ -48,14 +49,16 @@ import org.matsim.vehicles.VehicleType;
  * shipments into the vehicle * has passed.
  */
 /*package-private*/ class MainRunCarrierScheduler extends LSPResourceScheduler {
-
+  
   private Carrier carrier;
   private MainRunCarrierResource resource;
   private ArrayList<LSPShipmentCarrierServicePair> pairs;
+  private final Scenario scenario;
   private int tourIdIndex = 1; // Have unique TourIds for the MainRun.
 
-  /*package-private*/ MainRunCarrierScheduler() {
+  /*package-private*/ MainRunCarrierScheduler(Scenario scenario) {
     this.pairs = new ArrayList<>();
+    this.scenario = scenario;
   }
 
   @Override
@@ -117,7 +120,7 @@ import org.matsim.vehicles.VehicleType;
     // statt!
     NetworkBasedTransportCosts.Builder tpcostsBuilder =
         NetworkBasedTransportCosts.Builder.newInstance(
-            resource.getNetwork(),
+            scenario.getNetwork(),
             ResourceImplementationUtils.getVehicleTypeCollection(resource.getCarrier()));
     NetworkBasedTransportCosts netbasedTransportcosts = tpcostsBuilder.build();
     Collection<ScheduledTour> tours = new ArrayList<>();
@@ -193,14 +196,14 @@ import org.matsim.vehicles.VehicleType;
           // distance
           NetworkRoute route = (NetworkRoute) leg.getRoute();
           for (Id<Link> linkId : route.getLinkIds()) {
-            distance = distance + resource.getNetwork().getLinks().get(linkId).getLength();
+            distance = distance + scenario.getNetwork().getLinks().get(linkId).getLength();
           }
           if (route.getEndLinkId()
               != route
                   .getStartLinkId()) { // Do not calculate any distance, if start and endpoint are
                                        // identical
             distance =
-                distance + resource.getNetwork().getLinks().get(route.getEndLinkId()).getLength();
+                distance + scenario.getNetwork().getLinks().get(route.getEndLinkId()).getLength();
           }
 
           // travel time (exp.)

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/ResourceImplementationUtils.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/ResourceImplementationUtils.java
@@ -28,7 +28,6 @@ import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.api.core.v01.network.Network;
 import org.matsim.core.utils.io.IOUtils;
 import org.matsim.freight.carriers.Carrier;
 import org.matsim.freight.carriers.CarrierVehicle;
@@ -332,23 +331,21 @@ public class ResourceImplementationUtils {
 
     private final Id<LSPResource> id;
     private final ArrayList<LogisticChainElement> clientElements;
-    private final Network network;
     private Carrier carrier;
     private Id<Link> fromLinkId;
     private Id<Link> toLinkId;
     private MainRunCarrierScheduler mainRunScheduler;
     private VehicleReturn vehicleReturn;
 
-    private MainRunCarrierResourceBuilder(Carrier carrier, Network network) {
+    private MainRunCarrierResourceBuilder(Carrier carrier) {
       this.id = Id.create(carrier.getId().toString(), LSPResource.class);
       setCarrierType(carrier, CARRIER_TYPE.mainRunCarrier);
       this.carrier = carrier;
       this.clientElements = new ArrayList<>();
-      this.network = network;
     }
 
-    public static MainRunCarrierResourceBuilder newInstance(Carrier carrier, Network network) {
-      return new MainRunCarrierResourceBuilder(carrier, network);
+    public static MainRunCarrierResourceBuilder newInstance(Carrier carrier) {
+      return new MainRunCarrierResourceBuilder(carrier);
     }
 
     public MainRunCarrierResourceBuilder setMainRunCarrierScheduler(
@@ -401,10 +398,6 @@ public class ResourceImplementationUtils {
 
     MainRunCarrierScheduler getMainRunScheduler() {
       return mainRunScheduler;
-    }
-
-    Network getNetwork() {
-      return network;
     }
 
     VehicleReturn getVehicleReturn() {

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/ResourceImplementationUtils.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/ResourceImplementationUtils.java
@@ -213,12 +213,12 @@ public class ResourceImplementationUtils {
     carrier.getAttributes().putAttribute(CARRIER_TYPE_ATTR, carrierType);
   }
 
-  public static DistributionCarrierScheduler createDefaultDistributionCarrierScheduler() {
-    return new DistributionCarrierScheduler();
+  public static DistributionCarrierScheduler createDefaultDistributionCarrierScheduler(Scenario scenario) {
+    return new DistributionCarrierScheduler(scenario);
   }
 
-  public static CollectionCarrierScheduler createDefaultCollectionCarrierScheduler() {
-    return new CollectionCarrierScheduler();
+  public static CollectionCarrierScheduler createDefaultCollectionCarrierScheduler(Scenario scenario) {
+    return new CollectionCarrierScheduler(scenario);
   }
 
   /**

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/ResourceImplementationUtils.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/ResourceImplementationUtils.java
@@ -254,21 +254,19 @@ public class ResourceImplementationUtils {
 
     final Id<LSPResource> id;
     final ArrayList<LogisticChainElement> clientElements;
-    final Network network;
     final Carrier carrier;
     Id<Link> locationLinkId;
     DistributionCarrierScheduler distributionHandler;
 
-    private DistributionCarrierResourceBuilder(Carrier carrier, Network network) {
+    private DistributionCarrierResourceBuilder(Carrier carrier) {
       this.id = Id.create(carrier.getId().toString(), LSPResource.class);
       setCarrierType(carrier, CARRIER_TYPE.distributionCarrier);
       this.carrier = carrier;
       this.clientElements = new ArrayList<>();
-      this.network = network;
     }
 
-    public static DistributionCarrierResourceBuilder newInstance(Carrier carrier, Network network) {
-      return new DistributionCarrierResourceBuilder(carrier, network);
+    public static DistributionCarrierResourceBuilder newInstance(Carrier carrier) {
+      return new DistributionCarrierResourceBuilder(carrier);
     }
 
     public DistributionCarrierResourceBuilder setLocationLinkId(Id<Link> locationLinkId) {

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/ResourceImplementationUtils.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/ResourceImplementationUtils.java
@@ -213,33 +213,23 @@ public class ResourceImplementationUtils {
     carrier.getAttributes().putAttribute(CARRIER_TYPE_ATTR, carrierType);
   }
 
+  /**
+   * Utils method to create a  DistributionCarrierScheduler
+   *  TODO: In the future, the scheduler should get the scenario via injection. This here is only a dirty workaround. KMT'Aug'24
+   *
+   * @param scenario the scenario
+   */
   public static DistributionCarrierScheduler createDefaultDistributionCarrierScheduler(Scenario scenario) {
     return new DistributionCarrierScheduler(scenario);
   }
 
-  public static CollectionCarrierScheduler createDefaultCollectionCarrierScheduler(Scenario scenario) {
-    return new CollectionCarrierScheduler(scenario);
-  }
-
   /**
-   * Utils method to create a  DistributionCarrierScheduler with Roadpricing.
-   *  TODO: In the future, the scheduler should get the scenario via injection. This here is only a dirty workaround. KMT'Aug'24
-   *
-   * @param scenario the scenario
-   * @deprecated This is only a dirty workaround. KMT'Aug'24
-   */
-  public static DistributionCarrierScheduler createDefaultDistributionCarrierSchedulerWithRoadPricing(Scenario scenario) {
-    return new DistributionCarrierScheduler(scenario);
-  }
-
-  /**
-   * Utils method to create a  Collection CarrierScheduler with Roadpricing.
+   * Utils method to create a  Collection CarrierScheduler
    * TODO: In the future, the scheduler should get the scenario via injection. This here is only a dirty workaround. KMT'Aug'24
    *
    * @param scenario the scenario
-   * @deprecated This is only a dirty workaround. KMT'Aug'24
    */
-  public static CollectionCarrierScheduler createDefaultCollectionCarrierSchedulerWithRoadPricing(Scenario scenario) {
+  public static CollectionCarrierScheduler createDefaultCollectionCarrierScheduler(Scenario scenario) {
     return new CollectionCarrierScheduler(scenario);
   }
 

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/ResourceImplementationUtils.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/ResourceImplementationUtils.java
@@ -290,21 +290,19 @@ public class ResourceImplementationUtils {
 
     final Id<LSPResource> id;
     final ArrayList<LogisticChainElement> clientElements;
-    final Network network;
     final Carrier carrier;
     Id<Link> locationLinkId;
     CollectionCarrierScheduler collectionScheduler;
 
-    private CollectionCarrierResourceBuilder(Carrier carrier, Network network) {
+    private CollectionCarrierResourceBuilder(Carrier carrier) {
       this.id = Id.create(carrier.getId().toString(), LSPResource.class);
       setCarrierType(carrier, CARRIER_TYPE.collectionCarrier);
       this.carrier = carrier;
       this.clientElements = new ArrayList<>();
-      this.network = network;
     }
 
-    public static CollectionCarrierResourceBuilder newInstance(Carrier carrier, Network network) {
-      return new CollectionCarrierResourceBuilder(carrier, network);
+    public static CollectionCarrierResourceBuilder newInstance(Carrier carrier) {
+      return new CollectionCarrierResourceBuilder(carrier);
     }
 
     public CollectionCarrierResourceBuilder setLocationLinkId(Id<Link> locationLinkId) {

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/ResourceImplementationUtils.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/ResourceImplementationUtils.java
@@ -214,7 +214,7 @@ public class ResourceImplementationUtils {
   }
 
   /**
-   * Utils method to create a  DistributionCarrierScheduler
+   * Utils method to create a DistributionCarrierScheduler
    *  TODO: In the future, the scheduler should get the scenario via injection. This here is only a dirty workaround. KMT'Aug'24
    *
    * @param scenario the scenario
@@ -224,7 +224,7 @@ public class ResourceImplementationUtils {
   }
 
   /**
-   * Utils method to create a  Collection CarrierScheduler
+   * Utils method to create a CollectionCarrierScheduler
    * TODO: In the future, the scheduler should get the scenario via injection. This here is only a dirty workaround. KMT'Aug'24
    *
    * @param scenario the scenario
@@ -233,8 +233,14 @@ public class ResourceImplementationUtils {
     return new CollectionCarrierScheduler(scenario);
   }
 
-  public static MainRunCarrierScheduler createDefaultMainRunCarrierScheduler() {
-    return new MainRunCarrierScheduler();
+  /**
+   * Utils method to create a MainRunCarrierScheduler
+   * TODO: In the future, the scheduler should get the scenario via injection. This here is only a dirty workaround. KMT'Aug'24
+   *
+   * @param scenario the scenario
+   */
+  public static MainRunCarrierScheduler createDefaultMainRunCarrierScheduler(Scenario scenario) {
+    return new MainRunCarrierScheduler(scenario);
   }
 
   public enum VehicleReturn {

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/ResourceImplementationUtils.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/ResourceImplementationUtils.java
@@ -29,7 +29,6 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.contrib.roadpricing.RoadPricingScheme;
 import org.matsim.core.utils.io.IOUtils;
 import org.matsim.freight.carriers.Carrier;
 import org.matsim.freight.carriers.CarrierVehicle;
@@ -224,22 +223,24 @@ public class ResourceImplementationUtils {
 
   /**
    * Utils method to create a  DistributionCarrierScheduler with Roadpricing.
-   * TODO: In the future, the road pricing scheme should come from some the scenario: RoadPricingUtils.getRoadPricingScheme(scenario). This here is only a dirty workaround. KMT'Aug'24
+   *  TODO: In the future, the scheduler should get the scenario via injection. This here is only a dirty workaround. KMT'Aug'24
+   *
+   * @param scenario the scenario
    * @deprecated This is only a dirty workaround. KMT'Aug'24
-   * @param roadPricingScheme the road pricing scheme
    */
-  public static DistributionCarrierScheduler createDefaultDistributionCarrierSchedulerWithRoadPricing(RoadPricingScheme roadPricingScheme) {
-    return new DistributionCarrierScheduler(roadPricingScheme);
+  public static DistributionCarrierScheduler createDefaultDistributionCarrierSchedulerWithRoadPricing(Scenario scenario) {
+    return new DistributionCarrierScheduler(scenario);
   }
 
   /**
    * Utils method to create a  Collection CarrierScheduler with Roadpricing.
-   * TODO: In the future, the road pricing scheme should come from some the scenario: RoadPricingUtils.getRoadPricingScheme(scenario). This here is only a dirty workaround. KMT'Aug'24
+   * TODO: In the future, the scheduler should get the scenario via injection. This here is only a dirty workaround. KMT'Aug'24
+   *
+   * @param scenario the scenario
    * @deprecated This is only a dirty workaround. KMT'Aug'24
-   * @param roadPricingScheme the road pricing scheme
    */
-  public static CollectionCarrierScheduler createDefaultCollectionCarrierSchedulerWithRoadPricing(RoadPricingScheme roadPricingScheme) {
-    return new CollectionCarrierScheduler(roadPricingScheme);
+  public static CollectionCarrierScheduler createDefaultCollectionCarrierSchedulerWithRoadPricing(Scenario scenario) {
+    return new CollectionCarrierScheduler(scenario);
   }
 
   public static MainRunCarrierScheduler createDefaultMainRunCarrierScheduler() {

--- a/src/test/java/org/matsim/freight/logistics/adapterTests/CollectionResourceTest.java
+++ b/src/test/java/org/matsim/freight/logistics/adapterTests/CollectionResourceTest.java
@@ -82,7 +82,7 @@ public class CollectionResourceTest {
 		collectionCarrier.setCarrierCapabilities(capabilities);
 
 
-		carrierResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		carrierResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/adapterTests/CollectionResourceTest.java
+++ b/src/test/java/org/matsim/freight/logistics/adapterTests/CollectionResourceTest.java
@@ -83,7 +83,7 @@ public class CollectionResourceTest {
 
 
 		carrierResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 	}

--- a/src/test/java/org/matsim/freight/logistics/adapterTests/DistributionResourceTest.java
+++ b/src/test/java/org/matsim/freight/logistics/adapterTests/DistributionResourceTest.java
@@ -83,7 +83,7 @@ public class DistributionResourceTest {
 		distributionCarrier.setCarrierCapabilities(capabilities);
 
 
-		DistributionCarrierResourceBuilder builder = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(distributionCarrier, network);
+		DistributionCarrierResourceBuilder builder = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(distributionCarrier);
 		builder.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario));
 		builder.setLocationLinkId(distributionLinkId);
 		distributionResource = builder.build();

--- a/src/test/java/org/matsim/freight/logistics/adapterTests/DistributionResourceTest.java
+++ b/src/test/java/org/matsim/freight/logistics/adapterTests/DistributionResourceTest.java
@@ -84,7 +84,7 @@ public class DistributionResourceTest {
 
 
 		DistributionCarrierResourceBuilder builder = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(distributionCarrier, network);
-		builder.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler());
+		builder.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario));
 		builder.setLocationLinkId(distributionLinkId);
 		distributionResource = builder.build();
 	}

--- a/src/test/java/org/matsim/freight/logistics/adapterTests/MainRunResourceTest.java
+++ b/src/test/java/org/matsim/freight/logistics/adapterTests/MainRunResourceTest.java
@@ -83,7 +83,7 @@ public class MainRunResourceTest {
 		carrier.setCarrierCapabilities(capabilities);
 
 		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(carrier, network)
-				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)")).setToLinkId(Id.createLinkId("(14 2) (14 3)"))
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/adapterTests/MainRunResourceTest.java
+++ b/src/test/java/org/matsim/freight/logistics/adapterTests/MainRunResourceTest.java
@@ -82,7 +82,7 @@ public class MainRunResourceTest {
 		carrier = CarriersUtils.createCarrier(carrierId);
 		carrier.setCarrierCapabilities(capabilities);
 
-		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(carrier, network)
+		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(carrier)
 				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)")).setToLinkId(Id.createLinkId("(14 2) (14 3)"))
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/examples/lspReplanning/CollectionLSPReplanningTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/lspReplanning/CollectionLSPReplanningTest.java
@@ -115,7 +115,7 @@ public class CollectionLSPReplanningTest {
 
 
 		Id<LSPResource> adapterId = Id.create("CollectionCarrierResource", LSPResource.class);
-				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network);
+				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier);
 		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario));
 		adapterBuilder.setLocationLinkId(collectionLinkId);
 		LSPResource collectionResource = adapterBuilder.build();

--- a/src/test/java/org/matsim/freight/logistics/examples/lspReplanning/CollectionLSPReplanningTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/lspReplanning/CollectionLSPReplanningTest.java
@@ -116,7 +116,7 @@ public class CollectionLSPReplanningTest {
 
 		Id<LSPResource> adapterId = Id.create("CollectionCarrierResource", LSPResource.class);
 				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network);
-		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler());
+		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario));
 		adapterBuilder.setLocationLinkId(collectionLinkId);
 		LSPResource collectionResource = adapterBuilder.build();
 

--- a/src/test/java/org/matsim/freight/logistics/examples/lspScoring/CollectionLSPScoringTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/lspScoring/CollectionLSPScoringTest.java
@@ -80,7 +80,7 @@ public class CollectionLSPScoringTest {
 		carrier.setCarrierCapabilities(CarrierCapabilities.Builder.newInstance().addType(collectionVehicleType).addVehicle(carrierVehicle).setFleetSize(FleetSize.INFINITE).build());
 
 		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler()).setLocationLinkId(collectionLink.getId()).build();
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario)).setLocationLinkId(collectionLink.getId()).build();
 
 		LogisticChainElement collectionElement = LSPUtils.LogisticChainElementBuilder
 				.newInstance(Id.create("CollectionElement", LogisticChainElement.class)).setResource(collectionResource).build();

--- a/src/test/java/org/matsim/freight/logistics/examples/lspScoring/CollectionLSPScoringTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/lspScoring/CollectionLSPScoringTest.java
@@ -79,7 +79,7 @@ public class CollectionLSPScoringTest {
 		Carrier carrier = CarriersUtils.createCarrier(Id.create("CollectionCarrier", Carrier.class));
 		carrier.setCarrierCapabilities(CarrierCapabilities.Builder.newInstance().addType(collectionVehicleType).addVehicle(carrierVehicle).setFleetSize(FleetSize.INFINITE).build());
 
-		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network)
+		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario)).setLocationLinkId(collectionLink.getId()).build();
 
 		LogisticChainElement collectionElement = LSPUtils.LogisticChainElementBuilder

--- a/src/test/java/org/matsim/freight/logistics/examples/lspScoring/MultipleIterationsCollectionLSPScoringTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/lspScoring/MultipleIterationsCollectionLSPScoringTest.java
@@ -100,7 +100,7 @@ public class MultipleIterationsCollectionLSPScoringTest {
 		Carrier carrier = CarriersUtils.createCarrier(carrierId);
 		carrier.setCarrierCapabilities(capabilities);
 
-		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network)
+		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/examples/lspScoring/MultipleIterationsCollectionLSPScoringTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/lspScoring/MultipleIterationsCollectionLSPScoringTest.java
@@ -101,7 +101,7 @@ public class MultipleIterationsCollectionLSPScoringTest {
 		carrier.setCarrierCapabilities(capabilities);
 
 		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsReplanningTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsReplanningTest.java
@@ -103,7 +103,7 @@ public class MultipleChainsReplanningTest {
 
 				CarriersUtils.addCarrierVehicle(carrierLeft, CarrierVehicle.newInstance(Id.createVehicleId("veh_small"), DEPOT_LINK_ID, VEH_TYPE_LARGE_50));
 				LSPResource carrierLeftResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrierLeft, network)
-						.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+						.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 						.build();
 
 				leftCarrierElement = LSPUtils.LogisticChainElementBuilder.newInstance(Id.create("leftCarrierElement", LogisticChainElement.class))
@@ -118,7 +118,7 @@ public class MultipleChainsReplanningTest {
 
 				CarriersUtils.addCarrierVehicle(carrierRight, CarrierVehicle.newInstance(Id.createVehicleId("veh_small"), DEPOT_LINK_ID, VEH_TYPE_LARGE_50));
 				LSPResource carrierRightResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrierRight, network)
-						.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+						.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 						.build();
 
 				rightCarrierElement = LSPUtils.LogisticChainElementBuilder.newInstance(Id.create("rightCarrierElement", LogisticChainElement.class))

--- a/src/test/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsReplanningTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsReplanningTest.java
@@ -102,7 +102,7 @@ public class MultipleChainsReplanningTest {
 				carrierLeft.getCarrierCapabilities().setFleetSize(CarrierCapabilities.FleetSize.INFINITE);
 
 				CarriersUtils.addCarrierVehicle(carrierLeft, CarrierVehicle.newInstance(Id.createVehicleId("veh_small"), DEPOT_LINK_ID, VEH_TYPE_LARGE_50));
-				LSPResource carrierLeftResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrierLeft, network)
+				LSPResource carrierLeftResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrierLeft)
 						.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 						.build();
 
@@ -117,7 +117,7 @@ public class MultipleChainsReplanningTest {
 				carrierRight.getCarrierCapabilities().setFleetSize(CarrierCapabilities.FleetSize.INFINITE);
 
 				CarriersUtils.addCarrierVehicle(carrierRight, CarrierVehicle.newInstance(Id.createVehicleId("veh_small"), DEPOT_LINK_ID, VEH_TYPE_LARGE_50));
-				LSPResource carrierRightResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrierRight, network)
+				LSPResource carrierRightResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrierRight)
 						.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 						.build();
 

--- a/src/test/java/org/matsim/freight/logistics/examples/multipleChains/WorstPlanSelectorTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/multipleChains/WorstPlanSelectorTest.java
@@ -102,7 +102,7 @@ public class WorstPlanSelectorTest {
 			singleCarrier.getCarrierCapabilities().setFleetSize(CarrierCapabilities.FleetSize.INFINITE);
 
 			CarriersUtils.addCarrierVehicle(singleCarrier, CarrierVehicle.newInstance(Id.createVehicleId("directTruck"), DEPOT_SOUTH_LINK_ID, VEH_TYPE_EXPENSIVE));
-			LSPResource singleCarrierResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(singleCarrier, network)
+			LSPResource singleCarrierResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(singleCarrier)
 					.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 					.build();
 
@@ -131,7 +131,7 @@ public class WorstPlanSelectorTest {
 				carrierSouth.getCarrierCapabilities().setFleetSize(CarrierCapabilities.FleetSize.INFINITE);
 
 				CarriersUtils.addCarrierVehicle(carrierSouth, CarrierVehicle.newInstance(Id.createVehicleId("directTruck"), DEPOT_SOUTH_LINK_ID, VEH_TYPE_CHEAP));
-				LSPResource carrierSouthResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrierSouth, network)
+				LSPResource carrierSouthResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrierSouth)
 						.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 						.build();
 
@@ -146,7 +146,7 @@ public class WorstPlanSelectorTest {
 				carrierNorth.getCarrierCapabilities().setFleetSize(CarrierCapabilities.FleetSize.INFINITE);
 
 				CarriersUtils.addCarrierVehicle(carrierNorth, CarrierVehicle.newInstance(Id.createVehicleId("directTruck"), DEPOT_NORTH_LINK_ID, VEH_TYPE_CHEAP));
-				LSPResource carrierNorthResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrierNorth, network)
+				LSPResource carrierNorthResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrierNorth)
 						.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 						.build();
 

--- a/src/test/java/org/matsim/freight/logistics/examples/multipleChains/WorstPlanSelectorTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/multipleChains/WorstPlanSelectorTest.java
@@ -103,7 +103,7 @@ public class WorstPlanSelectorTest {
 
 			CarriersUtils.addCarrierVehicle(singleCarrier, CarrierVehicle.newInstance(Id.createVehicleId("directTruck"), DEPOT_SOUTH_LINK_ID, VEH_TYPE_EXPENSIVE));
 			LSPResource singleCarrierResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(singleCarrier, network)
-					.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+					.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 					.build();
 
 			LogisticChainElement singleCarrierElement = LSPUtils.LogisticChainElementBuilder.newInstance(Id.create("singleCarrierElement", LogisticChainElement.class))
@@ -132,7 +132,7 @@ public class WorstPlanSelectorTest {
 
 				CarriersUtils.addCarrierVehicle(carrierSouth, CarrierVehicle.newInstance(Id.createVehicleId("directTruck"), DEPOT_SOUTH_LINK_ID, VEH_TYPE_CHEAP));
 				LSPResource carrierSouthResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrierSouth, network)
-						.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+						.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 						.build();
 
 				southCarrierElement = LSPUtils.LogisticChainElementBuilder.newInstance(Id.create("southCarrierElement", LogisticChainElement.class))
@@ -147,7 +147,7 @@ public class WorstPlanSelectorTest {
 
 				CarriersUtils.addCarrierVehicle(carrierNorth, CarrierVehicle.newInstance(Id.createVehicleId("directTruck"), DEPOT_NORTH_LINK_ID, VEH_TYPE_CHEAP));
 				LSPResource carrierNorthResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrierNorth, network)
-						.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+						.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 						.build();
 
 				northCarrierElement = LSPUtils.LogisticChainElementBuilder.newInstance(Id.create("northCarrierElement", LogisticChainElement.class))

--- a/src/test/java/org/matsim/freight/logistics/examples/requirementsChecking/AssignerRequirementsTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/requirementsChecking/AssignerRequirementsTest.java
@@ -102,7 +102,7 @@ public class AssignerRequirementsTest {
 		redCarrier.setCarrierCapabilities(redCapabilities);
 
 		LSPResource redCollectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(redCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 
@@ -134,7 +134,7 @@ public class AssignerRequirementsTest {
 		blueCarrier.setCarrierCapabilities(blueCapabilities);
 
 		LSPResource blueCollectionResource  = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(blueCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/examples/requirementsChecking/AssignerRequirementsTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/requirementsChecking/AssignerRequirementsTest.java
@@ -101,7 +101,7 @@ public class AssignerRequirementsTest {
 		Carrier redCarrier = CarriersUtils.createCarrier(redCarrierId);
 		redCarrier.setCarrierCapabilities(redCapabilities);
 
-		LSPResource redCollectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(redCarrier, network)
+		LSPResource redCollectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(redCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
@@ -133,7 +133,7 @@ public class AssignerRequirementsTest {
 		Carrier blueCarrier = CarriersUtils.createCarrier(blueCarrierId);
 		blueCarrier.setCarrierCapabilities(blueCapabilities);
 
-		LSPResource blueCollectionResource  = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(blueCarrier, network)
+		LSPResource blueCollectionResource  = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(blueCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/examples/simulationTrackers/CollectionTrackerTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/simulationTrackers/CollectionTrackerTest.java
@@ -107,7 +107,7 @@ public class CollectionTrackerTest {
 
 		Id<LSPResource> adapterId = Id.create("CollectionCarrierResource", LSPResource.class);
 				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network);
-		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler());
+		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario));
 		adapterBuilder.setLocationLinkId(collectionLinkId);
 		LSPResource collectionResource = adapterBuilder.build();
 

--- a/src/test/java/org/matsim/freight/logistics/examples/simulationTrackers/CollectionTrackerTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/simulationTrackers/CollectionTrackerTest.java
@@ -106,7 +106,7 @@ public class CollectionTrackerTest {
 
 
 		Id<LSPResource> adapterId = Id.create("CollectionCarrierResource", LSPResource.class);
-				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network);
+				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier);
 		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario));
 		adapterBuilder.setLocationLinkId(collectionLinkId);
 		LSPResource collectionResource = adapterBuilder.build();

--- a/src/test/java/org/matsim/freight/logistics/logisticChainElementTests/CollectionElementTest.java
+++ b/src/test/java/org/matsim/freight/logistics/logisticChainElementTests/CollectionElementTest.java
@@ -75,7 +75,7 @@ public class CollectionElementTest {
 		carrier.setCarrierCapabilities(capabilities);
 
 		carrierResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/logisticChainElementTests/CollectionElementTest.java
+++ b/src/test/java/org/matsim/freight/logistics/logisticChainElementTests/CollectionElementTest.java
@@ -74,7 +74,7 @@ public class CollectionElementTest {
 		Carrier carrier = CarriersUtils.createCarrier(carrierId);
 		carrier.setCarrierCapabilities(capabilities);
 
-		carrierResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network)
+		carrierResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/logisticChainElementTests/DistributionElementTest.java
+++ b/src/test/java/org/matsim/freight/logistics/logisticChainElementTests/DistributionElementTest.java
@@ -78,7 +78,7 @@ public class DistributionElementTest {
 
 
 		Id<LSPResource> adapterId = Id.create("DistributionCarrierResource", LSPResource.class);
-		adapter = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier, network)
+		adapter = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier)
 				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 				.setLocationLinkId(distributionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/logisticChainElementTests/DistributionElementTest.java
+++ b/src/test/java/org/matsim/freight/logistics/logisticChainElementTests/DistributionElementTest.java
@@ -79,7 +79,7 @@ public class DistributionElementTest {
 
 		Id<LSPResource> adapterId = Id.create("DistributionCarrierResource", LSPResource.class);
 		adapter = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier, network)
-				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 				.setLocationLinkId(distributionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/logisticChainElementTests/MainRunElementTest.java
+++ b/src/test/java/org/matsim/freight/logistics/logisticChainElementTests/MainRunElementTest.java
@@ -79,7 +79,7 @@ public class MainRunElementTest {
 		mainRunCarrierResourceBuilder.setCarrierCapabilities(capabilities);
 
 		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrierResourceBuilder, network)
-				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/logisticChainElementTests/MainRunElementTest.java
+++ b/src/test/java/org/matsim/freight/logistics/logisticChainElementTests/MainRunElementTest.java
@@ -78,7 +78,7 @@ public class MainRunElementTest {
 		Carrier mainRunCarrierResourceBuilder = CarriersUtils.createCarrier(carrierId);
 		mainRunCarrierResourceBuilder.setCarrierCapabilities(capabilities);
 
-		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrierResourceBuilder, network)
+		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrierResourceBuilder)
 				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))

--- a/src/test/java/org/matsim/freight/logistics/logisticChainTests/CollectionChainTest.java
+++ b/src/test/java/org/matsim/freight/logistics/logisticChainTests/CollectionChainTest.java
@@ -75,7 +75,7 @@ public class CollectionChainTest {
 		carrier.setCarrierCapabilities(capabilities);
 
 		LSPCarrierResource carrierResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder
-				.newInstance(carrier, network)
+				.newInstance(carrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/logisticChainTests/CollectionChainTest.java
+++ b/src/test/java/org/matsim/freight/logistics/logisticChainTests/CollectionChainTest.java
@@ -76,7 +76,7 @@ public class CollectionChainTest {
 
 		LSPCarrierResource carrierResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder
 				.newInstance(carrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/logisticChainTests/CompleteLogisticChainTest.java
+++ b/src/test/java/org/matsim/freight/logistics/logisticChainTests/CompleteLogisticChainTest.java
@@ -134,7 +134,7 @@ public class CompleteLogisticChainTest {
 		Carrier mainRunCarrier = CarriersUtils.createCarrier(collectionCarrierId);
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
-		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
 				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))

--- a/src/test/java/org/matsim/freight/logistics/logisticChainTests/CompleteLogisticChainTest.java
+++ b/src/test/java/org/matsim/freight/logistics/logisticChainTests/CompleteLogisticChainTest.java
@@ -135,7 +135,7 @@ public class CompleteLogisticChainTest {
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
 		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
-				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/logisticChainTests/CompleteLogisticChainTest.java
+++ b/src/test/java/org/matsim/freight/logistics/logisticChainTests/CompleteLogisticChainTest.java
@@ -87,7 +87,7 @@ public class CompleteLogisticChainTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 		CollectionCarrierResourceBuilder collectionResourceBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder
-				.newInstance(collectionCarrier, network);
+				.newInstance(collectionCarrier);
 		collectionResourceBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario));
 		collectionResourceBuilder.setLocationLinkId(collectionLinkId);
 

--- a/src/test/java/org/matsim/freight/logistics/logisticChainTests/CompleteLogisticChainTest.java
+++ b/src/test/java/org/matsim/freight/logistics/logisticChainTests/CompleteLogisticChainTest.java
@@ -88,7 +88,7 @@ public class CompleteLogisticChainTest {
 
 		CollectionCarrierResourceBuilder collectionResourceBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder
 				.newInstance(collectionCarrier, network);
-		collectionResourceBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler());
+		collectionResourceBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario));
 		collectionResourceBuilder.setLocationLinkId(collectionLinkId);
 
 		Id<LogisticChainElement> collectionElementId = Id.create("CollectionElement",
@@ -189,7 +189,7 @@ public class CompleteLogisticChainTest {
 
 		final LSPResource distributionCarrierResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder
 				.newInstance(carrier, network)
-				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 				.setLocationLinkId(distributionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/logisticChainTests/CompleteLogisticChainTest.java
+++ b/src/test/java/org/matsim/freight/logistics/logisticChainTests/CompleteLogisticChainTest.java
@@ -188,7 +188,7 @@ public class CompleteLogisticChainTest {
 		carrier.setCarrierCapabilities(distributionCapabilities);
 
 		final LSPResource distributionCarrierResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder
-				.newInstance(carrier, network)
+				.newInstance(carrier)
 				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 				.setLocationLinkId(distributionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspCreationTests/CollectionLSPCreationTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspCreationTests/CollectionLSPCreationTest.java
@@ -77,7 +77,7 @@ public class CollectionLSPCreationTest {
 
 
 		Id<LSPResource> adapterId = Id.create("CollectionCarrierResource", LSPResource.class);
-				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network);
+				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier);
 		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario));
 		adapterBuilder.setLocationLinkId(collectionLinkId);
 		LSPResource collectionResource = adapterBuilder.build();

--- a/src/test/java/org/matsim/freight/logistics/lspCreationTests/CollectionLSPCreationTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspCreationTests/CollectionLSPCreationTest.java
@@ -78,7 +78,7 @@ public class CollectionLSPCreationTest {
 
 		Id<LSPResource> adapterId = Id.create("CollectionCarrierResource", LSPResource.class);
 				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network);
-		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler());
+		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario));
 		adapterBuilder.setLocationLinkId(collectionLinkId);
 		LSPResource collectionResource = adapterBuilder.build();
 

--- a/src/test/java/org/matsim/freight/logistics/lspCreationTests/CompleteLSPCreationTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspCreationTests/CompleteLSPCreationTest.java
@@ -177,7 +177,7 @@ public class CompleteLSPCreationTest {
 		carrier.setCarrierCapabilities(distributionCapabilities);
 
 
-		LSPResource distributionResource  = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier, network)
+		LSPResource distributionResource  = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier)
 				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 				.setLocationLinkId(distributionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspCreationTests/CompleteLSPCreationTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspCreationTests/CompleteLSPCreationTest.java
@@ -78,7 +78,7 @@ public class CompleteLSPCreationTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 
-		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspCreationTests/CompleteLSPCreationTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspCreationTests/CompleteLSPCreationTest.java
@@ -128,7 +128,7 @@ public class CompleteLSPCreationTest {
 
 
 		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
-				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspCreationTests/CompleteLSPCreationTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspCreationTests/CompleteLSPCreationTest.java
@@ -79,7 +79,7 @@ public class CompleteLSPCreationTest {
 
 
 		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 
@@ -178,7 +178,7 @@ public class CompleteLSPCreationTest {
 
 
 		LSPResource distributionResource  = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier, network)
-				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 				.setLocationLinkId(distributionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/lspCreationTests/CompleteLSPCreationTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspCreationTests/CompleteLSPCreationTest.java
@@ -127,7 +127,7 @@ public class CompleteLSPCreationTest {
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
 
-		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
 				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CollectionLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CollectionLSPMobsimTest.java
@@ -109,7 +109,7 @@ public class CollectionLSPMobsimTest {
 
 
 
-		collectionResource  = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, scenario.getNetwork())
+		collectionResource  = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario)).setLocationLinkId(collectionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CollectionLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CollectionLSPMobsimTest.java
@@ -110,7 +110,7 @@ public class CollectionLSPMobsimTest {
 
 
 		collectionResource  = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, scenario.getNetwork())
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler()).setLocationLinkId(collectionLinkId)
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario)).setLocationLinkId(collectionLinkId)
 				.build();
 
 		final LogisticChainElement collectionElement;

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CompleteLSPMobsimTest.java
@@ -95,7 +95,7 @@ public class CompleteLSPMobsimTest {
 
 
 		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 
@@ -193,7 +193,7 @@ public class CompleteLSPMobsimTest {
 		carrier.setCarrierCapabilities(distributionCapabilities);
 
 		LSPResource distributionResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier, network)
-				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 				.setLocationLinkId(distributionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CompleteLSPMobsimTest.java
@@ -144,7 +144,7 @@ public class CompleteLSPMobsimTest {
 
 
 		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
-				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CompleteLSPMobsimTest.java
@@ -143,7 +143,7 @@ public class CompleteLSPMobsimTest {
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
 
-		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
 				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CompleteLSPMobsimTest.java
@@ -94,7 +94,7 @@ public class CompleteLSPMobsimTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 
-		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CompleteLSPMobsimTest.java
@@ -192,7 +192,7 @@ public class CompleteLSPMobsimTest {
 		Carrier carrier = CarriersUtils.createCarrier(distributionCarrierId);
 		carrier.setCarrierCapabilities(distributionCapabilities);
 
-		LSPResource distributionResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier, network)
+		LSPResource distributionResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier)
 				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 				.setLocationLinkId(distributionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstAndSecondReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstAndSecondReloadLSPMobsimTest.java
@@ -149,7 +149,7 @@ public class FirstAndSecondReloadLSPMobsimTest {
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
 
-		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
 				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstAndSecondReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstAndSecondReloadLSPMobsimTest.java
@@ -150,7 +150,7 @@ public class FirstAndSecondReloadLSPMobsimTest {
 
 
 		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
-				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstAndSecondReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstAndSecondReloadLSPMobsimTest.java
@@ -98,7 +98,7 @@ public class FirstAndSecondReloadLSPMobsimTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 
-		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstAndSecondReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstAndSecondReloadLSPMobsimTest.java
@@ -99,7 +99,7 @@ public class FirstAndSecondReloadLSPMobsimTest {
 
 
 		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstReloadLSPMobsimTest.java
@@ -100,7 +100,7 @@ public class FirstReloadLSPMobsimTest {
 
 
 		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstReloadLSPMobsimTest.java
@@ -99,7 +99,7 @@ public class FirstReloadLSPMobsimTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 
-		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunLSPMobsimTest.java
@@ -99,7 +99,7 @@ public class MainRunLSPMobsimTest {
 
 
 		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunLSPMobsimTest.java
@@ -98,7 +98,7 @@ public class MainRunLSPMobsimTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 
-		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunLSPMobsimTest.java
@@ -148,7 +148,7 @@ public class MainRunLSPMobsimTest {
 
 
 		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
-				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunLSPMobsimTest.java
@@ -147,7 +147,7 @@ public class MainRunLSPMobsimTest {
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
 
-		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
 				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunOnlyLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunOnlyLSPMobsimTest.java
@@ -97,7 +97,7 @@ public class MainRunOnlyLSPMobsimTest {
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
 
-		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
 				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunOnlyLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunOnlyLSPMobsimTest.java
@@ -98,7 +98,7 @@ public class MainRunOnlyLSPMobsimTest {
 
 
 		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
-				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCollectionLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCollectionLSPMobsimTest.java
@@ -103,7 +103,7 @@ public class MultipleIterationsCollectionLSPMobsimTest {
 
 		Id<LSPResource> adapterId = Id.create("CollectionCarrierResource", LSPResource.class);
 				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network);
-		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler());
+		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario));
 		adapterBuilder.setLocationLinkId(collectionLinkId);
 		LSPResource collectionResource = adapterBuilder.build();
 

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCollectionLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCollectionLSPMobsimTest.java
@@ -102,7 +102,7 @@ public class MultipleIterationsCollectionLSPMobsimTest {
 
 
 		Id<LSPResource> adapterId = Id.create("CollectionCarrierResource", LSPResource.class);
-				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network);
+				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier);
 		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario));
 		adapterBuilder.setLocationLinkId(collectionLinkId);
 		LSPResource collectionResource = adapterBuilder.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCompleteLSPMobsimTest.java
@@ -104,7 +104,7 @@ public class MultipleIterationsCompleteLSPMobsimTest {
 
 
 		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 
@@ -204,7 +204,7 @@ public class MultipleIterationsCompleteLSPMobsimTest {
 		carrier.setCarrierCapabilities(distributionCapabilities);
 
 		LSPResource distributionResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier, network)
-				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 				.setLocationLinkId(distributionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCompleteLSPMobsimTest.java
@@ -103,7 +103,7 @@ public class MultipleIterationsCompleteLSPMobsimTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 
-		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCompleteLSPMobsimTest.java
@@ -154,7 +154,7 @@ public class MultipleIterationsCompleteLSPMobsimTest {
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
 
-		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
 				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCompleteLSPMobsimTest.java
@@ -203,7 +203,7 @@ public class MultipleIterationsCompleteLSPMobsimTest {
 		Carrier carrier = CarriersUtils.createCarrier(distributionCarrierId);
 		carrier.setCarrierCapabilities(distributionCapabilities);
 
-		LSPResource distributionResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier, network)
+		LSPResource distributionResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier)
 				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 				.setLocationLinkId(distributionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCompleteLSPMobsimTest.java
@@ -155,7 +155,7 @@ public class MultipleIterationsCompleteLSPMobsimTest {
 
 
 		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
-				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstAndSecondReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstAndSecondReloadLSPMobsimTest.java
@@ -104,7 +104,7 @@ public class MultipleIterationsFirstAndSecondReloadLSPMobsimTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 
-		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstAndSecondReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstAndSecondReloadLSPMobsimTest.java
@@ -156,7 +156,7 @@ public class MultipleIterationsFirstAndSecondReloadLSPMobsimTest {
 
 
 		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
-				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstAndSecondReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstAndSecondReloadLSPMobsimTest.java
@@ -105,7 +105,7 @@ public class MultipleIterationsFirstAndSecondReloadLSPMobsimTest {
 
 
 		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstAndSecondReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstAndSecondReloadLSPMobsimTest.java
@@ -155,7 +155,7 @@ public class MultipleIterationsFirstAndSecondReloadLSPMobsimTest {
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
 
-		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
 				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstReloadLSPMobsimTest.java
@@ -102,7 +102,7 @@ public class MultipleIterationsFirstReloadLSPMobsimTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 
-		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstReloadLSPMobsimTest.java
@@ -103,7 +103,7 @@ public class MultipleIterationsFirstReloadLSPMobsimTest {
 
 
 		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
@@ -104,7 +104,7 @@ public class MultipleIterationsMainRunLSPMobsimTest {
 
 
 		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
@@ -154,7 +154,7 @@ public class MultipleIterationsMainRunLSPMobsimTest {
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
 
-		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
 				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
@@ -103,7 +103,7 @@ public class MultipleIterationsMainRunLSPMobsimTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 
-		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
@@ -155,7 +155,7 @@ public class MultipleIterationsMainRunLSPMobsimTest {
 
 
 		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
-				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCollectionLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCollectionLSPMobsimTest.java
@@ -98,7 +98,7 @@ public class MultipleShipmentsCollectionLSPMobsimTest {
 
 		Id<LSPResource> adapterId = Id.create("CollectionCarrierResource", LSPResource.class);
 				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network);
-		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler());
+		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario));
 		adapterBuilder.setLocationLinkId(collectionLinkId);
 		LSPResource collectionResource = adapterBuilder.build();
 

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCollectionLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCollectionLSPMobsimTest.java
@@ -97,7 +97,7 @@ public class MultipleShipmentsCollectionLSPMobsimTest {
 
 
 		Id<LSPResource> adapterId = Id.create("CollectionCarrierResource", LSPResource.class);
-				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network);
+				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier);
 		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario));
 		adapterBuilder.setLocationLinkId(collectionLinkId);
 		LSPResource collectionResource = adapterBuilder.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
@@ -157,7 +157,7 @@ public class MultipleShipmentsCompleteLSPMobsimTest {
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
 
-		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
 				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
@@ -158,7 +158,7 @@ public class MultipleShipmentsCompleteLSPMobsimTest {
 
 
 		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
-				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
@@ -106,7 +106,7 @@ public class MultipleShipmentsCompleteLSPMobsimTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 
-		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
@@ -107,7 +107,7 @@ public class MultipleShipmentsCompleteLSPMobsimTest {
 
 
 		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 
@@ -208,7 +208,7 @@ public class MultipleShipmentsCompleteLSPMobsimTest {
 
 
 		LSPResource distributionResource  = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier, network)
-				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 				.setLocationLinkId(distributionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
@@ -207,7 +207,7 @@ public class MultipleShipmentsCompleteLSPMobsimTest {
 		carrier.setCarrierCapabilities(distributionCapabilities);
 
 
-		LSPResource distributionResource  = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier, network)
+		LSPResource distributionResource  = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier)
 				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 				.setLocationLinkId(distributionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstAndSecondReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstAndSecondReloadLSPMobsimTest.java
@@ -155,7 +155,7 @@ public class MultipleShipmentsFirstAndSecondReloadLSPMobsimTest {
 
 
 		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
-				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstAndSecondReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstAndSecondReloadLSPMobsimTest.java
@@ -104,7 +104,7 @@ public class MultipleShipmentsFirstAndSecondReloadLSPMobsimTest {
 
 
 		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstAndSecondReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstAndSecondReloadLSPMobsimTest.java
@@ -154,7 +154,7 @@ public class MultipleShipmentsFirstAndSecondReloadLSPMobsimTest {
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
 
-		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
 				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstAndSecondReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstAndSecondReloadLSPMobsimTest.java
@@ -103,7 +103,7 @@ public class MultipleShipmentsFirstAndSecondReloadLSPMobsimTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 
-		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstReloadLSPMobsimTest.java
@@ -99,7 +99,7 @@ public class MultipleShipmentsFirstReloadLSPMobsimTest {
 
 
 		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstReloadLSPMobsimTest.java
@@ -98,7 +98,7 @@ public class MultipleShipmentsFirstReloadLSPMobsimTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 
-		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsMainRunLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsMainRunLSPMobsimTest.java
@@ -98,7 +98,7 @@ public class MultipleShipmentsMainRunLSPMobsimTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 
-		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsMainRunLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsMainRunLSPMobsimTest.java
@@ -149,7 +149,7 @@ public class MultipleShipmentsMainRunLSPMobsimTest {
 
 
 		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
-				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsMainRunLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsMainRunLSPMobsimTest.java
@@ -148,7 +148,7 @@ public class MultipleShipmentsMainRunLSPMobsimTest {
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
 
-		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
 				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsMainRunLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsMainRunLSPMobsimTest.java
@@ -99,7 +99,7 @@ public class MultipleShipmentsMainRunLSPMobsimTest {
 
 
 		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/RepeatedMultipleShipmentsCompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/RepeatedMultipleShipmentsCompleteLSPMobsimTest.java
@@ -98,7 +98,7 @@ public class RepeatedMultipleShipmentsCompleteLSPMobsimTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 
-		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/RepeatedMultipleShipmentsCompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/RepeatedMultipleShipmentsCompleteLSPMobsimTest.java
@@ -149,7 +149,7 @@ public class RepeatedMultipleShipmentsCompleteLSPMobsimTest {
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
 
-		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
 				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/RepeatedMultipleShipmentsCompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/RepeatedMultipleShipmentsCompleteLSPMobsimTest.java
@@ -99,7 +99,7 @@ public class RepeatedMultipleShipmentsCompleteLSPMobsimTest {
 
 
 		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 
@@ -199,7 +199,7 @@ public class RepeatedMultipleShipmentsCompleteLSPMobsimTest {
 		carrier.setCarrierCapabilities(distributionCapabilities);
 
 		LSPResource distributionResource  = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier, network)
-				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 				.setLocationLinkId(distributionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/RepeatedMultipleShipmentsCompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/RepeatedMultipleShipmentsCompleteLSPMobsimTest.java
@@ -198,7 +198,7 @@ public class RepeatedMultipleShipmentsCompleteLSPMobsimTest {
 		Carrier carrier = CarriersUtils.createCarrier(distributionCarrierId);
 		carrier.setCarrierCapabilities(distributionCapabilities);
 
-		LSPResource distributionResource  = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier, network)
+		LSPResource distributionResource  = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier)
 				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 				.setLocationLinkId(distributionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/RepeatedMultipleShipmentsCompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/RepeatedMultipleShipmentsCompleteLSPMobsimTest.java
@@ -150,7 +150,7 @@ public class RepeatedMultipleShipmentsCompleteLSPMobsimTest {
 
 
 		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
-				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspPlanTests/CollectionLSPPlanTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspPlanTests/CollectionLSPPlanTest.java
@@ -75,7 +75,7 @@ public class CollectionLSPPlanTest {
 		carrier.setCarrierCapabilities(capabilities);
 
 
-		CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network);
+		CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier);
 		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario));
 		adapterBuilder.setLocationLinkId(collectionLinkId);
 

--- a/src/test/java/org/matsim/freight/logistics/lspPlanTests/CollectionLSPPlanTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspPlanTests/CollectionLSPPlanTest.java
@@ -76,7 +76,7 @@ public class CollectionLSPPlanTest {
 
 
 		CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network);
-		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler());
+		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario));
 		adapterBuilder.setLocationLinkId(collectionLinkId);
 
 

--- a/src/test/java/org/matsim/freight/logistics/lspPlanTests/CompleteLSPPlanTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspPlanTests/CompleteLSPPlanTest.java
@@ -129,7 +129,7 @@ public class CompleteLSPPlanTest {
 
 
 		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
-				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspPlanTests/CompleteLSPPlanTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspPlanTests/CompleteLSPPlanTest.java
@@ -79,7 +79,7 @@ public class CompleteLSPPlanTest {
 
 
 		Id<LSPResource> collectionResourceId = Id.create("CollectionCarrierResource", LSPResource.class);
-		final LSPResource collectionCarrierResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		final LSPResource collectionCarrierResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspPlanTests/CompleteLSPPlanTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspPlanTests/CompleteLSPPlanTest.java
@@ -128,7 +128,7 @@ public class CompleteLSPPlanTest {
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
 
-		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
 				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))

--- a/src/test/java/org/matsim/freight/logistics/lspPlanTests/CompleteLSPPlanTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspPlanTests/CompleteLSPPlanTest.java
@@ -80,7 +80,7 @@ public class CompleteLSPPlanTest {
 
 		Id<LSPResource> collectionResourceId = Id.create("CollectionCarrierResource", LSPResource.class);
 		final LSPResource collectionCarrierResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 
@@ -179,7 +179,7 @@ public class CompleteLSPPlanTest {
 
 
 		final LSPResource distributionCarrierResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier, network)
-				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 				.setLocationLinkId(distributionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/lspPlanTests/CompleteLSPPlanTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspPlanTests/CompleteLSPPlanTest.java
@@ -178,7 +178,7 @@ public class CompleteLSPPlanTest {
 		carrier.setCarrierCapabilities(distributionCapabilities);
 
 
-		final LSPResource distributionCarrierResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier, network)
+		final LSPResource distributionCarrierResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier)
 				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 				.setLocationLinkId(distributionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspShipmentAssignmentTests/CollectionLSPShipmentAssigmentTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspShipmentAssignmentTests/CollectionLSPShipmentAssigmentTest.java
@@ -80,7 +80,7 @@ public class CollectionLSPShipmentAssigmentTest {
 
 
 		Id<LSPResource> adapterId = Id.create("CollectionCarrierResource", LSPResource.class);
-				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network);
+				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier);
 		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario));
 		adapterBuilder.setLocationLinkId(collectionLinkId);
 		LSPResource collectionResource = adapterBuilder.build();

--- a/src/test/java/org/matsim/freight/logistics/lspShipmentAssignmentTests/CollectionLSPShipmentAssigmentTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspShipmentAssignmentTests/CollectionLSPShipmentAssigmentTest.java
@@ -81,7 +81,7 @@ public class CollectionLSPShipmentAssigmentTest {
 
 		Id<LSPResource> adapterId = Id.create("CollectionCarrierResource", LSPResource.class);
 				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network);
-		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler());
+		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario));
 		adapterBuilder.setLocationLinkId(collectionLinkId);
 		LSPResource collectionResource = adapterBuilder.build();
 

--- a/src/test/java/org/matsim/freight/logistics/lspShipmentAssignmentTests/CompleteLSPShipmentAssignerTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspShipmentAssignmentTests/CompleteLSPShipmentAssignerTest.java
@@ -83,7 +83,7 @@ public class CompleteLSPShipmentAssignerTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 
-		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspShipmentAssignmentTests/CompleteLSPShipmentAssignerTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspShipmentAssignmentTests/CompleteLSPShipmentAssignerTest.java
@@ -133,7 +133,7 @@ public class CompleteLSPShipmentAssignerTest {
 
 
 		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
-				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/lspShipmentAssignmentTests/CompleteLSPShipmentAssignerTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspShipmentAssignmentTests/CompleteLSPShipmentAssignerTest.java
@@ -132,7 +132,7 @@ public class CompleteLSPShipmentAssignerTest {
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
 
-		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+		LSPResource mainRunResource  = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
 				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(Id.createLinkId("(4 2) (4 3)"))
 				.setToLinkId(Id.createLinkId("(14 2) (14 3)"))

--- a/src/test/java/org/matsim/freight/logistics/lspShipmentAssignmentTests/CompleteLSPShipmentAssignerTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspShipmentAssignmentTests/CompleteLSPShipmentAssignerTest.java
@@ -84,7 +84,7 @@ public class CompleteLSPShipmentAssignerTest {
 
 
 		LSPResource collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 
@@ -182,7 +182,7 @@ public class CompleteLSPShipmentAssignerTest {
 		carrier.setCarrierCapabilities(distributionCapabilities);
 
 		LSPResource distributionResource  = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier, network)
-				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 				.setLocationLinkId(distributionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/lspShipmentAssignmentTests/CompleteLSPShipmentAssignerTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspShipmentAssignmentTests/CompleteLSPShipmentAssignerTest.java
@@ -181,7 +181,7 @@ public class CompleteLSPShipmentAssignerTest {
 		Carrier carrier = CarriersUtils.createCarrier(distributionCarrierId);
 		carrier.setCarrierCapabilities(distributionCapabilities);
 
-		LSPResource distributionResource  = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier, network)
+		LSPResource distributionResource  = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(carrier)
 				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 				.setLocationLinkId(distributionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/CollectionLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/CollectionLSPSchedulingTest.java
@@ -82,7 +82,7 @@ public class CollectionLSPSchedulingTest {
 
 
 		Id<LSPResource> adapterId = Id.create("CollectionCarrierResource", LSPResource.class);
-				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network);
+				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier);
 		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario));
 		adapterBuilder.setLocationLinkId(collectionLinkId);
 		collectionResource = adapterBuilder.build();

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/CollectionLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/CollectionLSPSchedulingTest.java
@@ -83,7 +83,7 @@ public class CollectionLSPSchedulingTest {
 
 		Id<LSPResource> adapterId = Id.create("CollectionCarrierResource", LSPResource.class);
 				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network);
-		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler());
+		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario));
 		adapterBuilder.setLocationLinkId(collectionLinkId);
 		collectionResource = adapterBuilder.build();
 

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
@@ -144,7 +144,7 @@ public class CompleteLSPSchedulingTest {
 		Carrier mainRunCarrier = CarriersUtils.createCarrier(mainRunCarrierId);
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
-		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
 				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(fromLinkId)
 				.setToLinkId(toLinkId)

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
@@ -94,7 +94,7 @@ public class CompleteLSPSchedulingTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 		collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 
@@ -194,7 +194,7 @@ public class CompleteLSPSchedulingTest {
 		distributionCarrier.setCarrierCapabilities(distributionCapabilities);
 
 		distributionResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(distributionCarrier, network)
-				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 				.setLocationLinkId(distributionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
@@ -193,7 +193,7 @@ public class CompleteLSPSchedulingTest {
 		Carrier distributionCarrier = CarriersUtils.createCarrier(distributionCarrierId);
 		distributionCarrier.setCarrierCapabilities(distributionCapabilities);
 
-		distributionResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(distributionCarrier, network)
+		distributionResource = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(distributionCarrier)
 				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 				.setLocationLinkId(distributionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
@@ -145,7 +145,7 @@ public class CompleteLSPSchedulingTest {
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
 		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
-				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(fromLinkId)
 				.setToLinkId(toLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
@@ -93,7 +93,7 @@ public class CompleteLSPSchedulingTest {
 		Carrier collectionCarrier = CarriersUtils.createCarrier(collectionCarrierId);
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
-		collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/FirstReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/FirstReloadLSPSchedulingTest.java
@@ -86,7 +86,7 @@ public class FirstReloadLSPSchedulingTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 
-		collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/FirstReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/FirstReloadLSPSchedulingTest.java
@@ -87,7 +87,7 @@ public class FirstReloadLSPSchedulingTest {
 
 
 		collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MainRunLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MainRunLSPSchedulingTest.java
@@ -87,7 +87,7 @@ public class MainRunLSPSchedulingTest {
 		Carrier collectionCarrier = CarriersUtils.createCarrier(collectionCarrierId);
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
-		collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MainRunLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MainRunLSPSchedulingTest.java
@@ -88,7 +88,7 @@ public class MainRunLSPSchedulingTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 		collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MainRunLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MainRunLSPSchedulingTest.java
@@ -136,7 +136,7 @@ public class MainRunLSPSchedulingTest {
 		Carrier mainRunCarrier = CarriersUtils.createCarrier(mainRunCarrierId);
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
-		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
 				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(fromLinkId)
 				.setToLinkId(toLinkId)

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MainRunLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MainRunLSPSchedulingTest.java
@@ -137,7 +137,7 @@ public class MainRunLSPSchedulingTest {
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
 		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
-				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(fromLinkId)
 				.setToLinkId(toLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCollectionLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCollectionLSPSchedulingTest.java
@@ -84,7 +84,7 @@ public class MultipleShipmentsCollectionLSPSchedulingTest {
 
 
 		Id<LSPResource> adapterId = Id.create("CollectionCarrierResource", LSPResource.class);
-				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network);
+				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier);
 		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario));
 		adapterBuilder.setLocationLinkId(collectionLinkId);
 		collectionResource = adapterBuilder.build();

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCollectionLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCollectionLSPSchedulingTest.java
@@ -85,7 +85,7 @@ public class MultipleShipmentsCollectionLSPSchedulingTest {
 
 		Id<LSPResource> adapterId = Id.create("CollectionCarrierResource", LSPResource.class);
 				CollectionCarrierResourceBuilder adapterBuilder = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(carrier, network);
-		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler());
+		adapterBuilder.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario));
 		adapterBuilder.setLocationLinkId(collectionLinkId);
 		collectionResource = adapterBuilder.build();
 

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
@@ -94,7 +94,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 
-		collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
@@ -95,7 +95,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 
 
 		collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 
@@ -197,7 +197,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 
 
 		distributionResource  = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(distributionCarrier, network)
-				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler())
+				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 				.setLocationLinkId(distributionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
@@ -147,7 +147,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 
 
 		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
-				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(fromLinkId)
 				.setToLinkId(toLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
@@ -196,7 +196,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 		distributionCarrier.setCarrierCapabilities(distributionCapabilities);
 
 
-		distributionResource  = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(distributionCarrier, network)
+		distributionResource  = ResourceImplementationUtils.DistributionCarrierResourceBuilder.newInstance(distributionCarrier)
 				.setDistributionScheduler(ResourceImplementationUtils.createDefaultDistributionCarrierScheduler(scenario))
 				.setLocationLinkId(distributionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
@@ -146,7 +146,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
 
-		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
 				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(fromLinkId)
 				.setToLinkId(toLinkId)

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsFirstReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsFirstReloadLSPSchedulingTest.java
@@ -86,7 +86,7 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 		collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsFirstReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsFirstReloadLSPSchedulingTest.java
@@ -85,7 +85,7 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 		Carrier collectionCarrier = CarriersUtils.createCarrier(collectionCarrierId);
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
-		collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsMainRunLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsMainRunLSPSchedulingTest.java
@@ -136,7 +136,7 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 		Carrier mainRunCarrier = CarriersUtils.createCarrier(mainRunCarrierId);
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
-		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
 				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(fromLinkId)
 				.setToLinkId(toLinkId)

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsMainRunLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsMainRunLSPSchedulingTest.java
@@ -137,7 +137,7 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
 		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
-				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(fromLinkId)
 				.setToLinkId(toLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsMainRunLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsMainRunLSPSchedulingTest.java
@@ -87,7 +87,7 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 		Carrier collectionCarrier = CarriersUtils.createCarrier(collectionCarrierId);
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
-		collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsMainRunLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsMainRunLSPSchedulingTest.java
@@ -88,7 +88,7 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 		collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsSecondReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsSecondReloadLSPSchedulingTest.java
@@ -93,7 +93,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 
 
 		collectionResource  = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsSecondReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsSecondReloadLSPSchedulingTest.java
@@ -145,7 +145,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 
 
 		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
-				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(fromLinkId)
 				.setToLinkId(Id.createLinkId(toLinkId))
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsSecondReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsSecondReloadLSPSchedulingTest.java
@@ -144,7 +144,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
 
-		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
 				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(fromLinkId)
 				.setToLinkId(Id.createLinkId(toLinkId))

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsSecondReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsSecondReloadLSPSchedulingTest.java
@@ -92,7 +92,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 
-		collectionResource  = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		collectionResource  = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/SecondReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/SecondReloadLSPSchedulingTest.java
@@ -145,7 +145,7 @@ public class SecondReloadLSPSchedulingTest {
 
 
 		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
-				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler())
+				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(fromLinkId)
 				.setToLinkId(Id.createLinkId(toLinkId))
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/SecondReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/SecondReloadLSPSchedulingTest.java
@@ -92,7 +92,7 @@ public class SecondReloadLSPSchedulingTest {
 		collectionCarrier.setCarrierCapabilities(collectionCapabilities);
 
 
-		collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
+		collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier)
 				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/SecondReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/SecondReloadLSPSchedulingTest.java
@@ -93,7 +93,7 @@ public class SecondReloadLSPSchedulingTest {
 
 
 		collectionResource = ResourceImplementationUtils.CollectionCarrierResourceBuilder.newInstance(collectionCarrier, network)
-				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler())
+				.setCollectionScheduler(ResourceImplementationUtils.createDefaultCollectionCarrierScheduler(scenario))
 				.setLocationLinkId(collectionLinkId)
 				.build();
 

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/SecondReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/SecondReloadLSPSchedulingTest.java
@@ -144,7 +144,7 @@ public class SecondReloadLSPSchedulingTest {
 		mainRunCarrier.setCarrierCapabilities(mainRunCapabilities);
 
 
-		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier, network)
+		mainRunResource = ResourceImplementationUtils.MainRunCarrierResourceBuilder.newInstance(mainRunCarrier)
 				.setMainRunCarrierScheduler(ResourceImplementationUtils.createDefaultMainRunCarrierScheduler(scenario))
 				.setFromLinkId(fromLinkId)
 				.setToLinkId(Id.createLinkId(toLinkId))


### PR DESCRIPTION
... and get from there the network, roadPricingScheme, .... instead of handing over all these things separately.

This is also a necessary step, to get the settings, whetere the VRP shpuld be based on Services (as it is now) or on Shipments. This behavior should be settable (see #44).

In the future, it would be better getting the scenario from injection.... this is just a workaround / small improvement.

