### PR TITLE
Renamings; small step forward for VrPLogic

### DIFF
--- a/src/main/java/org/matsim/freight/logistics/ForwardLogisticChainSchedulerImpl.java
+++ b/src/main/java/org/matsim/freight/logistics/ForwardLogisticChainSchedulerImpl.java
@@ -22,7 +22,7 @@ package org.matsim.freight.logistics;
 
 import java.util.ArrayList;
 import org.matsim.api.core.v01.Id;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /**
  * .... Macht 3 Schritte: 1.) the LSPShipments are handed over to the first {@link
@@ -131,7 +131,7 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
     for (LogisticChain solution : lsp.getSelectedPlan().getLogisticChains()) {
       LogisticChainElement firstElement = getFirstElement(solution);
       assert firstElement != null;
-      for (Id<LSPShipment> lspShipmentId : solution.getLspShipmentIds()) {
+      for (Id<LspShipment> lspShipmentId : solution.getLspShipmentIds()) {
         var shipment = LSPUtils.findLspShipment(lsp, lspShipmentId);
         assert shipment != null;
         firstElement

--- a/src/main/java/org/matsim/freight/logistics/FreightLogisticsConfigGroup.java
+++ b/src/main/java/org/matsim/freight/logistics/FreightLogisticsConfigGroup.java
@@ -35,22 +35,6 @@ public class FreightLogisticsConfigGroup extends ReflectiveConfigGroup {
     static final String LSPS_FILE = "lspsFile";
     private static final String LSPS_FILE_DESC = "Freight LogisticsServiceProviders (LSP)s File, according to MATSim logistics extension as part of MATSim's freight contrib.";
 
-
-    public enum LogicOfVrp {serviceBased, shipmentBased}
-
-    static final String VRP_LOGIC_OF_DISTRIBUTION_CARRIER = "vrpLogicOfDistributionCarrier";
-    private LogicOfVrp vrpLogicOfDistributionCarrier = LogicOfVrp.serviceBased;
-    private static final String VRP_LOGIC_OF_DISTRIBUTION_CARRIER_DESC = "Define, on which type of jobs the VRP of the **distribution** carrier will base on:" + Arrays.toString(LogicOfVrp.values());
-
-    static final String VRP_LOGIC_OF_MAINRUN_CARRIER = "vrpLogicOfMainRunCarrier";
-    private LogicOfVrp vrpLogicOfMainRunCarrier = LogicOfVrp.serviceBased;
-    private static final String VRP_LOGIC_OF_MAINRUN_CARRIER_DESC = "Define, on which type of jobs the VRP of the **MainRun** carrier will base on:" + Arrays.toString(LogicOfVrp.values());
-
-    static final String VRP_LOGIC_OF_COLLECTION_CARRIER = "vrpLogicOfCollectionCarrier";
-    private LogicOfVrp vrpLogicOfCollectionCarrier = LogicOfVrp.serviceBased;
-    private static final String VRP_LOGIC_OF_COLLECTION_CARRIER_DESC = "Define, on which type of jobs the VRP of the **Collection** carrier will base on:" + Arrays.toString(LogicOfVrp.values());
-
-
     public FreightLogisticsConfigGroup() {
         super(GROUPNAME);
     }
@@ -79,56 +63,70 @@ public class FreightLogisticsConfigGroup extends ReflectiveConfigGroup {
 
 
     //---
+    // Commenting this out, because in a frist step I think it is better/ more streight forward to have the VRP logic in the carriers as an attribute.
+    // please see {@link CarrierSchedulerUtils#setVrpLogic(carrier, VRPLogic)} and {@link CarrierSchedulerUtils#getVrpLogic(carrier)}
     //---
 
-    /**
-     *
-     * @return The internal type of jobs, on which the VRPs of the distribution carrier bases on.
-     */
-    @StringGetter(VRP_LOGIC_OF_DISTRIBUTION_CARRIER)
-    public LogicOfVrp getVrpLogicOfDistributionCarrier() {
-        return vrpLogicOfDistributionCarrier;
-    }
-
-    /**
-     * @param vrpLogicOfDistributionCarrier {@value #VRP_LOGIC_OF_DISTRIBUTION_CARRIER}
-     */
-    @StringSetter(VRP_LOGIC_OF_DISTRIBUTION_CARRIER)
-    public void setVrpLogicOfDistributionCarrier(LogicOfVrp vrpLogicOfDistributionCarrier) {
-        this.vrpLogicOfDistributionCarrier = vrpLogicOfDistributionCarrier;
-    }
-
-    /**
-     * @return The internal type of jobs, on which the VRPs of the main run carrier bases on.
-     */
-    @StringGetter(FreightLogisticsConfigGroup.VRP_LOGIC_OF_MAINRUN_CARRIER)
-    public LogicOfVrp getVrpLogicOfMainRunCarrier() {
-        return vrpLogicOfMainRunCarrier;
-    }
-
-    /**
-     * @param vrpLogicOfMainRunCarrier {@value #VRP_LOGIC_OF_MAINRUN_CARRIER}
-     */
-    @StringSetter(FreightLogisticsConfigGroup.VRP_LOGIC_OF_MAINRUN_CARRIER)
-    public void setVrpLogicOfMainRunCarrier(LogicOfVrp vrpLogicOfMainRunCarrier) {
-        this.vrpLogicOfMainRunCarrier = vrpLogicOfMainRunCarrier;
-    }
-
-    /**
-     * @return The internal type of jobs, on which the VRPs of the collection carrier bases on.
-     */
-    @StringGetter(FreightLogisticsConfigGroup.VRP_LOGIC_OF_COLLECTION_CARRIER)
-    public LogicOfVrp getVrpLogicOfCollectionCarrier() {
-        return vrpLogicOfCollectionCarrier;
-    }
-
-    /**
-     * @param vrpLogicOfCollectionCarrier {@value #VRP_LOGIC_OF_COLLECTION_CARRIER}
-     */
-    @StringSetter(FreightLogisticsConfigGroup.VRP_LOGIC_OF_COLLECTION_CARRIER)
-    public void setVrpLogicOfCollectionCarrier(LogicOfVrp vrpLogicOfCollectionCarrier) {
-        this.vrpLogicOfCollectionCarrier = vrpLogicOfCollectionCarrier;
-    }
+//    static final String VRP_LOGIC_OF_DISTRIBUTION_CARRIER = "vrpLogicOfDistributionCarrier";
+//    private LSPUtils.LogicOfVrp vrpLogicOfDistributionCarrier = LSPUtils.LogicOfVrp.serviceBased;
+//    private static final String VRP_LOGIC_OF_DISTRIBUTION_CARRIER_DESC = "Define, on which type of jobs the VRP of the **distribution** carrier will base on:" + Arrays.toString(LSPUtils.LogicOfVrp.values());
+//
+//    static final String VRP_LOGIC_OF_MAINRUN_CARRIER = "vrpLogicOfMainRunCarrier";
+//    private LSPUtils.LogicOfVrp vrpLogicOfMainRunCarrier = LSPUtils.LogicOfVrp.serviceBased;
+//    private static final String VRP_LOGIC_OF_MAINRUN_CARRIER_DESC = "Define, on which type of jobs the VRP of the **MainRun** carrier will base on:" + Arrays.toString(LSPUtils.LogicOfVrp.values());
+//
+//    static final String VRP_LOGIC_OF_COLLECTION_CARRIER = "vrpLogicOfCollectionCarrier";
+//    private LSPUtils.LogicOfVrp vrpLogicOfCollectionCarrier = LSPUtils.LogicOfVrp.serviceBased;
+//    private static final String VRP_LOGIC_OF_COLLECTION_CARRIER_DESC = "Define, on which type of jobs the VRP of the **Collection** carrier will base on:" + Arrays.toString(LSPUtils.LogicOfVrp.values());
+//
+//    /**
+//     *
+//     * @return The internal type of jobs, on which the VRPs of the distribution carrier bases on.
+//     */
+//    @StringGetter(VRP_LOGIC_OF_DISTRIBUTION_CARRIER)
+//    public LSPUtils.LogicOfVrp getVrpLogicOfDistributionCarrier() {
+//        return vrpLogicOfDistributionCarrier;
+//    }
+//
+//    /**
+//     * @param vrpLogicOfDistributionCarrier {@value #VRP_LOGIC_OF_DISTRIBUTION_CARRIER}
+//     */
+//    @StringSetter(VRP_LOGIC_OF_DISTRIBUTION_CARRIER)
+//    public void setVrpLogicOfDistributionCarrier(LSPUtils.LogicOfVrp vrpLogicOfDistributionCarrier) {
+//        this.vrpLogicOfDistributionCarrier = vrpLogicOfDistributionCarrier;
+//    }
+//
+//    /**
+//     * @return The internal type of jobs, on which the VRPs of the main run carrier bases on.
+//     */
+//    @StringGetter(FreightLogisticsConfigGroup.VRP_LOGIC_OF_MAINRUN_CARRIER)
+//    public LSPUtils.LogicOfVrp getVrpLogicOfMainRunCarrier() {
+//        return vrpLogicOfMainRunCarrier;
+//    }
+//
+//    /**
+//     * @param vrpLogicOfMainRunCarrier {@value #VRP_LOGIC_OF_MAINRUN_CARRIER}
+//     */
+//    @StringSetter(FreightLogisticsConfigGroup.VRP_LOGIC_OF_MAINRUN_CARRIER)
+//    public void setVrpLogicOfMainRunCarrier(LSPUtils.LogicOfVrp vrpLogicOfMainRunCarrier) {
+//        this.vrpLogicOfMainRunCarrier = vrpLogicOfMainRunCarrier;
+//    }
+//
+//    /**
+//     * @return The internal type of jobs, on which the VRPs of the collection carrier bases on.
+//     */
+//    @StringGetter(FreightLogisticsConfigGroup.VRP_LOGIC_OF_COLLECTION_CARRIER)
+//    public LSPUtils.LogicOfVrp getVrpLogicOfCollectionCarrier() {
+//        return vrpLogicOfCollectionCarrier;
+//    }
+//
+//    /**
+//     * @param vrpLogicOfCollectionCarrier {@value #VRP_LOGIC_OF_COLLECTION_CARRIER}
+//     */
+//    @StringSetter(FreightLogisticsConfigGroup.VRP_LOGIC_OF_COLLECTION_CARRIER)
+//    public void setVrpLogicOfCollectionCarrier(LSPUtils.LogicOfVrp vrpLogicOfCollectionCarrier) {
+//        this.vrpLogicOfCollectionCarrier = vrpLogicOfCollectionCarrier;
+//    }
 
     //---
     //---
@@ -136,9 +134,9 @@ public class FreightLogisticsConfigGroup extends ReflectiveConfigGroup {
     public Map<String, String> getComments() {
         Map<String, String> map = super.getComments();
         map.put(LSPS_FILE, LSPS_FILE_DESC);
-        map.put(VRP_LOGIC_OF_DISTRIBUTION_CARRIER, VRP_LOGIC_OF_DISTRIBUTION_CARRIER_DESC);
-        map.put(VRP_LOGIC_OF_MAINRUN_CARRIER, VRP_LOGIC_OF_MAINRUN_CARRIER_DESC);
-        map.put(VRP_LOGIC_OF_COLLECTION_CARRIER, VRP_LOGIC_OF_COLLECTION_CARRIER_DESC);
+//        map.put(VRP_LOGIC_OF_DISTRIBUTION_CARRIER, VRP_LOGIC_OF_DISTRIBUTION_CARRIER_DESC);
+//        map.put(VRP_LOGIC_OF_MAINRUN_CARRIER, VRP_LOGIC_OF_MAINRUN_CARRIER_DESC);
+//        map.put(VRP_LOGIC_OF_COLLECTION_CARRIER, VRP_LOGIC_OF_COLLECTION_CARRIER_DESC);
         return map;
     }
 

--- a/src/main/java/org/matsim/freight/logistics/HasLspShipmentId.java
+++ b/src/main/java/org/matsim/freight/logistics/HasLspShipmentId.java
@@ -19,7 +19,7 @@
 package org.matsim.freight.logistics;
 
 import org.matsim.api.core.v01.Id;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /**
  * @author Kai Martins-Turner (kturner)
@@ -28,5 +28,5 @@ public interface HasLspShipmentId {
 
   String ATTRIBUTE_LSP_SHIPMENT_ID = "lspShipmentId";
 
-  Id<LSPShipment> getLspShipmentId();
+  Id<LspShipment> getLspShipmentId();
 }

--- a/src/main/java/org/matsim/freight/logistics/InitialShipmentAssigner.java
+++ b/src/main/java/org/matsim/freight/logistics/InitialShipmentAssigner.java
@@ -20,24 +20,24 @@
 
 package org.matsim.freight.logistics;
 
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /**
- * Takes an {@link LSPShipment} and normally assigns it to something that belongs to an {@link LSP}.
+ * Takes an {@link LspShipment} and normally assigns it to something that belongs to an {@link LSP}.
  * <br>
  * After changes in fall 2023 (see master thesis of nrichter), the assingment is
  * there to be done one time initially.
  * <br>
  * If there are several {@link LogisticChain}s in a {@link LSPPlan}, the {@link LSP} has to assign each {@link
- * LSPShipment} to the suitable {@link LogisticChain}. For this purpose, each {@link LSPPlan}
+ * LspShipment} to the suitable {@link LogisticChain}. For this purpose, each {@link LSPPlan}
  * (or only the LSP? - kmt'jan'24), contains a pluggable strategy
  * that is contained in classes implementing the interface {@link InitialShipmentAssigner}. <br>
  * <br>
- * During iterations, it can happen that the {@link LSPShipment} should be moved to another
+ * During iterations, it can happen that the {@link LspShipment} should be moved to another
  * {@link LogisticChain} of the same {@link LSPPlan}. This is now (since fall 2023; see master
  * thesis of nrichter) part of the (innovative) **Replanning** strategies.
  */
 public interface InitialShipmentAssigner {
 
-  void assignToPlan(LSPPlan lspPlan, LSPShipment lspShipment);
+  void assignToPlan(LSPPlan lspPlan, LspShipment lspShipment);
 }

--- a/src/main/java/org/matsim/freight/logistics/LSP.java
+++ b/src/main/java/org/matsim/freight/logistics/LSP.java
@@ -22,11 +22,11 @@ package org.matsim.freight.logistics;
 
 import java.util.Collection;
 import org.matsim.api.core.v01.population.HasPlansAndId;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /**
  * In the class library, the interface LSP has the following tasks: 1. Maintain one or several
- * transport chains through which {@link LSPShipment}s are routed. 2. Assign {@link LSPShipment}s to
+ * transport chains through which {@link LspShipment}s are routed. 2. Assign {@link LspShipment}s to
  * the suitable transport chain. --> {@link InitialShipmentAssigner}. 3. Interact with the agents that
  * embody the demand side of the freight transport market, if they are specified in the setting. 4.
  * Coordinate carriers that are in charge of the physical transport.
@@ -34,7 +34,7 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
 public interface LSP extends HasPlansAndId<LSPPlan, LSP>, HasSimulationTrackers<LSP> {
 
   /** yyyy does this have to be exposed? */
-  Collection<LSPShipment> getLspShipments();
+  Collection<LspShipment> getLspShipments();
 
   /** ok (behavioral method) */
   void scheduleLogisticChains();
@@ -48,6 +48,6 @@ public interface LSP extends HasPlansAndId<LSPPlan, LSP>, HasSimulationTrackers<
   /**
    * @param lspShipment ok (LSP needs to be told that it is responsible for lspShipment)
    */
-  void assignShipmentToLSP(LSPShipment lspShipment);
+  void assignShipmentToLSP(LspShipment lspShipment);
 
 }

--- a/src/main/java/org/matsim/freight/logistics/LSPControlerListener.java
+++ b/src/main/java/org/matsim/freight/logistics/LSPControlerListener.java
@@ -43,7 +43,7 @@ import org.matsim.freight.carriers.Carriers;
 import org.matsim.freight.carriers.CarriersUtils;
 import org.matsim.freight.carriers.controler.CarrierAgentTracker;
 import org.matsim.freight.logistics.io.LSPPlanXmlWriter;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 class LSPControlerListener
     implements StartupListener,
@@ -134,7 +134,7 @@ class LSPControlerListener
       }
 
       // simulation trackers of shipments:
-      for (LSPShipment lspShipment : lsp.getLspShipments()) {
+      for (LspShipment lspShipment : lsp.getLspShipments()) {
         registerSimulationTrackers(lspShipment);
       }
 

--- a/src/main/java/org/matsim/freight/logistics/LSPImpl.java
+++ b/src/main/java/org/matsim/freight/logistics/LSPImpl.java
@@ -25,12 +25,12 @@ import java.util.Collection;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /* package-private */ class LSPImpl extends LSPDataObject<LSP> implements LSP {
   private static final Logger log = LogManager.getLogger(LSPImpl.class);
 
-  private final Collection<LSPShipment> lspShipments;
+  private final Collection<LspShipment> lspShipments;
   private final ArrayList<LSPPlan> lspPlans;
   private final LogisticChainScheduler logisticChainScheduler;
   private final Collection<LSPResource> resources;
@@ -147,7 +147,7 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
   }
 
   @Override
-  public void assignShipmentToLSP(LSPShipment lspShipment) {
+  public void assignShipmentToLSP(LspShipment lspShipment) {
     //		shipment.setLspId(this.getId()); // und rückweg dann auch darüber und dann
     // lsp.getselectedPlan.getShipment...
     lspShipments.add(lspShipment);
@@ -157,7 +157,7 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
   }
 
   @Override
-  public Collection<LSPShipment> getLspShipments() {
+  public Collection<LspShipment> getLspShipments() {
     return this.lspShipments;
   }
 }

--- a/src/main/java/org/matsim/freight/logistics/LSPPlan.java
+++ b/src/main/java/org/matsim/freight/logistics/LSPPlan.java
@@ -22,8 +22,8 @@ package org.matsim.freight.logistics;
 
 import java.util.Collection;
 import org.matsim.api.core.v01.population.BasicPlan;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlan;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlan;
 
 /**
  * This interface has the following properties:
@@ -31,7 +31,7 @@ import org.matsim.freight.logistics.shipment.ShipmentPlan;
  * <ul>
  *   <li>As a {@link BasicPlan} it has a score, so it can be used for evolutionary learning. kai,
  *       may'22
- *   <li>An {@link LSPShipment} is added via lspPlan#getAssigner().assignToSolution(shipment). The
+ *   <li>An {@link LspShipment} is added via lspPlan#getAssigner().assignToSolution(shipment). The
  *       {@link InitialShipmentAssigner} assigns it deterministically to a {@link LogisticChain}.
  * </ul>
  */
@@ -49,9 +49,9 @@ public interface LSPPlan extends BasicPlan, KnowsLSP {
 
   LSPPlan setInitialShipmentAssigner(InitialShipmentAssigner assigner);
 
-  Collection<ShipmentPlan> getShipmentPlans();
+  Collection<LspShipmentPlan> getShipmentPlans();
 
-  LSPPlan addShipmentPlan(ShipmentPlan shipmentPlan);
+  LSPPlan addShipmentPlan(LspShipmentPlan lspShipmentPlan);
 
   String getType();
 

--- a/src/main/java/org/matsim/freight/logistics/LSPPlanImpl.java
+++ b/src/main/java/org/matsim/freight/logistics/LSPPlanImpl.java
@@ -22,12 +22,12 @@ package org.matsim.freight.logistics;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import org.matsim.freight.logistics.shipment.ShipmentPlan;
+import org.matsim.freight.logistics.shipment.LspShipmentPlan;
 
 public class LSPPlanImpl implements LSPPlan {
 
   private final Collection<LogisticChain> logisticChains;
-  private final Collection<ShipmentPlan> shipmentPlans;
+  private final Collection<LspShipmentPlan> lspShipmentPlans;
   private LSP lsp;
   private Double score = null;
   private InitialShipmentAssigner assigner;
@@ -35,7 +35,7 @@ public class LSPPlanImpl implements LSPPlan {
 
   public LSPPlanImpl() {
     this.logisticChains = new ArrayList<>();
-    this.shipmentPlans = new ArrayList<>();
+    this.lspShipmentPlans = new ArrayList<>();
   }
 
   @Override
@@ -62,13 +62,13 @@ public class LSPPlanImpl implements LSPPlan {
   }
 
   @Override
-  public Collection<ShipmentPlan> getShipmentPlans() {
-    return this.shipmentPlans;
+  public Collection<LspShipmentPlan> getShipmentPlans() {
+    return this.lspShipmentPlans;
   }
 
   @Override
-  public LSPPlan addShipmentPlan(ShipmentPlan shipmentPlan) {
-    this.shipmentPlans.add(shipmentPlan);
+  public LSPPlan addShipmentPlan(LspShipmentPlan lspShipmentPlan) {
+    this.lspShipmentPlans.add(lspShipmentPlan);
     return null;
   }
 

--- a/src/main/java/org/matsim/freight/logistics/LSPResourceScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/LSPResourceScheduler.java
@@ -22,8 +22,8 @@ package org.matsim.freight.logistics;
 
 import java.util.ArrayList;
 import java.util.Comparator;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 
 /**
  * Resources are scheduled separately by calling their individual scheduling algorithm.
@@ -71,9 +71,9 @@ public abstract class LSPResourceScheduler {
   protected abstract void scheduleResource();
 
   /**
-   * Endows the involved {@link LSPShipment}s with information that resulted from the scheduling in
+   * Endows the involved {@link LspShipment}s with information that resulted from the scheduling in
    * a narrow sense in scheduleResource(). The information can be divided into two main components.
-   * 1.) the schedule of the {@link LSPShipment}s is updated if necessary 2.) the information for a
+   * 1.) the schedule of the {@link LspShipment}s is updated if necessary 2.) the information for a
    * later logging of the is added.
    */
   protected abstract void updateShipments();
@@ -89,7 +89,7 @@ public abstract class LSPResourceScheduler {
   private void switchHandledShipments(int bufferTime) {
     for (LspShipmentWithTime lspShipmentWithTime : lspShipmentsWithTime) {
       var shipmentPlan =
-          ShipmentUtils.getOrCreateShipmentPlan(lspPlan, lspShipmentWithTime.getLspShipment().getId());
+          LspShipmentUtils.getOrCreateShipmentPlan(lspPlan, lspShipmentWithTime.getLspShipment().getId());
       double endOfTransportTime = shipmentPlan.getMostRecentEntry().getEndTime() + bufferTime;
       LspShipmentWithTime outgoingTuple =
           new LspShipmentWithTime(endOfTransportTime, lspShipmentWithTime.getLspShipment());

--- a/src/main/java/org/matsim/freight/logistics/LSPUtils.java
+++ b/src/main/java/org/matsim/freight/logistics/LSPUtils.java
@@ -144,7 +144,9 @@ public final class LSPUtils {
     return null;
   }
 
-  public static final class LSPBuilder {
+    public enum LogicOfVrp {serviceBased, shipmentBased}
+
+    public static final class LSPBuilder {
     final Collection<LSPResource> resources;
     final Id<LSP> id;
     LogisticChainScheduler logisticChainScheduler;

--- a/src/main/java/org/matsim/freight/logistics/LSPUtils.java
+++ b/src/main/java/org/matsim/freight/logistics/LSPUtils.java
@@ -26,8 +26,8 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.freight.carriers.Carriers;
 import org.matsim.freight.carriers.CarriersUtils;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlan;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlan;
 import org.matsim.utils.objectattributes.attributable.Attributable;
 
 public final class LSPUtils {
@@ -113,14 +113,14 @@ public final class LSPUtils {
   }
 
   /**
-   * Gives back the {@link LSPShipment} object of the {@link LSP}, which matches to the shipmentId
+   * Gives back the {@link LspShipment} object of the {@link LSP}, which matches to the shipmentId
    *
    * @param lsp In this LSP this method tries to find the shipment.
    * @param shipmentId Id of the shipment that should be found.
    * @return the lspShipment object or null, if it is not found.
    */
-  public static LSPShipment findLspShipment(LSP lsp, Id<LSPShipment> shipmentId) {
-    for (LSPShipment lspShipment : lsp.getLspShipments()) {
+  public static LspShipment findLspShipment(LSP lsp, Id<LspShipment> shipmentId) {
+    for (LspShipment lspShipment : lsp.getLspShipments()) {
       if (lspShipment.getId().equals(shipmentId)) {
         return lspShipment;
       }
@@ -129,16 +129,16 @@ public final class LSPUtils {
   }
 
   /**
-   * Returns the {@link ShipmentPlan} of an {@link LSPShipment}.
+   * Returns the {@link LspShipmentPlan} of an {@link LspShipment}.
    *
    * @param lspPlan the lspPlan: It contains the information of its shipmentPlans
    * @param shipmentId Id of the shipment that should be found.
    * @return the shipmentPlan object or null, if it is not found.
    */
-  public static ShipmentPlan findLspShipmentPlan(LSPPlan lspPlan, Id<LSPShipment> shipmentId) {
-    for (ShipmentPlan shipmentPlan : lspPlan.getShipmentPlans()) {
-      if (shipmentPlan.getLspShipmentId().equals(shipmentId)) {
-        return shipmentPlan;
+  public static LspShipmentPlan findLspShipmentPlan(LSPPlan lspPlan, Id<LspShipment> shipmentId) {
+    for (LspShipmentPlan lspShipmentPlan : lspPlan.getShipmentPlans()) {
+      if (lspShipmentPlan.getLspShipmentId().equals(shipmentId)) {
+        return lspShipmentPlan;
       }
     }
     return null;

--- a/src/main/java/org/matsim/freight/logistics/LogisticChain.java
+++ b/src/main/java/org/matsim/freight/logistics/LogisticChain.java
@@ -23,7 +23,7 @@ package org.matsim.freight.logistics;
 import java.util.Collection;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Identifiable;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 import org.matsim.utils.objectattributes.attributable.Attributable;
 
 /**
@@ -42,7 +42,7 @@ public interface LogisticChain
 
   Collection<LogisticChainElement> getLogisticChainElements();
 
-  Collection<Id<LSPShipment>> getLspShipmentIds();
+  Collection<Id<LspShipment>> getLspShipmentIds();
 
-  void addShipmentToChain(LSPShipment lspShipment);
+  void addShipmentToChain(LspShipment lspShipment);
 }

--- a/src/main/java/org/matsim/freight/logistics/LogisticChainImpl.java
+++ b/src/main/java/org/matsim/freight/logistics/LogisticChainImpl.java
@@ -25,14 +25,14 @@ import java.util.Collection;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /* package-private */ class LogisticChainImpl extends LSPDataObject<LogisticChain>
     implements LogisticChain {
   private static final Logger log = LogManager.getLogger(LogisticChainImpl.class);
 
   private final Collection<LogisticChainElement> logisticChainElements;
-  private final Collection<Id<LSPShipment>> lspShipmentIds;
+  private final Collection<Id<LspShipment>> lspShipmentIds;
   private LSP lsp;
 
   LogisticChainImpl(LSPUtils.LogisticChainBuilder builder) {
@@ -60,12 +60,12 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
   }
 
   @Override
-  public Collection<Id<LSPShipment>> getLspShipmentIds() {
+  public Collection<Id<LspShipment>> getLspShipmentIds() {
     return lspShipmentIds;
   }
 
   @Override
-  public void addShipmentToChain(LSPShipment lspShipment) {
+  public void addShipmentToChain(LspShipment lspShipment) {
     lspShipmentIds.add(lspShipment.getId());
   }
 
@@ -86,7 +86,7 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
     strb.append("[No of Shipments=").append(lspShipmentIds.size()).append("] \n");
     if (!lspShipmentIds.isEmpty()) {
       strb.append("{ShipmentIds=");
-      for (Id<LSPShipment> lspShipmentId : lspShipmentIds) {
+      for (Id<LspShipment> lspShipmentId : lspShipmentIds) {
         strb.append("[").append(lspShipmentId.toString()).append("]");
       }
       strb.append("}");

--- a/src/main/java/org/matsim/freight/logistics/LogisticChainScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/LogisticChainScheduler.java
@@ -20,8 +20,10 @@
 
 package org.matsim.freight.logistics;
 
+import org.matsim.freight.logistics.shipment.LspShipment;
+
 /**
- * Serve the purpose of routing a set of {@link org.matsim.freight.logistics.shipment.LSPShipment}s
+ * Serve the purpose of routing a set of {@link LspShipment}s
  * through a set of {@link LogisticChain}s, which, in turn, consist of several {@link
  * LogisticChainElement}s and the corresponding {@link LSPResource}s.
  */

--- a/src/main/java/org/matsim/freight/logistics/LspShipmentWithTime.java
+++ b/src/main/java/org/matsim/freight/logistics/LspShipmentWithTime.java
@@ -20,7 +20,7 @@
 
 package org.matsim.freight.logistics;
 
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 public class LspShipmentWithTime {
   // yyyyyy find better solution for this.  It is not so good to define an interface, and then
@@ -29,15 +29,15 @@ public class LspShipmentWithTime {
   // means (delivery time?  current time?).  kai,
   // jun'22
 
-  private final LSPShipment lspShipment;
+  private final LspShipment lspShipment;
   private final double time;
 
-  public LspShipmentWithTime(double time, LSPShipment lspShipment) {
+  public LspShipmentWithTime(double time, LspShipment lspShipment) {
     this.lspShipment = lspShipment;
     this.time = time;
   }
 
-  public LSPShipment getLspShipment() {
+  public LspShipment getLspShipment() {
     return lspShipment;
   }
 

--- a/src/main/java/org/matsim/freight/logistics/WaitingShipments.java
+++ b/src/main/java/org/matsim/freight/logistics/WaitingShipments.java
@@ -21,7 +21,7 @@
 package org.matsim.freight.logistics;
 
 import java.util.Collection;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /**
  * Each LogisticsSolutionElement maintains two collections of WaitingShipments. Instances of the
@@ -41,7 +41,7 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
  */
 public interface WaitingShipments {
 
-  void addShipment(double time, LSPShipment lspShipment);
+  void addShipment(double time, LspShipment lspShipment);
 
   Collection<LspShipmentWithTime> getSortedLspShipments();
 

--- a/src/main/java/org/matsim/freight/logistics/WaitingShipmentsImpl.java
+++ b/src/main/java/org/matsim/freight/logistics/WaitingShipmentsImpl.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /* package-private */ class WaitingShipmentsImpl implements WaitingShipments {
 
@@ -35,7 +35,7 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
   }
 
   @Override
-  public void addShipment(double time, LSPShipment lspShipment) {
+  public void addShipment(double time, LspShipment lspShipment) {
     LspShipmentWithTime tuple = new LspShipmentWithTime(time, lspShipment);
     this.shipments.add(tuple);
     shipments.sort(Comparator.comparingDouble(LspShipmentWithTime::getTime));

--- a/src/main/java/org/matsim/freight/logistics/events/AbstractLogisticEvent.java
+++ b/src/main/java/org/matsim/freight/logistics/events/AbstractLogisticEvent.java
@@ -6,11 +6,11 @@ import org.matsim.api.core.v01.events.Event;
 import org.matsim.api.core.v01.events.HasLinkId;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.freight.logistics.HasLspShipmentId;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /**
  * A general logistic event contains the information (= {@link Id}) of the - the location (= {@link
- * Link}) - the lspShipment (= {@link LSPShipment}) belonging to it.
+ * Link}) - the lspShipment (= {@link LspShipment}) belonging to it.
  *
  * <p>Please note, that general _freight_ events can be found in the freight contrib.
  *
@@ -19,19 +19,19 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
 public abstract class AbstractLogisticEvent extends Event implements HasLinkId, HasLspShipmentId {
 
   private final Id<Link> linkId;
-  private final Id<LSPShipment> lspShipmentId;
+  private final Id<LspShipment> lspShipmentId;
 
-  public AbstractLogisticEvent(double time, Id<Link> linkId, Id<LSPShipment> lspShipmentId) {
+  public AbstractLogisticEvent(double time, Id<Link> linkId, Id<LspShipment> lspShipmentId) {
     super(time);
     this.linkId = linkId;
     this.lspShipmentId = lspShipmentId;
   }
 
   /**
-   * @return id of the {@link LSPShipment}
+   * @return id of the {@link LspShipment}
    */
   @Override
-  public final Id<LSPShipment> getLspShipmentId() {
+  public final Id<LspShipment> getLspShipmentId() {
     return lspShipmentId;
   }
 
@@ -41,7 +41,7 @@ public abstract class AbstractLogisticEvent extends Event implements HasLinkId, 
   }
 
   /**
-   * Adds the {@link Id<LSPShipment>} to the list of attributes. {@link Id<Link>} is handled by
+   * Adds the {@link Id< LspShipment >} to the list of attributes. {@link Id<Link>} is handled by
    * superclass {@link Event}
    *
    * @return The map of attributes

--- a/src/main/java/org/matsim/freight/logistics/events/HandlingInHubStartsEvent.java
+++ b/src/main/java/org/matsim/freight/logistics/events/HandlingInHubStartsEvent.java
@@ -29,10 +29,10 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.events.GenericEvent;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.freight.logistics.LSPResource;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /**
- * An event, that informs that the handling of a {@link LSPShipment} in a hub has started.
+ * An event, that informs that the handling of a {@link LspShipment} in a hub has started.
  *
  * @author Kai Martins-Turner (kturner)
  */
@@ -45,7 +45,7 @@ public final class HandlingInHubStartsEvent extends AbstractLogisticEvent {
   public HandlingInHubStartsEvent(
       double time,
       Id<Link> linkId,
-      Id<LSPShipment> lspShipmentId,
+      Id<LspShipment> lspShipmentId,
       Id<LSPResource> hubId,
       double expHandlingDuration) {
     super(time, linkId, lspShipmentId);
@@ -57,8 +57,8 @@ public final class HandlingInHubStartsEvent extends AbstractLogisticEvent {
     Map<String, String> attributes = event.getAttributes();
     double time = Double.parseDouble(attributes.get(ATTRIBUTE_TIME));
     Id<Link> linkId = Id.createLinkId(attributes.get(ATTRIBUTE_LINK));
-    Id<LSPShipment> lspSipmentId =
-        Id.create(attributes.get(ATTRIBUTE_LSP_SHIPMENT_ID), LSPShipment.class);
+    Id<LspShipment> lspSipmentId =
+        Id.create(attributes.get(ATTRIBUTE_LSP_SHIPMENT_ID), LspShipment.class);
     var hubId = Id.create(attributes.get(ATTRIBUTE_HUB_ID), LSPResource.class);
     double expHandlingDuration =
         Double.parseDouble(attributes.get(ATTRIBUTE_EXP_HANDLING_DURATION));

--- a/src/main/java/org/matsim/freight/logistics/events/LspEventCreator.java
+++ b/src/main/java/org/matsim/freight/logistics/events/LspEventCreator.java
@@ -24,7 +24,7 @@ package org.matsim.freight.logistics.events;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.events.Event;
 import org.matsim.api.core.v01.population.Activity;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /**
  * @author Kai Martins-Turner (kturner)
@@ -32,5 +32,5 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
 public interface LspEventCreator {
 
   // I am unsure, if I need the activity or not. kmt 'dec22
-  Event createEvent(Event event, Id<LSPShipment> lspShipmentId, Activity activity);
+  Event createEvent(Event event, Id<LspShipment> lspShipmentId, Activity activity);
 }

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfInitialPlan.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfInitialPlan.java
@@ -36,9 +36,9 @@ import org.matsim.freight.carriers.*;
 import org.matsim.freight.carriers.CarrierCapabilities.FleetSize;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 
@@ -116,14 +116,14 @@ import org.matsim.vehicles.VehicleType;
         .build();
   }
 
-  private static Collection<LSPShipment> createInitialLSPShipments(Network network) {
-    ArrayList<LSPShipment> shipmentList = new ArrayList<>();
+  private static Collection<LspShipment> createInitialLSPShipments(Network network) {
+    ArrayList<LspShipment> shipmentList = new ArrayList<>();
     ArrayList<Link> linkList = new ArrayList<>(network.getLinks().values());
 
     // Create five LSPShipments that are located in the left half of the network.
     for (int i = 1; i < 6; i++) {
-      Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-      ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+      Id<LspShipment> id = Id.create(i, LspShipment.class);
+      LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
       Random random = new Random(1);
       int capacityDemand = random.nextInt(4);
       builder.setCapacityDemand(capacityDemand);
@@ -163,10 +163,10 @@ import org.matsim.vehicles.VehicleType;
 
     // Create LSP and lspShipments
     LSP lsp = createInitialLSP(scenario);
-    Collection<LSPShipment> lspShipments = createInitialLSPShipments(network);
+    Collection<LspShipment> lspShipments = createInitialLSPShipments(network);
 
     // assign the lspShipments to the LSP
-    for (LSPShipment lspShipment : lspShipments) {
+    for (LspShipment lspShipment : lspShipments) {
       lsp.assignShipmentToLSP(lspShipment);
     }
 
@@ -174,20 +174,20 @@ import org.matsim.vehicles.VehicleType;
     lsp.scheduleLogisticChains();
 
     // print the schedules for the assigned LSPShipments
-    for (LSPShipment lspShipment : lspShipments) {
+    for (LspShipment lspShipment : lspShipments) {
       System.out.println("Shipment: " + lspShipment.getId());
-      ArrayList<ShipmentPlanElement> scheduleElements =
+      ArrayList<LspShipmentPlanElement> scheduleElements =
           new ArrayList<>(
-              ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), lspShipment.getId())
+              LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), lspShipment.getId())
                   .getPlanElements()
                   .values());
-      scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
-      ArrayList<ShipmentPlanElement> logElements =
+      scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
+      ArrayList<LspShipmentPlanElement> logElements =
           new ArrayList<>(lspShipment.getShipmentLog().getPlanElements().values());
-      logElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+      logElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
-      for (ShipmentPlanElement element :
-          ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), lspShipment.getId())
+      for (LspShipmentPlanElement element :
+          LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), lspShipment.getId())
               .getPlanElements()
               .values()) {
         System.out.println(

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChain.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChain.java
@@ -38,9 +38,9 @@ import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.DistributionCarrierResourceBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 
@@ -284,13 +284,13 @@ import org.matsim.vehicles.VehicleType;
     return completeLSPBuilder.build();
   }
 
-  private static Collection<LSPShipment> createInitialLSPShipments(Network network) {
-    ArrayList<LSPShipment> shipmentList = new ArrayList<>();
+  private static Collection<LspShipment> createInitialLSPShipments(Network network) {
+    ArrayList<LspShipment> shipmentList = new ArrayList<>();
     ArrayList<Link> linkList = new ArrayList<>(network.getLinks().values());
     Random rand = new Random(1);
     for (int i = 1; i < 6; i++) {
-      Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-      ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+      Id<LspShipment> id = Id.create(i, LspShipment.class);
+      LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
       int capacityDemand = rand.nextInt(10);
       builder.setCapacityDemand(capacityDemand);
 
@@ -341,10 +341,10 @@ import org.matsim.vehicles.VehicleType;
 
     // Create LSP and shipments
     LSP lsp = createInitialLSP(scenario);
-    Collection<LSPShipment> lspShipments = createInitialLSPShipments(scenario.getNetwork());
+    Collection<LspShipment> lspShipments = createInitialLSPShipments(scenario.getNetwork());
 
     // assign the shipments to the LSP
-    for (LSPShipment lspShipment : lspShipments) {
+    for (LspShipment lspShipment : lspShipments) {
       lsp.assignShipmentToLSP(lspShipment);
     }
 
@@ -352,15 +352,15 @@ import org.matsim.vehicles.VehicleType;
     lsp.scheduleLogisticChains();
 
     // print the schedules for the assigned LSPShipments
-    for (LSPShipment lspShipment : lsp.getLspShipments()) {
-      ArrayList<ShipmentPlanElement> elementList =
+    for (LspShipment lspShipment : lsp.getLspShipments()) {
+      ArrayList<LspShipmentPlanElement> elementList =
           new ArrayList<>(
-              ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), lspShipment.getId())
+              LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), lspShipment.getId())
                   .getPlanElements()
                   .values());
-      elementList.sort(ShipmentUtils.createShipmentPlanElementComparator());
+      elementList.sort(LspShipmentUtils.createShipmentPlanElementComparator());
       System.out.println("Shipment: " + lspShipment.getId());
-      for (ShipmentPlanElement element : elementList) {
+      for (LspShipmentPlanElement element : elementList) {
         System.out.println(
             element.getLogisticChainElement().getId()
                 + "\t\t"

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirect.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirect.java
@@ -49,8 +49,8 @@ import org.matsim.freight.carriers.events.eventhandler.CarrierTourEndEventHandle
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.examples.lspReplanning.AssignmentStrategyFactory;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.VehicleType;
 
 /**
@@ -121,7 +121,7 @@ import org.matsim.vehicles.VehicleType;
 
     log.info("create initial LSPShipments");
     log.info("assign the shipments to the LSP");
-    for (LSPShipment lspShipment : createInitialLSPShipments(scenario.getNetwork())) {
+    for (LspShipment lspShipment : createInitialLSPShipments(scenario.getNetwork())) {
       lsp.assignShipmentToLSP(lspShipment);
     }
 
@@ -542,13 +542,13 @@ import org.matsim.vehicles.VehicleType;
         .build();
   }
 
-  private static Collection<LSPShipment> createInitialLSPShipments(Network network) {
-    ArrayList<LSPShipment> shipmentList = new ArrayList<>();
+  private static Collection<LspShipment> createInitialLSPShipments(Network network) {
+    ArrayList<LspShipment> shipmentList = new ArrayList<>();
     ArrayList<Link> linkList = new ArrayList<>(network.getLinks().values());
     Random rand = new Random(1);
     for (int i = 1; i < 6; i++) {
-      Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-      ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+      Id<LspShipment> id = Id.create(i, LspShipment.class);
+      LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
       int capacityDemand = rand.nextInt(10);
       builder.setCapacityDemand(capacityDemand);
 
@@ -575,7 +575,7 @@ import org.matsim.vehicles.VehicleType;
       TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
       builder.setStartTimeWindow(startTimeWindow);
       builder.setDeliveryServiceTime(capacityDemand * 60);
-      LSPShipment lspShipment = builder.build();
+      LspShipment lspShipment = builder.build();
       shipmentList.add(lspShipment);
     }
     return shipmentList;

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid.java
@@ -47,8 +47,8 @@ import org.matsim.freight.carriers.controler.CarrierScoringFunctionFactory;
 import org.matsim.freight.carriers.controler.CarrierStrategyManager;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.VehicleType;
 
 /**
@@ -391,7 +391,7 @@ final class ExampleTwoEchelonGrid {
 
     log.info("create initial LSPShipments");
     log.info("assign the shipments to the LSP");
-    for (LSPShipment lspShipment : createInitialLSPShipments(network)) {
+    for (LspShipment lspShipment : createInitialLSPShipments(network)) {
       lsp.assignShipmentToLSP(lspShipment);
     }
 
@@ -401,15 +401,15 @@ final class ExampleTwoEchelonGrid {
     return lsp;
   }
 
-  private static Collection<LSPShipment> createInitialLSPShipments(Network network) {
-    List<LSPShipment> shipmentList = new ArrayList<>();
+  private static Collection<LspShipment> createInitialLSPShipments(Network network) {
+    List<LspShipment> shipmentList = new ArrayList<>();
 
     switch (demandSetting) {
       case oneCustomer -> {
-        Id<LSPShipment> id = Id.create("Shipment_" + 1, LSPShipment.class);
+        Id<LspShipment> id = Id.create("Shipment_" + 1, LspShipment.class);
         int capacityDemand = 1;
 
-        ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+        LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 
         builder.setCapacityDemand(capacityDemand);
         builder.setFromLinkId(DEPOT_LINK_ID);
@@ -439,9 +439,9 @@ final class ExampleTwoEchelonGrid {
         }
 
         for (int i = 1; i <= 10; i++) {
-          Id<LSPShipment> id = Id.create("Shipment_" + i, LSPShipment.class);
-          ShipmentUtils.LSPShipmentBuilder builder =
-              ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+          Id<LspShipment> id = Id.create("Shipment_" + i, LspShipment.class);
+          LspShipmentUtils.LspShipmentBuilder builder =
+              LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 
           int capacityDemand =
               rand1.nextInt(5) + 1; // Random is drawn from 0 (incl) to bound (excl) -> adding 1.

--- a/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid_NR.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid_NR.java
@@ -49,8 +49,8 @@ import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.io.LSPPlanXmlReader;
 import org.matsim.freight.logistics.io.LSPPlanXmlWriter;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.VehicleType;
 
 /**
@@ -401,7 +401,7 @@ final class ExampleTwoEchelonGrid_NR {
 
     log.info("create initial LSPShipments");
     log.info("assign the shipments to the LSP");
-    for (LSPShipment lspShipment : createInitialLSPShipments(network)) {
+    for (LspShipment lspShipment : createInitialLSPShipments(network)) {
       lsp.assignShipmentToLSP(lspShipment);
     }
 
@@ -411,15 +411,15 @@ final class ExampleTwoEchelonGrid_NR {
     return lsp;
   }
 
-  private static Collection<LSPShipment> createInitialLSPShipments(Network network) {
-    List<LSPShipment> shipmentList = new ArrayList<>();
+  private static Collection<LspShipment> createInitialLSPShipments(Network network) {
+    List<LspShipment> shipmentList = new ArrayList<>();
 
     switch (demandSetting) {
       case oneCustomer -> {
-        Id<LSPShipment> id = Id.create("Shipment_" + 1, LSPShipment.class);
+        Id<LspShipment> id = Id.create("Shipment_" + 1, LspShipment.class);
         int capacityDemand = 1;
 
-        ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+        LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 
         builder.setCapacityDemand(capacityDemand);
         builder.setFromLinkId(DEPOT_LINK_ID);
@@ -449,9 +449,9 @@ final class ExampleTwoEchelonGrid_NR {
         }
 
         for (int i = 1; i <= 10; i++) {
-          Id<LSPShipment> id = Id.create("Shipment_" + i, LSPShipment.class);
-          ShipmentUtils.LSPShipmentBuilder builder =
-              ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+          Id<LspShipment> id = Id.create("Shipment_" + i, LspShipment.class);
+          LspShipmentUtils.LspShipmentBuilder builder =
+              LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 
           int capacityDemand =
               rand1.nextInt(5) + 1; // Random is drawn from 0 (incl) to bound (excl) -> adding 1.

--- a/src/main/java/org/matsim/freight/logistics/examples/lspReplanning/AssignmentStrategyFactory.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/lspReplanning/AssignmentStrategyFactory.java
@@ -30,8 +30,8 @@ import org.matsim.freight.logistics.LSP;
 import org.matsim.freight.logistics.LSPPlan;
 import org.matsim.freight.logistics.LogisticChain;
 import org.matsim.freight.logistics.LogisticChainElement;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 
 /**
  * @deprecated This class is a work-around. Please do not use this method for any new runs!
@@ -71,8 +71,8 @@ public class AssignmentStrategyFactory {
               }
             }
 
-            for (LSPShipment lspShipment : lspPlan.getLSP().getLspShipments()) {
-              ShipmentUtils.getOrCreateShipmentPlan(lspPlan, lspShipment.getId()).clear();
+            for (LspShipment lspShipment : lspPlan.getLSP().getLspShipments()) {
+              LspShipmentUtils.getOrCreateShipmentPlan(lspPlan, lspShipment.getId()).clear();
               lspShipment.getShipmentLog().clear();
               lspPlan.getInitialShipmentAssigner().assignToPlan(lspPlan, lspShipment);
             }

--- a/src/main/java/org/matsim/freight/logistics/examples/lspReplanning/MaybeTodayAssigner.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/lspReplanning/MaybeTodayAssigner.java
@@ -25,7 +25,7 @@ import java.util.Random;
 import org.matsim.core.gbl.Gbl;
 import org.matsim.freight.logistics.InitialShipmentAssigner;
 import org.matsim.freight.logistics.LSPPlan;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /**
 * This class is deprecated and will be removed in the future.
@@ -45,7 +45,7 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
   }
 
   @Override
-  public void assignToPlan(LSPPlan lspPlan, LSPShipment lspShipment) {
+  public void assignToPlan(LSPPlan lspPlan, LspShipment lspShipment) {
     boolean assignToday = random.nextBoolean();
     if (assignToday) {
       Gbl.assertIf(lspPlan.getLogisticChains().size() == 1);

--- a/src/main/java/org/matsim/freight/logistics/examples/lspReplanning/TomorrowShipmentAssignerStrategyFactory.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/lspReplanning/TomorrowShipmentAssignerStrategyFactory.java
@@ -28,8 +28,8 @@ import org.matsim.core.replanning.ReplanningContext;
 import org.matsim.core.replanning.modules.GenericPlanStrategyModule;
 import org.matsim.core.replanning.selectors.BestPlanSelector;
 import org.matsim.freight.logistics.*;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 
 @Deprecated
 /*package-private*/ class TomorrowShipmentAssignerStrategyFactory {
@@ -59,8 +59,8 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
             plan.setInitialShipmentAssigner(assigner);
             //				LSP lsp = assigner.getLSP();
             LSP lsp = plan.getLSP();
-            Collection<LSPShipment> lspShipments = lsp.getLspShipments();
-            for (LSPShipment lspShipment : lspShipments) {
+            Collection<LspShipment> lspShipments = lsp.getLspShipments();
+            for (LspShipment lspShipment : lspShipments) {
               assigner.assignToPlan(plan, lspShipment);
             }
 
@@ -72,8 +72,8 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
               }
             }
 
-            for (LSPShipment lspShipment : plan.getLSP().getLspShipments()) {
-              ShipmentUtils.getOrCreateShipmentPlan(plan, lspShipment.getId()).clear();
+            for (LspShipment lspShipment : plan.getLSP().getLspShipments()) {
+              LspShipmentUtils.getOrCreateShipmentPlan(plan, lspShipment.getId()).clear();
               lspShipment.getShipmentLog().clear();
               plan.getInitialShipmentAssigner().assignToPlan(plan, lspShipment);
             }

--- a/src/main/java/org/matsim/freight/logistics/examples/lspScoring/ExampleLSPScoring.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/lspScoring/ExampleLSPScoring.java
@@ -41,8 +41,8 @@ import org.matsim.freight.carriers.events.CarrierServiceEndEvent;
 import org.matsim.freight.carriers.events.eventhandler.CarrierServiceEndEventHandler;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.VehicleType;
 
 /* Example for customized scoring. Each customer that is visited will give a random tip between zero and five
@@ -125,14 +125,14 @@ import org.matsim.vehicles.VehicleType;
         .build();
   }
 
-  private static Collection<LSPShipment> createInitialLSPShipments(Network network) {
-    List<LSPShipment> shipmentList = new ArrayList<>();
+  private static Collection<LspShipment> createInitialLSPShipments(Network network) {
+    List<LspShipment> shipmentList = new ArrayList<>();
     ArrayList<Link> linkList = new ArrayList<>(network.getLinks().values());
 
     // Create five LSPShipments that are located in the left half of the network.
     for (int i = 1; i < 6; i++) {
-      Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-      ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+      Id<LspShipment> id = Id.create(i, LspShipment.class);
+      LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
       Random random = new Random(1);
       int capacityDemand = random.nextInt(4);
       builder.setCapacityDemand(capacityDemand);
@@ -200,10 +200,10 @@ import org.matsim.vehicles.VehicleType;
 
     // Create LSP and lspShipments
     LSP lsp = createLSPWithScorer(scenario);
-    Collection<LSPShipment> lspShipments = createInitialLSPShipments(scenario.getNetwork());
+    Collection<LspShipment> lspShipments = createInitialLSPShipments(scenario.getNetwork());
 
     // assign the lspShipments to the LSP
-    for (LSPShipment lspShipment : lspShipments) {
+    for (LspShipment lspShipment : lspShipments) {
       lsp.assignShipmentToLSP(lspShipment);
     }
 

--- a/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfSimpleLSP.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfSimpleLSP.java
@@ -41,9 +41,9 @@ import org.matsim.freight.carriers.*;
 import org.matsim.freight.carriers.CarrierCapabilities.FleetSize;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 
@@ -68,10 +68,10 @@ import org.matsim.vehicles.VehicleType;
 
     // Create LSP and lspShipments
     LSP lsp = createInitialLSP(scenario);
-    Collection<LSPShipment> lspShipments = createInitialLSPShipments(scenario.getNetwork());
+    Collection<LspShipment> lspShipments = createInitialLSPShipments(scenario.getNetwork());
 
     // assign the lspShipments to the LSP
-    for (LSPShipment lspShipment : lspShipments) {
+    for (LspShipment lspShipment : lspShipments) {
       lsp.assignShipmentToLSP(lspShipment);
     }
 
@@ -104,21 +104,21 @@ import org.matsim.vehicles.VehicleType;
         .setVspDefaultsCheckingLevel(VspExperimentalConfigGroup.VspDefaultsCheckingLevel.warn);
     controler.run();
 
-    for (LSPShipment lspShipment : lsp.getLspShipments()) {
+    for (LspShipment lspShipment : lsp.getLspShipments()) {
       System.out.println("LspShipment: " + lspShipment.getId());
-      ArrayList<ShipmentPlanElement> scheduleElements =
+      ArrayList<LspShipmentPlanElement> scheduleElements =
           new ArrayList<>(
-              ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), lspShipment.getId())
+              LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), lspShipment.getId())
                   .getPlanElements()
                   .values());
-      scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
-      ArrayList<ShipmentPlanElement> logElements =
+      scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
+      ArrayList<LspShipmentPlanElement> logElements =
           new ArrayList<>(lspShipment.getShipmentLog().getPlanElements().values());
-      logElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+      logElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
       for (int i = 0;
           i
-              < ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), lspShipment.getId())
+              < LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), lspShipment.getId())
                   .getPlanElements()
                   .size();
           i++) {
@@ -225,14 +225,14 @@ import org.matsim.vehicles.VehicleType;
     return collectionLSPBuilder.build();
   }
 
-  private static Collection<LSPShipment> createInitialLSPShipments(Network network) {
-    ArrayList<LSPShipment> shipmentList = new ArrayList<>();
+  private static Collection<LspShipment> createInitialLSPShipments(Network network) {
+    ArrayList<LspShipment> shipmentList = new ArrayList<>();
     ArrayList<Link> linkList = new ArrayList<>(network.getLinks().values());
 
     // Create five LSPShipments that are located in the left half of the network.
     for (int i = 1; i < 6; i++) {
-      Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-      ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+      Id<LspShipment> id = Id.create(i, LspShipment.class);
+      LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
       Random random = new Random(1);
       int capacityDemand = random.nextInt(4);
       builder.setCapacityDemand(capacityDemand);

--- a/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfTransportChain.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfTransportChain.java
@@ -42,9 +42,9 @@ import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 
@@ -280,13 +280,13 @@ import org.matsim.vehicles.VehicleType;
     return completeLSPBuilder.build();
   }
 
-  private static Collection<LSPShipment> createInitialLSPShipments(Network network) {
-    ArrayList<LSPShipment> shipmentList = new ArrayList<>();
+  private static Collection<LspShipment> createInitialLSPShipments(Network network) {
+    ArrayList<LspShipment> shipmentList = new ArrayList<>();
     ArrayList<Link> linkList = new ArrayList<>(network.getLinks().values());
     Random rand = new Random(1);
     for (int i = 1; i < 6; i++) {
-      Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-      ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+      Id<LspShipment> id = Id.create(i, LspShipment.class);
+      LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
       int capacityDemand = rand.nextInt(10);
       builder.setCapacityDemand(capacityDemand);
 
@@ -336,10 +336,10 @@ import org.matsim.vehicles.VehicleType;
 
     // Create LSP and lspShipments
     LSP lsp = createInitialLSP(scenario);
-    Collection<LSPShipment> lspShipments = createInitialLSPShipments(scenario.getNetwork());
+    Collection<LspShipment> lspShipments = createInitialLSPShipments(scenario.getNetwork());
 
     // assign the lspShipments to the LSP
-    for (LSPShipment lspShipment : lspShipments) {
+    for (LspShipment lspShipment : lspShipments) {
       lsp.assignShipmentToLSP(lspShipment);
     }
 
@@ -374,21 +374,21 @@ import org.matsim.vehicles.VehicleType;
         .setVspDefaultsCheckingLevel(VspExperimentalConfigGroup.VspDefaultsCheckingLevel.warn);
     controler.run();
 
-    for (LSPShipment lspShipment : lsp.getLspShipments()) {
+    for (LspShipment lspShipment : lsp.getLspShipments()) {
       System.out.println("Shipment: " + lspShipment.getId());
-      ArrayList<ShipmentPlanElement> scheduleElements =
+      ArrayList<LspShipmentPlanElement> scheduleElements =
           new ArrayList<>(
-              ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), lspShipment.getId())
+              LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), lspShipment.getId())
                   .getPlanElements()
                   .values());
-      scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
-      ArrayList<ShipmentPlanElement> logElements =
+      scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
+      ArrayList<LspShipmentPlanElement> logElements =
           new ArrayList<>(lspShipment.getShipmentLog().getPlanElements().values());
-      logElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+      logElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
       for (int i = 0;
           i
-              < ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), lspShipment.getId())
+              < LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), lspShipment.getId())
                   .getPlanElements()
                   .size();
           i++) {

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleGroceryDeliveryMultipleChains.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleGroceryDeliveryMultipleChains.java
@@ -50,7 +50,7 @@ import org.matsim.freight.carriers.controler.CarrierStrategyManager;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.examples.ExampleConstants;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 import org.matsim.vehicles.VehicleType;
 
 final class ExampleGroceryDeliveryMultipleChains {
@@ -320,7 +320,7 @@ final class ExampleGroceryDeliveryMultipleChains {
 
     log.info("create initial LSPShipments");
     log.info("assign the shipments to the LSP");
-    for (LSPShipment lspShipment : createLSPShipmentsFromCarrierShipments(carrier)) {
+    for (LspShipment lspShipment : createLSPShipmentsFromCarrierShipments(carrier)) {
       lsp.assignShipmentToLSP(lspShipment);
     }
 

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleMixedEchelonChains.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleMixedEchelonChains.java
@@ -47,8 +47,8 @@ import org.matsim.freight.carriers.controler.CarrierStrategyManager;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.examples.ExampleConstants;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.VehicleType;
 
 final class ExampleMultipleMixedEchelonChains {
@@ -405,7 +405,7 @@ final class ExampleMultipleMixedEchelonChains {
 
     log.info("create initial LSPShipments");
     log.info("assign the shipments to the LSP");
-    for (LSPShipment lspShipment : createInitialLSPShipments(network)) {
+    for (LspShipment lspShipment : createInitialLSPShipments(network)) {
       lsp.assignShipmentToLSP(lspShipment);
     }
 
@@ -415,8 +415,8 @@ final class ExampleMultipleMixedEchelonChains {
     return lsp;
   }
 
-  private static Collection<LSPShipment> createInitialLSPShipments(Network network) {
-    List<LSPShipment> shipmentList = new ArrayList<>();
+  private static Collection<LspShipment> createInitialLSPShipments(Network network) {
+    List<LspShipment> shipmentList = new ArrayList<>();
 
     Random rand = MatsimRandom.getLocalInstance();
 
@@ -435,8 +435,8 @@ final class ExampleMultipleMixedEchelonChains {
 
     for (int i = 1; i <= 10; i++) {
       if (i % 2 != 0) {
-        Id<LSPShipment> id = Id.create("ShipmentInside_" + i, LSPShipment.class);
-        ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+        Id<LspShipment> id = Id.create("ShipmentInside_" + i, LspShipment.class);
+        LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 
         builder.setCapacityDemand(capacityDemand);
         builder.setFromLinkId(DEPOT_LINK_ID);
@@ -450,8 +450,8 @@ final class ExampleMultipleMixedEchelonChains {
 
         shipmentList.add(builder.build());
       } else {
-        Id<LSPShipment> id = Id.create("ShipmentOutside_" + i, LSPShipment.class);
-        ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+        Id<LspShipment> id = Id.create("ShipmentOutside_" + i, LspShipment.class);
+        LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 
         builder.setCapacityDemand(capacityDemand);
         builder.setFromLinkId(DEPOT_LINK_ID);

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChains.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChains.java
@@ -48,8 +48,8 @@ import org.matsim.freight.carriers.controler.CarrierScoringFunctionFactory;
 import org.matsim.freight.carriers.controler.CarrierStrategyManager;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.VehicleType;
 
 final class ExampleMultipleOneEchelonChains {
@@ -305,7 +305,7 @@ final class ExampleMultipleOneEchelonChains {
 
     log.info("create initial LSPShipments");
     log.info("assign the shipments to the LSP");
-    for (LSPShipment lspShipment : createInitialLSPShipments()) {
+    for (LspShipment lspShipment : createInitialLSPShipments()) {
       lsp.assignShipmentToLSP(lspShipment);
     }
 
@@ -315,8 +315,8 @@ final class ExampleMultipleOneEchelonChains {
     return lsp;
   }
 
-  private static Collection<LSPShipment> createInitialLSPShipments() {
-    List<LSPShipment> lspShipmentList = new ArrayList<>();
+  private static Collection<LspShipment> createInitialLSPShipments() {
+    List<LspShipment> lspShipmentList = new ArrayList<>();
     int capacityDemand;
 
     switch (demandSetting) {
@@ -327,8 +327,8 @@ final class ExampleMultipleOneEchelonChains {
 
     for (int i = 1; i <= 10; i++) {
       if (i % 2 != 0) {
-        Id<LSPShipment> id = Id.create("ShipmentLeft_" + i, LSPShipment.class);
-        ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+        Id<LspShipment> id = Id.create("ShipmentLeft_" + i, LspShipment.class);
+        LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 
         builder.setCapacityDemand(capacityDemand);
         builder.setFromLinkId(DEPOT_LINK_ID);
@@ -341,8 +341,8 @@ final class ExampleMultipleOneEchelonChains {
 
         lspShipmentList.add(builder.build());
       } else {
-        Id<LSPShipment> id = Id.create("ShipmentRight_" + i, LSPShipment.class);
-        ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+        Id<LspShipment> id = Id.create("ShipmentRight_" + i, LspShipment.class);
+        LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 
         builder.setCapacityDemand(capacityDemand);
         builder.setFromLinkId(DEPOT_LINK_ID);

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChainsReplanning.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChainsReplanning.java
@@ -51,8 +51,8 @@ import org.matsim.freight.carriers.controler.CarrierScoringFunctionFactory;
 import org.matsim.freight.carriers.controler.CarrierStrategyManager;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.VehicleType;
 
 final class ExampleMultipleOneEchelonChainsReplanning {
@@ -329,7 +329,7 @@ final class ExampleMultipleOneEchelonChainsReplanning {
 
     log.info("create initial LSPShipments");
     log.info("assign the shipments to the LSP");
-    for (LSPShipment lspShipment : createInitialLSPShipments()) {
+    for (LspShipment lspShipment : createInitialLSPShipments()) {
       lsp.assignShipmentToLSP(lspShipment);
     }
 
@@ -339,14 +339,14 @@ final class ExampleMultipleOneEchelonChainsReplanning {
     return lsp;
   }
 
-  private static Collection<LSPShipment> createInitialLSPShipments() {
-    List<LSPShipment> shipmentList = new ArrayList<>();
+  private static Collection<LspShipment> createInitialLSPShipments() {
+    List<LspShipment> shipmentList = new ArrayList<>();
     int capacityDemand = 1;
 
     for (int i = 1; i <= 10; i++) {
       if (i % 2 != 0) {
-        Id<LSPShipment> id = Id.create("ShipmentLeft_" + i, LSPShipment.class);
-        ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+        Id<LspShipment> id = Id.create("ShipmentLeft_" + i, LspShipment.class);
+        LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 
         builder.setCapacityDemand(capacityDemand);
         builder.setFromLinkId(DEPOT_LINK_ID);
@@ -359,8 +359,8 @@ final class ExampleMultipleOneEchelonChainsReplanning {
 
         shipmentList.add(builder.build());
       } else {
-        Id<LSPShipment> id = Id.create("ShipmentRight_" + i, LSPShipment.class);
-        ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+        Id<LspShipment> id = Id.create("ShipmentRight_" + i, LspShipment.class);
+        LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 
         builder.setCapacityDemand(capacityDemand);
         builder.setFromLinkId(DEPOT_LINK_ID);

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleTwoEchelonChainsReplanning.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleTwoEchelonChainsReplanning.java
@@ -51,8 +51,8 @@ import org.matsim.freight.carriers.controler.CarrierScoringFunctionFactory;
 import org.matsim.freight.carriers.controler.CarrierStrategyManager;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.VehicleType;
 
 final class ExampleMultipleTwoEchelonChainsReplanning {
@@ -369,7 +369,7 @@ final class ExampleMultipleTwoEchelonChainsReplanning {
 
     log.info("create initial LSPShipments");
     log.info("assign the shipments to the LSP");
-    for (LSPShipment lspShipment : createInitialLSPShipments()) {
+    for (LspShipment lspShipment : createInitialLSPShipments()) {
       lsp.assignShipmentToLSP(lspShipment);
     }
 
@@ -379,14 +379,14 @@ final class ExampleMultipleTwoEchelonChainsReplanning {
     return lsp;
   }
 
-  private static Collection<LSPShipment> createInitialLSPShipments() {
-    List<LSPShipment> shipmentList = new ArrayList<>();
+  private static Collection<LspShipment> createInitialLSPShipments() {
+    List<LspShipment> shipmentList = new ArrayList<>();
     int capacityDemand = 1;
 
     for (int i = 1; i <= 10; i++) {
       if (i % 2 != 0) {
-        Id<LSPShipment> id = Id.create("ShipmentLeft_" + i, LSPShipment.class);
-        ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+        Id<LspShipment> id = Id.create("ShipmentLeft_" + i, LspShipment.class);
+        LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 
         builder.setCapacityDemand(capacityDemand);
         builder.setFromLinkId(DEPOT_LINK_ID);
@@ -399,8 +399,8 @@ final class ExampleMultipleTwoEchelonChainsReplanning {
 
         shipmentList.add(builder.build());
       } else {
-        Id<LSPShipment> id = Id.create("ShipmentRight_" + i, LSPShipment.class);
-        ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+        Id<LspShipment> id = Id.create("ShipmentRight_" + i, LspShipment.class);
+        LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 
         builder.setCapacityDemand(capacityDemand);
         builder.setFromLinkId(DEPOT_LINK_ID);

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChains.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChains.java
@@ -68,7 +68,7 @@ import org.matsim.freight.carriers.controler.CarrierStrategyManager;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.examples.ExampleConstants;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 import org.matsim.vehicles.VehicleType;
 
 
@@ -226,7 +226,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChains {
    * @param vehicleTypesDirect          vehicle types for the direct run (direct chain)
    * @return the LSP
    */
-  private static LSP createLspWithTwoChains(Scenario scenario, String lspName, Collection<LSPShipment> lspShipments, Id<Link> depotLinkId, Id<Link> hubLinkId, CarrierVehicleTypes vehicleTypesMainRun, CarrierVehicleTypes vehicleTypesDistributionRun, CarrierVehicleTypes vehicleTypesDirect) {
+  private static LSP createLspWithTwoChains(Scenario scenario, String lspName, Collection<LspShipment> lspShipments, Id<Link> depotLinkId, Id<Link> hubLinkId, CarrierVehicleTypes vehicleTypesMainRun, CarrierVehicleTypes vehicleTypesDistributionRun, CarrierVehicleTypes vehicleTypesDirect) {
     log.info("create LSP");
     //Chains
     LogisticChain directChain = createDirectChain(scenario, lspName, depotLinkId, vehicleTypesDirect);
@@ -248,7 +248,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChains {
             .build();
 
     log.info("assign the shipments to the LSP");
-    for (LSPShipment lspShipment : lspShipments) {
+    for (LspShipment lspShipment : lspShipments) {
       lsp.assignShipmentToLSP(lspShipment);
     }
 
@@ -369,7 +369,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChains {
    * @param vehicleTypesDirect          vehicle types for the direct run (direct chain)
    * @return the LSP
    */
-  private static LSP createLspWithDirectChain(Scenario scenario, String lspName, Collection<LSPShipment> lspShipments, Id<Link> depotLinkId, CarrierVehicleTypes vehicleTypesDirect) {
+  private static LSP createLspWithDirectChain(Scenario scenario, String lspName, Collection<LspShipment> lspShipments, Id<Link> depotLinkId, CarrierVehicleTypes vehicleTypesDirect) {
     log.info("create LSP");
 
       LSPPlan lspPlan = LSPUtils.createLSPPlan()
@@ -385,7 +385,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChains {
                     .build();
 
     log.info("assign the shipments to the LSP");
-    for (LSPShipment lspShipment : lspShipments) {
+    for (LspShipment lspShipment : lspShipments) {
       lsp.assignShipmentToLSP(lspShipment);
     }
 

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll.java
@@ -49,7 +49,7 @@ import org.matsim.freight.carriers.controler.CarrierStrategyManager;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.examples.ExampleConstants;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehicleUtils;
 
@@ -252,7 +252,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll {
    * @param vehicleTypesDirect          vehicle types for the direct run (direct chain)
    * @return the LSP
    */
-  private static LSP createLspWithTwoChains(Scenario scenario, String lspName, Collection<LSPShipment> lspShipments, Id<Link> depotLinkId, Id<Link> hubLinkId, CarrierVehicleTypes vehicleTypesMainRun, CarrierVehicleTypes vehicleTypesDistributionRun, CarrierVehicleTypes vehicleTypesDirect) {
+  private static LSP createLspWithTwoChains(Scenario scenario, String lspName, Collection<LspShipment> lspShipments, Id<Link> depotLinkId, Id<Link> hubLinkId, CarrierVehicleTypes vehicleTypesMainRun, CarrierVehicleTypes vehicleTypesDistributionRun, CarrierVehicleTypes vehicleTypesDirect) {
     log.info("create LSP");
     //Chains
     LogisticChain directChain = createDirectChain(scenario, lspName, depotLinkId, vehicleTypesDirect);
@@ -274,7 +274,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll {
             .build();
 
     log.info("assign the shipments to the LSP");
-    for (LSPShipment lspShipment : lspShipments) {
+    for (LspShipment lspShipment : lspShipments) {
       lsp.assignShipmentToLSP(lspShipment);
     }
 
@@ -395,7 +395,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll {
    * @param vehicleTypesDirect          vehicle types for the direct run (direct chain)
    * @return the LSP
    */
-  private static LSP createLspWithDirectChain(Scenario scenario, String lspName, Collection<LSPShipment> lspShipments, Id<Link> depotLinkId, CarrierVehicleTypes vehicleTypesDirect) {
+  private static LSP createLspWithDirectChain(Scenario scenario, String lspName, Collection<LspShipment> lspShipments, Id<Link> depotLinkId, CarrierVehicleTypes vehicleTypesDirect) {
     log.info("create LSP");
 
     LSPPlan lspPlan = LSPUtils.createLSPPlan()
@@ -411,7 +411,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll {
                     .build();
 
     log.info("assign the shipments to the LSP");
-    for (LSPShipment lspShipment : lspShipments) {
+    for (LspShipment lspShipment : lspShipments) {
       lsp.assignShipmentToLSP(lspShipment);
     }
 

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsUtils.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsUtils.java
@@ -31,8 +31,8 @@ import java.util.stream.Stream;
 import org.matsim.api.core.v01.Id;
 import org.matsim.freight.carriers.Carrier;
 import org.matsim.freight.carriers.CarrierShipment;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 
 class MultipleChainsUtils {
   private MultipleChainsUtils() {}
@@ -50,15 +50,15 @@ class MultipleChainsUtils {
     return new PrimaryLogisticChainShipmentAssigner();
   }
 
-  public static Collection<LSPShipment> createLSPShipmentsFromCarrierShipments(Carrier carrier) {
-    List<LSPShipment> shipmentList = new ArrayList<>();
+  public static Collection<LspShipment> createLSPShipmentsFromCarrierShipments(Carrier carrier) {
+    List<LspShipment> shipmentList = new ArrayList<>();
 
     List<CarrierShipment> carrierShipments = carrier.getShipments().values().stream().toList();
 
     for (CarrierShipment shipment : carrierShipments) {
-      ShipmentUtils.LSPShipmentBuilder builder =
-          ShipmentUtils.LSPShipmentBuilder.newInstance(
-              Id.create(shipment.getId().toString(), LSPShipment.class));
+      LspShipmentUtils.LspShipmentBuilder builder =
+          LspShipmentUtils.LspShipmentBuilder.newInstance(
+              Id.create(shipment.getId().toString(), LspShipment.class));
       builder.setCapacityDemand(shipment.getSize());
       builder.setFromLinkId(shipment.getFrom());
       builder.setToLinkId(shipment.getTo());

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/PrimaryLogisticChainShipmentAssigner.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/PrimaryLogisticChainShipmentAssigner.java
@@ -25,10 +25,10 @@ import org.matsim.core.gbl.Gbl;
 import org.matsim.freight.logistics.InitialShipmentAssigner;
 import org.matsim.freight.logistics.LSPPlan;
 import org.matsim.freight.logistics.LogisticChain;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /**
- * The {@link LSPShipment} is assigned to the first {@link LogisticChain}. In case of one chain the
+ * The {@link LspShipment} is assigned to the first {@link LogisticChain}. In case of one chain the
  * shipment is assigned to that chain. If there are more chains, the shipment is assigned to the
  * first of all chains. Requirements: There must be at least one logisticChain in the plan
  */
@@ -38,7 +38,7 @@ class PrimaryLogisticChainShipmentAssigner implements InitialShipmentAssigner {
   public PrimaryLogisticChainShipmentAssigner() {}
 
   @Override
-  public void assignToPlan(LSPPlan lspPlan, LSPShipment lspShipment) {
+  public void assignToPlan(LSPPlan lspPlan, LspShipment lspShipment) {
     Gbl.assertIf(!lspPlan.getLogisticChains().isEmpty());
     LogisticChain firstLogisticChain = lspPlan.getLogisticChains().iterator().next();
     firstLogisticChain.addShipmentToChain(lspShipment);

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ProximityStrategyFactory.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ProximityStrategyFactory.java
@@ -36,7 +36,7 @@ import org.matsim.core.replanning.ReplanningContext;
 import org.matsim.core.replanning.modules.GenericPlanStrategyModule;
 import org.matsim.core.replanning.selectors.ExpBetaPlanSelector;
 import org.matsim.freight.logistics.*;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /**
  *  This strategy removes **one** randomly selected shipment from logistic chain with the most shipments and reassign it to the chain with the closest chain.
@@ -76,17 +76,17 @@ final class ProximityStrategyFactory {
             LSPResource minDistanceResource = null;
 
             // get all shipments assigned to the LSP
-            Map<Id<LSPShipment>, LSPShipment> lspShipmentById = new HashMap<>();
-            for (LSPShipment lspShipment : lsp.getLspShipments()) {
+            Map<Id<LspShipment>, LspShipment> lspShipmentById = new HashMap<>();
+            for (LspShipment lspShipment : lsp.getLspShipments()) {
               lspShipmentById.put(lspShipment.getId(), lspShipment);
             }
 
             // Retrieve all shipments in the logistic chains of the plan
             // These should be all shipments of the lsp, but not necessarily if shipments got lost
-            ArrayList<LSPShipment> shipments = new ArrayList<>();
+            ArrayList<LspShipment> shipments = new ArrayList<>();
             for (LogisticChain logisticChain : lspPlan.getLogisticChains()) {
-              for (Id<LSPShipment> id : logisticChain.getLspShipmentIds()) {
-                LSPShipment lspShipment = lspShipmentById.get(id);
+              for (Id<LspShipment> id : logisticChain.getLspShipmentIds()) {
+                LspShipment lspShipment = lspShipmentById.get(id);
                 if (lspShipment != null) {
                   shipments.add(lspShipment);
                 }
@@ -95,7 +95,7 @@ final class ProximityStrategyFactory {
 
             // pick a random lspShipment from the shipments contained in the plan
             int shipmentIndex = MatsimRandom.getRandom().nextInt(shipments.size());
-            LSPShipment lspShipment = shipments.get(shipmentIndex);
+            LspShipment lspShipment = shipments.get(shipmentIndex);
 
             // Collect all resources of the logistic chains of the LSP plan
             ArrayList<LSPResource> resources = new ArrayList<>();

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RandomDistributionAllShipmentsStrategyFactory.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RandomDistributionAllShipmentsStrategyFactory.java
@@ -33,7 +33,7 @@ import org.matsim.core.replanning.selectors.ExpBetaPlanSelector;
 import org.matsim.freight.logistics.LSP;
 import org.matsim.freight.logistics.LSPPlan;
 import org.matsim.freight.logistics.LogisticChain;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /**
  *  This strategy removes **all** shipments from the logistic chains and reassigns them randomly.
@@ -74,7 +74,7 @@ final class RandomDistributionAllShipmentsStrategyFactory {
                         List<LogisticChain> logisticChains =
                                 new ArrayList<>(lsp.getSelectedPlan().getLogisticChains());
 
-                        for (LSPShipment lspShipment : lsp.getLspShipments()) {
+                        for (LspShipment lspShipment : lsp.getLspShipments()) {
                             int index = MatsimRandom.getRandom().nextInt(logisticChains.size());
                             logisticChains.get(index).addShipmentToChain(lspShipment);
                         }

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RandomLogisticChainShipmentAssigner.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RandomLogisticChainShipmentAssigner.java
@@ -29,10 +29,10 @@ import org.matsim.core.gbl.MatsimRandom;
 import org.matsim.freight.logistics.LSPPlan;
 import org.matsim.freight.logistics.LogisticChain;
 import org.matsim.freight.logistics.InitialShipmentAssigner;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /**
- * The {@link LSPShipment} is assigned randomly to a {@link LogisticChain}. The logistic chains of a
+ * The {@link LspShipment} is assigned randomly to a {@link LogisticChain}. The logistic chains of a
  * plan are collected in a list. The chain to which the shipment is to be assigned is selected by a
  * seeded random index. Requirements: There must be at least one logisticChain in the plan.
  */
@@ -46,7 +46,7 @@ class RandomLogisticChainShipmentAssigner implements InitialShipmentAssigner {
   }
 
   @Override
-  public void assignToPlan(LSPPlan lspPlan, LSPShipment lspShipment) {
+  public void assignToPlan(LSPPlan lspPlan, LspShipment lspShipment) {
     Gbl.assertIf(!lspPlan.getLogisticChains().isEmpty());
     List<LogisticChain> logisticChains = new ArrayList<>(lspPlan.getLogisticChains());
     int index = random.nextInt(logisticChains.size());

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RandomShiftingStrategyFactory.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RandomShiftingStrategyFactory.java
@@ -36,7 +36,7 @@ import org.matsim.core.replanning.selectors.ExpBetaPlanSelector;
 import org.matsim.freight.logistics.LSP;
 import org.matsim.freight.logistics.LSPPlan;
 import org.matsim.freight.logistics.LogisticChain;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /**
  *  This strategy removes **one** randomly selected shipment from the logistic chain it was assigned to and reassign it to another chain.
@@ -73,9 +73,9 @@ class RandomShiftingStrategyFactory {
                 LSP lsp = lspPlan.getLSP();
 
                 // Make a new list of lspShipments and pick a random lspShipment from it
-                List<LSPShipment> lspShipments = new ArrayList<>(lsp.getLspShipments());
+                List<LspShipment> lspShipments = new ArrayList<>(lsp.getLspShipments());
                 int shipmentIndex = random.nextInt(lsp.getLspShipments().size());
-                LSPShipment lspShipment = lspShipments.get(shipmentIndex);
+                LspShipment lspShipment = lspShipments.get(shipmentIndex);
 
                 // Find and remove the random lspShipment from its current logistic chain
                 LogisticChain sourceLogisticChain = null;

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RebalancingStrategyFactory.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RebalancingStrategyFactory.java
@@ -34,7 +34,7 @@ import org.matsim.core.replanning.selectors.ExpBetaPlanSelector;
 import org.matsim.freight.logistics.LSP;
 import org.matsim.freight.logistics.LSPPlan;
 import org.matsim.freight.logistics.LogisticChain;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /**
  *  This strategy removes **one** randomly selected shipment from logistic chain with the most shipments and reassign it to one of the chains with the lowest number of shipments.
@@ -87,7 +87,7 @@ class RebalancingStrategyFactory {
             if (minChain.equals(maxChain)) return;
 
             // get the first shipment ID from the chain with the maximum shipment count
-            Id<LSPShipment> shipmentIdForReplanning = maxChain.getLspShipmentIds().iterator().next();
+            Id<LspShipment> shipmentIdForReplanning = maxChain.getLspShipmentIds().iterator().next();
 
             // iterate through the chains and move the shipment from the max chain to the min chain
             for (LogisticChain logisticChain : lsp.getSelectedPlan().getLogisticChains()) {

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RoundRobinDistributionAllShipmentsStrategyFactory.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RoundRobinDistributionAllShipmentsStrategyFactory.java
@@ -33,7 +33,7 @@ import org.matsim.core.replanning.selectors.ExpBetaPlanSelector;
 import org.matsim.freight.logistics.LSP;
 import org.matsim.freight.logistics.LSPPlan;
 import org.matsim.freight.logistics.LogisticChain;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /**
  *  This strategy removes **all** shipments from the logistic chains and reassigns them.
@@ -73,7 +73,7 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
             LSP lsp = lspPlan.getLSP();
             Map<LogisticChain, Integer> shipmentCountByChain = new LinkedHashMap<>();
 
-            for (LSPShipment lspShipment : lsp.getLspShipments()) {
+            for (LspShipment lspShipment : lsp.getLspShipments()) {
               if (shipmentCountByChain.isEmpty()) {
                 for (LogisticChain chain : lsp.getSelectedPlan().getLogisticChains()) {
                   shipmentCountByChain.put(chain, 0);

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RoundRobinLogisticChainShipmentAssigner.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/RoundRobinLogisticChainShipmentAssigner.java
@@ -28,10 +28,10 @@ import org.matsim.core.gbl.Gbl;
 import org.matsim.freight.logistics.InitialShipmentAssigner;
 import org.matsim.freight.logistics.LSPPlan;
 import org.matsim.freight.logistics.LogisticChain;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /**
- * The {@link LSPShipment} is assigned consecutively to a {@link LogisticChain}. In case of one
+ * The {@link LspShipment} is assigned consecutively to a {@link LogisticChain}. In case of one
  * chain the shipment is assigned to that chain. If there are more chains, the shipment is assigned
  * to the chain which has the least shipments to this point and thus distributes the shipments
  * evenly in sequence across the logistics chains. Requirements: There must be at least one
@@ -45,7 +45,7 @@ class RoundRobinLogisticChainShipmentAssigner implements InitialShipmentAssigner
   RoundRobinLogisticChainShipmentAssigner() {}
 
   @Override
-  public void assignToPlan(LSPPlan lspPlan, LSPShipment lspShipment) {
+  public void assignToPlan(LSPPlan lspPlan, LspShipment lspShipment) {
     Gbl.assertIf(!lspPlan.getLogisticChains().isEmpty());
     // prepare the map if empty for the first time with each number of assigned shipments being zero
     if (shipmentCountByChain.isEmpty()) {

--- a/src/main/java/org/matsim/freight/logistics/examples/requirementsChecking/BlueRequirement.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/requirementsChecking/BlueRequirement.java
@@ -45,9 +45,9 @@ package org.matsim.freight.logistics.examples.requirementsChecking;
 import static org.matsim.freight.logistics.examples.requirementsChecking.ExampleCheckRequirementsOfAssigner.ATTRIBUTE_COLOR;
 
 import org.matsim.freight.logistics.LogisticChain;
-import org.matsim.freight.logistics.shipment.LSPShipmentRequirement;
+import org.matsim.freight.logistics.shipment.LspShipmentRequirement;
 
-/*package-private*/ class BlueRequirement implements LSPShipmentRequirement {
+/*package-private*/ class BlueRequirement implements LspShipmentRequirement {
 
   static final String BLUE = "blue";
 

--- a/src/main/java/org/matsim/freight/logistics/examples/requirementsChecking/ExampleCheckRequirementsOfAssigner.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/requirementsChecking/ExampleCheckRequirementsOfAssigner.java
@@ -57,8 +57,8 @@ import org.matsim.freight.carriers.*;
 import org.matsim.freight.carriers.CarrierCapabilities.FleetSize;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 
@@ -173,17 +173,17 @@ class ExampleCheckRequirementsOfAssigner {
         .build();
   }
 
-  public static Collection<LSPShipment> createShipmentsWithRequirements(Network network) {
+  public static Collection<LspShipment> createShipmentsWithRequirements(Network network) {
     // Create ten shipments with either a red or blue requirement, i.e. that they only can be
     // transported in a solution with the matching color
-    ArrayList<LSPShipment> shipmentList = new ArrayList<>();
+    ArrayList<LspShipment> shipmentList = new ArrayList<>();
     ArrayList<Link> linkList = new ArrayList<>(network.getLinks().values());
 
     Random rand = new Random(1);
 
     for (int i = 1; i < 11; i++) {
-      Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-      ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+      Id<LspShipment> id = Id.create(i, LspShipment.class);
+      LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
       int capacityDemand = rand.nextInt(10);
       builder.setCapacityDemand(capacityDemand);
 
@@ -230,17 +230,17 @@ class ExampleCheckRequirementsOfAssigner {
 
     // Create LSP and lspShipments
     LSP lsp = createLSPWithProperties(scenario);
-    Collection<LSPShipment> lspShipments = createShipmentsWithRequirements(network);
+    Collection<LspShipment> lspShipments = createShipmentsWithRequirements(network);
 
     // assign the lspShipments to the LSP
-    for (LSPShipment lspShipment : lspShipments) {
+    for (LspShipment lspShipment : lspShipments) {
       lsp.assignShipmentToLSP(lspShipment);
     }
 
     for (LogisticChain logisticChain : lsp.getSelectedPlan().getLogisticChains()) {
       if (logisticChain.getId().toString().equals("RedSolution")) {
-        for (Id<LSPShipment> lspShipmentId : logisticChain.getLspShipmentIds()) {
-          LSPShipment lspShipment = LSPUtils.findLspShipment(lsp, lspShipmentId);
+        for (Id<LspShipment> lspShipmentId : logisticChain.getLspShipmentIds()) {
+          LspShipment lspShipment = LSPUtils.findLspShipment(lsp, lspShipmentId);
             if (lspShipment != null && !(lspShipment.getRequirements().iterator().next() instanceof RedRequirement)) {
                 break;
             }
@@ -248,8 +248,8 @@ class ExampleCheckRequirementsOfAssigner {
         System.out.println("All lspShipments in " + logisticChain.getId() + " are red");
       }
       if (logisticChain.getId().toString().equals("BlueSolution")) {
-        for (Id<LSPShipment> lspShipmentId : logisticChain.getLspShipmentIds()) {
-          LSPShipment shipment = LSPUtils.findLspShipment(lsp, lspShipmentId);
+        for (Id<LspShipment> lspShipmentId : logisticChain.getLspShipmentIds()) {
+          LspShipment shipment = LSPUtils.findLspShipment(lsp, lspShipmentId);
             if (shipment != null && !(shipment.getRequirements().iterator().next() instanceof BlueRequirement)) {
                 break;
             }

--- a/src/main/java/org/matsim/freight/logistics/examples/requirementsChecking/RedRequirement.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/requirementsChecking/RedRequirement.java
@@ -43,9 +43,9 @@
 package org.matsim.freight.logistics.examples.requirementsChecking;
 
 import org.matsim.freight.logistics.LogisticChain;
-import org.matsim.freight.logistics.shipment.LSPShipmentRequirement;
+import org.matsim.freight.logistics.shipment.LspShipmentRequirement;
 
-/*package-private*/ class RedRequirement implements LSPShipmentRequirement {
+/*package-private*/ class RedRequirement implements LspShipmentRequirement {
 
   static final String RED = "red";
 

--- a/src/main/java/org/matsim/freight/logistics/examples/requirementsChecking/RequirementsAssigner.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/requirementsChecking/RequirementsAssigner.java
@@ -47,8 +47,8 @@ import java.util.Collection;
 import org.matsim.freight.logistics.InitialShipmentAssigner;
 import org.matsim.freight.logistics.LSPPlan;
 import org.matsim.freight.logistics.LogisticChain;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.LSPShipmentRequirement;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentRequirement;
 
 class RequirementsAssigner implements InitialShipmentAssigner {
 
@@ -59,12 +59,12 @@ class RequirementsAssigner implements InitialShipmentAssigner {
   }
 
   @Override
-  public void assignToPlan(LSPPlan lspPlan, LSPShipment lspShipment) {
+  public void assignToPlan(LSPPlan lspPlan, LspShipment lspShipment) {
     feasibleLogisticChains.clear();
 
     label:
     for (LogisticChain solution : lspPlan.getLogisticChains()) {
-      for (LSPShipmentRequirement requirement : lspShipment.getRequirements()) {
+      for (LspShipmentRequirement requirement : lspShipment.getRequirements()) {
         if (!requirement.checkRequirement(solution)) {
 
           continue label;

--- a/src/main/java/org/matsim/freight/logistics/examples/simulationTrackers/ExampleSimulationTrackers.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/simulationTrackers/ExampleSimulationTrackers.java
@@ -39,8 +39,8 @@ import org.matsim.freight.carriers.*;
 import org.matsim.freight.carriers.CarrierCapabilities.FleetSize;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 
@@ -129,14 +129,14 @@ import org.matsim.vehicles.VehicleType;
     return collectionLSPBuilder.build();
   }
 
-  public static Collection<LSPShipment> createInitialLSPShipments(Network network) {
-    ArrayList<LSPShipment> shipmentList = new ArrayList<>();
+  public static Collection<LspShipment> createInitialLSPShipments(Network network) {
+    ArrayList<LspShipment> shipmentList = new ArrayList<>();
     ArrayList<Link> linkList = new ArrayList<>(network.getLinks().values());
 
     // Create five LSPShipments that are located in the left half of the network.
     for (int i = 1; i < 6; i++) {
-      Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-      ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+      Id<LspShipment> id = Id.create(i, LspShipment.class);
+      LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
       Random random = new Random(1);
       int capacityDemand = random.nextInt(4);
       builder.setCapacityDemand(capacityDemand);
@@ -176,10 +176,10 @@ import org.matsim.vehicles.VehicleType;
 
     // Create LSP and lspShipments
     LSP lsp = createLSPWithTracker(scenario);
-    Collection<LSPShipment> lspShipments = createInitialLSPShipments(network);
+    Collection<LspShipment> lspShipments = createInitialLSPShipments(network);
 
     // assign the lspShipments to the LSP
-    for (LSPShipment lspShipment : lspShipments) {
+    for (LspShipment lspShipment : lspShipments) {
       lsp.assignShipmentToLSP(lspShipment);
     }
 

--- a/src/main/java/org/matsim/freight/logistics/io/LSPPlanXmlParserV1.java
+++ b/src/main/java/org/matsim/freight/logistics/io/LSPPlanXmlParserV1.java
@@ -36,9 +36,9 @@ import org.matsim.freight.carriers.*;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
 import org.matsim.freight.logistics.resourceImplementations.TransshipmentHubResource;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.utils.objectattributes.attributable.AttributesXmlReaderDelegate;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
@@ -57,12 +57,12 @@ class LSPPlanXmlParserV1 extends MatsimXmlParser {
   private final LSPs lsPs;
   private final Carriers carriers;
   private final Map<String, String> elementIdResourceIdMap = new LinkedHashMap<>();
-  private final Map<String, ShipmentPlanElement> planElements = new LinkedHashMap<>();
+  private final Map<String, LspShipmentPlanElement> planElements = new LinkedHashMap<>();
   private final AttributesXmlReaderDelegate attributesReader = new AttributesXmlReaderDelegate();
   private final List<LogisticChain> logisticChains = new LinkedList<>();
   private LSP currentLsp = null;
   private Carrier currentCarrier = null;
-  private LSPShipment currentShipment = null;
+  private LspShipment currentShipment = null;
   private LSPPlan currentLspPlan = null;
   private CarrierCapabilities.Builder capabilityBuilder;
   private TransshipmentHubResource hubResource;
@@ -180,7 +180,7 @@ class LSPPlanXmlParserV1 extends MatsimXmlParser {
       case SHIPMENT -> {
         String shipmentId = atts.getValue(ID);
         Gbl.assertNotNull(shipmentId);
-        Id<LSPShipment> id = Id.create(shipmentId, LSPShipment.class);
+        Id<LspShipment> id = Id.create(shipmentId, LspShipment.class);
 
         String from = atts.getValue(FROM);
         Gbl.assertNotNull(from);
@@ -189,8 +189,8 @@ class LSPPlanXmlParserV1 extends MatsimXmlParser {
         String sizeString = atts.getValue(SIZE);
         Gbl.assertNotNull(sizeString);
         int size = Integer.parseInt(sizeString);
-        ShipmentUtils.LSPShipmentBuilder shipmentBuilder =
-            ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+        LspShipmentUtils.LspShipmentBuilder shipmentBuilder =
+            LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 
         shipmentBuilder.setFromLinkId(Id.createLinkId(from));
         shipmentBuilder.setToLinkId(Id.createLinkId(to));
@@ -258,32 +258,32 @@ class LSPPlanXmlParserV1 extends MatsimXmlParser {
         String resourceId = atts.getValue(RESOURCE_ID);
         Gbl.assertNotNull(resourceId);
 
-        ShipmentPlanElement planElement = null;
+        LspShipmentPlanElement planElement = null;
 
         switch (type) {
           case "LOAD" -> {
-            var planElementBuilder = ShipmentUtils.ScheduledShipmentLoadBuilder.newInstance();
+            var planElementBuilder = LspShipmentUtils.ScheduledShipmentLoadBuilder.newInstance();
             planElementBuilder.setStartTime(parseTimeToDouble(startTime));
             planElementBuilder.setEndTime(parseTimeToDouble(endTime));
             planElementBuilder.setResourceId(Id.create(resourceId, LSPResource.class));
             planElement = planElementBuilder.build();
           }
           case "TRANSPORT" -> {
-            var planElementBuilder = ShipmentUtils.ScheduledShipmentTransportBuilder.newInstance();
+            var planElementBuilder = LspShipmentUtils.ScheduledShipmentTransportBuilder.newInstance();
             planElementBuilder.setStartTime(parseTimeToDouble(startTime));
             planElementBuilder.setEndTime(parseTimeToDouble(endTime));
             planElementBuilder.setResourceId(Id.create(resourceId, LSPResource.class));
             planElement = planElementBuilder.build();
           }
           case "UNLOAD" -> {
-            var planElementBuilder = ShipmentUtils.ScheduledShipmentUnloadBuilder.newInstance();
+            var planElementBuilder = LspShipmentUtils.ScheduledShipmentUnloadBuilder.newInstance();
             planElementBuilder.setStartTime(parseTimeToDouble(startTime));
             planElementBuilder.setEndTime(parseTimeToDouble(endTime));
             planElementBuilder.setResourceId(Id.create(resourceId, LSPResource.class));
             planElement = planElementBuilder.build();
           }
           case "HANDLE" -> {
-            var planElementBuilder = ShipmentUtils.ScheduledShipmentHandleBuilder.newInstance();
+            var planElementBuilder = LspShipmentUtils.ScheduledShipmentHandleBuilder.newInstance();
             planElementBuilder.setStartTime(parseTimeToDouble(startTime));
             planElementBuilder.setEndTime(parseTimeToDouble(endTime));
             planElementBuilder.setResourceId(Id.create(resourceId, LSPResource.class));
@@ -405,12 +405,12 @@ class LSPPlanXmlParserV1 extends MatsimXmlParser {
       }
 
       case SHIPMENT_PLAN -> {
-        for (LSPShipment lspShipment : currentLsp.getLspShipments()) {
+        for (LspShipment lspShipment : currentLsp.getLspShipments()) {
           if (lspShipment.getId().toString().equals(shipmentPlanId)) {
-            for (Map.Entry<String, ShipmentPlanElement> planElement : planElements.entrySet()) {
-              ShipmentUtils.getOrCreateShipmentPlan(currentLspPlan, lspShipment.getId())
+            for (Map.Entry<String, LspShipmentPlanElement> planElement : planElements.entrySet()) {
+              LspShipmentUtils.getOrCreateShipmentPlan(currentLspPlan, lspShipment.getId())
                   .addPlanElement(
-                      Id.create(planElement.getKey(), ShipmentPlanElement.class),
+                      Id.create(planElement.getKey(), LspShipmentPlanElement.class),
                       planElement.getValue());
             }
           }

--- a/src/main/java/org/matsim/freight/logistics/io/LSPPlanXmlWriter.java
+++ b/src/main/java/org/matsim/freight/logistics/io/LSPPlanXmlWriter.java
@@ -37,9 +37,9 @@ import org.matsim.core.utils.io.MatsimXmlWriter;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.LSP;
 import org.matsim.freight.logistics.resourceImplementations.TransshipmentHubResource;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 
 /**
  * Writes out resources, shipments and plans for each LSP in an XML-file including header for
@@ -130,7 +130,7 @@ public class LSPPlanXmlWriter extends MatsimXmlWriter {
   private void writeShipments(LSP lsp) throws IOException {
     if (lsp.getLspShipments().isEmpty()) return;
     this.writeStartTag(SHIPMENTS, null);
-    for (LSPShipment lspShipment : lsp.getLspShipments()) {
+    for (LspShipment lspShipment : lsp.getLspShipments()) {
       this.writeStartTag(
           SHIPMENT,
           List.of(
@@ -185,7 +185,7 @@ public class LSPPlanXmlWriter extends MatsimXmlWriter {
 
       writeStartTag(SHIPMENT_PLANS, null);
       for (LogisticChain chain : plan.getLogisticChains()) {
-        for (Id<LSPShipment> shipmentId : chain.getLspShipmentIds()) {
+        for (Id<LspShipment> shipmentId : chain.getLspShipmentIds()) {
           if (chain.getLspShipmentIds().contains(shipmentId)) {
             this.writeStartTag(
                 SHIPMENT_PLAN,
@@ -193,12 +193,12 @@ public class LSPPlanXmlWriter extends MatsimXmlWriter {
                     createTuple(SHIPMENT_ID, shipmentId.toString()),
                     createTuple(CHAIN_ID, chain.getId().toString())));
           }
-          LSPShipment lspShipment = LSPUtils.findLspShipment(lsp, shipmentId);
+          LspShipment lspShipment = LSPUtils.findLspShipment(lsp, shipmentId);
           assert lspShipment != null;
-          final Map<Id<ShipmentPlanElement>, ShipmentPlanElement> planElements =
-              ShipmentUtils.getOrCreateShipmentPlan(plan, lspShipment.getId()).getPlanElements();
-          for (Id<ShipmentPlanElement> elementId : planElements.keySet()) {
-            ShipmentPlanElement element = planElements.get(elementId);
+          final Map<Id<LspShipmentPlanElement>, LspShipmentPlanElement> planElements =
+              LspShipmentUtils.getOrCreateShipmentPlan(plan, lspShipment.getId()).getPlanElements();
+          for (Id<LspShipmentPlanElement> elementId : planElements.keySet()) {
+            LspShipmentPlanElement element = planElements.get(elementId);
             this.writeStartTag(
                 ELEMENT,
                 List.of(

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/CarrierSchedulerUtils.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/CarrierSchedulerUtils.java
@@ -19,6 +19,7 @@ import org.matsim.freight.carriers.CarriersUtils;
 import org.matsim.freight.carriers.jsprit.MatsimJspritFactory;
 import org.matsim.freight.carriers.jsprit.NetworkBasedTransportCosts;
 import org.matsim.freight.carriers.jsprit.NetworkRouter;
+import org.matsim.freight.logistics.LSPUtils;
 
 /**
  * This class contains some code fragments, that are used in the different *CarrierScheduler
@@ -28,6 +29,7 @@ import org.matsim.freight.carriers.jsprit.NetworkRouter;
  */
 public class CarrierSchedulerUtils {
   private static final Logger log = LogManager.getLogger(CarrierSchedulerUtils.class);
+  private static final String LOGIC_OF_VRP = "logicOfVrp";
 
   /**
    * Creates a VehicleRoutingProblem from a carrier and a network and solves it with Jsprit.
@@ -107,4 +109,27 @@ public class CarrierSchedulerUtils {
     }
     return jspritScore;
   }
+
+  /**
+   * Setter for the internal solving logic of a VRP.
+   * This decides later, whether the VRP is build base on {@link org.matsim.freight.carriers.CarrierService}s or {@link org.matsim.freight.carriers.CarrierShipment}s.
+   *
+   * @param carrier The carrier for which the setting should be set.
+   * @param logicOfVrp the logic of the VRP
+   */
+  public static void setVrpLogic(Carrier carrier, LSPUtils.LogicOfVrp logicOfVrp){
+    carrier.getAttributes().putAttribute(LOGIC_OF_VRP, logicOfVrp);
+  }
+
+    /**
+     * Getter for the internal solving logic of a VRP.
+     * This decides later, whether the VRP is build base on {@link org.matsim.freight.carriers.CarrierService}s or {@link org.matsim.freight.carriers.CarrierShipment}s.
+     *
+     * @param carrier The carrier for which the setting should be got.
+     * @return the logic of the VRP
+     */
+  public static LSPUtils.LogicOfVrp getVrpLogic(Carrier carrier){
+    return (LSPUtils.LogicOfVrp) carrier.getAttributes().getAttribute(LOGIC_OF_VRP);
+  }
+
 }

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
@@ -31,14 +31,14 @@ import org.matsim.freight.carriers.Tour;
 import org.matsim.freight.carriers.Tour.Leg;
 import org.matsim.freight.carriers.Tour.TourElement;
 import org.matsim.freight.logistics.*;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 
 /**
  * Schedules the {@link CollectionCarrierResource}.
  *
- * <p>Converts the {@link LSPShipment}s into {@link CarrierService}s that are needed for the {@link
+ * <p>Converts the {@link LspShipment}s into {@link CarrierService}s that are needed for the {@link
  * Carrier} from the freight contrib of MATSim and then routes the vehicles of this {@link Carrier}
  * through the network by calling the corresponding methods of jsprit
  */
@@ -120,8 +120,8 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
 
   private void addShipmentLoadElement(
       LspShipmentWithTime tuple, Tour tour, Tour.ServiceActivity serviceActivity) {
-    ShipmentUtils.ScheduledShipmentLoadBuilder builder =
-        ShipmentUtils.ScheduledShipmentLoadBuilder.newInstance();
+    LspShipmentUtils.ScheduledShipmentLoadBuilder builder =
+        LspShipmentUtils.ScheduledShipmentLoadBuilder.newInstance();
     builder.setResourceId(resource.getId());
     for (LogisticChainElement element : resource.getClientElements()) {
       if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
@@ -135,18 +135,18 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
     builder.setStartTime(startTimeOfLoading);
     builder.setEndTime(startTimeOfLoading + tuple.getLspShipment().getDeliveryServiceTime());
 
-    ShipmentPlanElement load = builder.build();
+    LspShipmentPlanElement load = builder.build();
     String idString =
         load.getResourceId() + "" + load.getLogisticChainElement().getId() + load.getElementType();
-    Id<ShipmentPlanElement> id = Id.create(idString, ShipmentPlanElement.class);
-    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
+    Id<LspShipmentPlanElement> id = Id.create(idString, LspShipmentPlanElement.class);
+    LspShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
         .addPlanElement(id, load);
   }
 
   private void addShipmentTransportElement(
       LspShipmentWithTime tuple, Tour tour, Tour.ServiceActivity serviceActivity) {
-    ShipmentUtils.ScheduledShipmentTransportBuilder builder =
-        ShipmentUtils.ScheduledShipmentTransportBuilder.newInstance();
+    LspShipmentUtils.ScheduledShipmentTransportBuilder builder =
+        LspShipmentUtils.ScheduledShipmentTransportBuilder.newInstance();
     builder.setResourceId(resource.getId());
     for (LogisticChainElement element : resource.getClientElements()) {
       if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
@@ -165,14 +165,14 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
     builder.setFromLinkId(serviceActivity.getLocation());
     builder.setToLinkId(tour.getEndLinkId());
     builder.setCarrierService(serviceActivity.getService());
-    ShipmentPlanElement transport = builder.build();
+    LspShipmentPlanElement transport = builder.build();
     String idString =
         transport.getResourceId()
             + ""
             + transport.getLogisticChainElement().getId()
             + transport.getElementType();
-    Id<ShipmentPlanElement> id = Id.create(idString, ShipmentPlanElement.class);
-    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
+    Id<LspShipmentPlanElement> id = Id.create(idString, LspShipmentPlanElement.class);
+    LspShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
         .addPlanElement(id, transport);
   }
 
@@ -207,8 +207,8 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
 
   private void addShipmentUnloadElement(
       LspShipmentWithTime tuple, Tour tour, Tour.ServiceActivity serviceActivity) {
-    ShipmentUtils.ScheduledShipmentUnloadBuilder builder =
-        ShipmentUtils.ScheduledShipmentUnloadBuilder.newInstance();
+    LspShipmentUtils.ScheduledShipmentUnloadBuilder builder =
+        LspShipmentUtils.ScheduledShipmentUnloadBuilder.newInstance();
     builder.setResourceId(resource.getId());
     for (LogisticChainElement element : resource.getClientElements()) {
       if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
@@ -220,14 +220,14 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
     builder.setStartTime(startTime);
     builder.setEndTime(startTime + getUnloadEndTime(tour));
 
-    ShipmentPlanElement unload = builder.build();
+    LspShipmentPlanElement unload = builder.build();
     String idString =
         unload.getResourceId()
             + ""
             + unload.getLogisticChainElement().getId()
             + unload.getElementType();
-    Id<ShipmentPlanElement> id = Id.create(idString, ShipmentPlanElement.class);
-    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
+    Id<LspShipmentPlanElement> id = Id.create(idString, LspShipmentPlanElement.class);
+    LspShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
         .addPlanElement(id, unload);
   }
 

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionServiceEndEventHandler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionServiceEndEventHandler.java
@@ -31,24 +31,24 @@ import org.matsim.freight.logistics.LSPCarrierResource;
 import org.matsim.freight.logistics.LSPResource;
 import org.matsim.freight.logistics.LSPSimulationTracker;
 import org.matsim.freight.logistics.LogisticChainElement;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentLeg;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentLeg;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 
 /*package-private*/ class CollectionServiceEndEventHandler
     implements AfterMobsimListener,
         CarrierServiceEndEventHandler,
-        LSPSimulationTracker<LSPShipment> {
+        LSPSimulationTracker<LspShipment> {
 
   private final CarrierService carrierService;
   private final LogisticChainElement logisticChainElement;
   private final LSPCarrierResource resource;
-  private LSPShipment lspShipment;
+  private LspShipment lspShipment;
 
   public CollectionServiceEndEventHandler(
       CarrierService carrierService,
-      LSPShipment lspShipment,
+      LspShipment lspShipment,
       LogisticChainElement element,
       LSPCarrierResource resource) {
     this.carrierService = carrierService;
@@ -73,39 +73,39 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
   }
 
   private void logLoad(CarrierServiceEndEvent event) {
-    ShipmentUtils.LoggedShipmentLoadBuilder builder =
-        ShipmentUtils.LoggedShipmentLoadBuilder.newInstance();
+    LspShipmentUtils.LoggedShipmentLoadBuilder builder =
+        LspShipmentUtils.LoggedShipmentLoadBuilder.newInstance();
     builder.setStartTime(event.getTime() - event.getServiceDuration());
     builder.setEndTime(event.getTime());
     builder.setLogisticsChainElement(logisticChainElement);
     builder.setResourceId(resource.getId());
     builder.setLinkId(event.getLinkId());
     builder.setCarrierId(event.getCarrierId());
-    ShipmentPlanElement loggedShipmentLoad = builder.build();
+    LspShipmentPlanElement loggedShipmentLoad = builder.build();
     String idString =
         loggedShipmentLoad.getResourceId()
             + ""
             + loggedShipmentLoad.getLogisticChainElement().getId()
             + loggedShipmentLoad.getElementType();
-    Id<ShipmentPlanElement> loadId = Id.create(idString, ShipmentPlanElement.class);
+    Id<LspShipmentPlanElement> loadId = Id.create(idString, LspShipmentPlanElement.class);
     lspShipment.getShipmentLog().addPlanElement(loadId, loggedShipmentLoad);
   }
 
   private void logTransport(CarrierServiceEndEvent event) {
-    ShipmentUtils.LoggedShipmentTransportBuilder builder =
-        ShipmentUtils.LoggedShipmentTransportBuilder.newInstance();
+    LspShipmentUtils.LoggedShipmentTransportBuilder builder =
+        LspShipmentUtils.LoggedShipmentTransportBuilder.newInstance();
     builder.setStartTime(event.getTime());
     builder.setLogisticChainElement(logisticChainElement);
     builder.setResourceId(resource.getId());
     builder.setFromLinkId(event.getLinkId());
     builder.setCarrierId(event.getCarrierId());
-    ShipmentLeg transport = builder.build();
+    LspShipmentLeg transport = builder.build();
     String idString =
         transport.getResourceId()
             + ""
             + transport.getLogisticChainElement().getId()
             + transport.getElementType();
-    Id<ShipmentPlanElement> transportId = Id.create(idString, ShipmentPlanElement.class);
+    Id<LspShipmentPlanElement> transportId = Id.create(idString, LspShipmentPlanElement.class);
     lspShipment.getShipmentLog().addPlanElement(transportId, transport);
   }
 
@@ -113,7 +113,7 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
     return carrierService;
   }
 
-  public LSPShipment getLspShipment() {
+  public LspShipment getLspShipment() {
     return lspShipment;
   }
 
@@ -126,7 +126,7 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
   }
 
   @Override
-  public void setEmbeddingContainer(LSPShipment pointer) {
+  public void setEmbeddingContainer(LspShipment pointer) {
     this.lspShipment = pointer;
   }
 

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
@@ -34,8 +34,8 @@ import org.matsim.freight.carriers.Tour.Leg;
 import org.matsim.freight.carriers.Tour.ServiceActivity;
 import org.matsim.freight.carriers.Tour.TourElement;
 import org.matsim.freight.logistics.*;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.VehicleType;
 
 /**
@@ -207,8 +207,8 @@ import org.matsim.vehicles.VehicleType;
 
   private void addShipmentLoadElement(
       LspShipmentWithTime tuple, Tour tour, Tour.ServiceActivity serviceActivity) {
-    ShipmentUtils.ScheduledShipmentLoadBuilder builder =
-        ShipmentUtils.ScheduledShipmentLoadBuilder.newInstance();
+    LspShipmentUtils.ScheduledShipmentLoadBuilder builder =
+        LspShipmentUtils.ScheduledShipmentLoadBuilder.newInstance();
     builder.setResourceId(resource.getId());
     for (LogisticChainElement element : resource.getClientElements()) {
       if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
@@ -228,18 +228,18 @@ import org.matsim.vehicles.VehicleType;
     builder.setStartTime(startTimeOfTransport - cumulatedLoadingTime);
     builder.setEndTime(startTimeOfTransport);
 
-    ShipmentPlanElement load = builder.build();
+    LspShipmentPlanElement load = builder.build();
     String idString =
         load.getResourceId() + "" + load.getLogisticChainElement().getId() + load.getElementType();
-    Id<ShipmentPlanElement> id = Id.create(idString, ShipmentPlanElement.class);
-    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
+    Id<LspShipmentPlanElement> id = Id.create(idString, LspShipmentPlanElement.class);
+    LspShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
         .addPlanElement(id, load);
   }
 
   private void addShipmentTransportElement(
       LspShipmentWithTime tuple, Tour tour, Tour.ServiceActivity serviceActivity) {
-    ShipmentUtils.ScheduledShipmentTransportBuilder builder =
-        ShipmentUtils.ScheduledShipmentTransportBuilder.newInstance();
+    LspShipmentUtils.ScheduledShipmentTransportBuilder builder =
+        LspShipmentUtils.ScheduledShipmentTransportBuilder.newInstance();
     builder.setResourceId(resource.getId());
     for (LogisticChainElement element : resource.getClientElements()) {
       if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
@@ -267,21 +267,21 @@ import org.matsim.vehicles.VehicleType;
     builder.setFromLinkId(tour.getStartLinkId());
     builder.setToLinkId(serviceActivity.getLocation());
     builder.setCarrierService(serviceActivity.getService());
-    ShipmentPlanElement transport = builder.build();
+    LspShipmentPlanElement transport = builder.build();
     String idString =
         transport.getResourceId()
             + ""
             + transport.getLogisticChainElement().getId()
             + transport.getElementType();
-    Id<ShipmentPlanElement> id = Id.create(idString, ShipmentPlanElement.class);
-    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
+    Id<LspShipmentPlanElement> id = Id.create(idString, LspShipmentPlanElement.class);
+    LspShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
         .addPlanElement(id, transport);
   }
 
   private void addShipmentUnloadElement(
       LspShipmentWithTime tuple, Tour tour, Tour.ServiceActivity serviceActivity) {
-    ShipmentUtils.ScheduledShipmentUnloadBuilder builder =
-        ShipmentUtils.ScheduledShipmentUnloadBuilder.newInstance();
+    LspShipmentUtils.ScheduledShipmentUnloadBuilder builder =
+        LspShipmentUtils.ScheduledShipmentUnloadBuilder.newInstance();
     builder.setResourceId(resource.getId());
     for (LogisticChainElement element : resource.getClientElements()) {
       if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
@@ -300,13 +300,13 @@ import org.matsim.vehicles.VehicleType;
     builder.setStartTime(startTime);
     builder.setEndTime(endTime);
 
-    ShipmentPlanElement unload = builder.build();
+    LspShipmentPlanElement unload = builder.build();
     String idString =
         unload.getResourceId()
             + String.valueOf(unload.getLogisticChainElement().getId())
             + unload.getElementType();
-    Id<ShipmentPlanElement> id = Id.create(idString, ShipmentPlanElement.class);
-    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
+    Id<LspShipmentPlanElement> id = Id.create(idString, LspShipmentPlanElement.class);
+    LspShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
         .addPlanElement(id, unload);
   }
 

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionServiceStartEventHandler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionServiceStartEventHandler.java
@@ -30,24 +30,24 @@ import org.matsim.freight.carriers.events.eventhandler.CarrierServiceStartEventH
 import org.matsim.freight.logistics.LSPCarrierResource;
 import org.matsim.freight.logistics.LSPSimulationTracker;
 import org.matsim.freight.logistics.LogisticChainElement;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentLeg;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentLeg;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 
 /*package-private*/ class DistributionServiceStartEventHandler
     implements AfterMobsimListener,
         CarrierServiceStartEventHandler,
-        LSPSimulationTracker<LSPShipment> {
+        LSPSimulationTracker<LspShipment> {
 
   private final CarrierService carrierService;
   private final LogisticChainElement logisticChainElement;
   private final LSPCarrierResource resource;
-  private LSPShipment lspShipment;
+  private LspShipment lspShipment;
 
   DistributionServiceStartEventHandler(
       CarrierService carrierService,
-      LSPShipment lspShipment,
+      LspShipment lspShipment,
       LogisticChainElement element,
       LSPCarrierResource resource) {
     this.carrierService = carrierService;
@@ -73,30 +73,30 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
 
   private void logTransport(CarrierServiceStartEvent event) {
     String idString = resource.getId() + "" + logisticChainElement.getId() + "TRANSPORT";
-    Id<ShipmentPlanElement> id = Id.create(idString, ShipmentPlanElement.class);
-    ShipmentPlanElement abstractPlanElement =
+    Id<LspShipmentPlanElement> id = Id.create(idString, LspShipmentPlanElement.class);
+    LspShipmentPlanElement abstractPlanElement =
         lspShipment.getShipmentLog().getPlanElements().get(id);
-    if (abstractPlanElement instanceof ShipmentLeg transport) {
+    if (abstractPlanElement instanceof LspShipmentLeg transport) {
       transport.setEndTime(event.getTime());
     }
   }
 
   private void logUnload(CarrierServiceStartEvent event) {
-    ShipmentUtils.LoggedShipmentUnloadBuilder builder =
-        ShipmentUtils.LoggedShipmentUnloadBuilder.newInstance();
+    LspShipmentUtils.LoggedShipmentUnloadBuilder builder =
+        LspShipmentUtils.LoggedShipmentUnloadBuilder.newInstance();
     builder.setCarrierId(event.getCarrierId());
     builder.setLinkId(event.getLinkId());
     builder.setLogisticChainElement(logisticChainElement);
     builder.setResourceId(resource.getId());
     builder.setStartTime(event.getTime());
     builder.setEndTime(event.getTime() + event.getServiceDuration());
-    ShipmentPlanElement unload = builder.build();
+    LspShipmentPlanElement unload = builder.build();
     String idString =
         unload.getResourceId()
             + ""
             + unload.getLogisticChainElement().getId()
             + unload.getElementType();
-    Id<ShipmentPlanElement> unloadId = Id.create(idString, ShipmentPlanElement.class);
+    Id<LspShipmentPlanElement> unloadId = Id.create(idString, LspShipmentPlanElement.class);
     lspShipment.getShipmentLog().addPlanElement(unloadId, unload);
   }
 
@@ -104,7 +104,7 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
     return carrierService;
   }
 
-  public LSPShipment getLspShipment() {
+  public LspShipment getLspShipment() {
     return lspShipment;
   }
 
@@ -117,7 +117,7 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
   }
 
   @Override
-  public void setEmbeddingContainer(LSPShipment pointer) {
+  public void setEmbeddingContainer(LspShipment pointer) {
     this.lspShipment = pointer;
   }
 

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/LSPTourEndEventHandler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/LSPTourEndEventHandler.java
@@ -32,22 +32,22 @@ import org.matsim.freight.carriers.Tour.TourElement;
 import org.matsim.freight.carriers.events.CarrierTourEndEvent;
 import org.matsim.freight.carriers.events.eventhandler.CarrierTourEndEventHandler;
 import org.matsim.freight.logistics.*;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentLeg;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentLeg;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 
 /*package-private*/ class LSPTourEndEventHandler
-    implements AfterMobsimListener, CarrierTourEndEventHandler, LSPSimulationTracker<LSPShipment> {
+    implements AfterMobsimListener, CarrierTourEndEventHandler, LSPSimulationTracker<LspShipment> {
 
   private final CarrierService carrierService;
   private final LogisticChainElement logisticChainElement;
   private final LSPCarrierResource resource;
   private final Tour tour;
-  private LSPShipment lspShipment;
+  private LspShipment lspShipment;
 
   public LSPTourEndEventHandler(
-      LSPShipment lspShipment,
+      LspShipment lspShipment,
       CarrierService carrierService,
       LogisticChainElement logisticChainElement,
       LSPCarrierResource resource,
@@ -91,30 +91,30 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
   }
 
   private void logUnload(Id<Carrier> carrierId, double startTime, double endTime) {
-    ShipmentUtils.LoggedShipmentUnloadBuilder builder =
-        ShipmentUtils.LoggedShipmentUnloadBuilder.newInstance();
+    LspShipmentUtils.LoggedShipmentUnloadBuilder builder =
+        LspShipmentUtils.LoggedShipmentUnloadBuilder.newInstance();
     builder.setStartTime(startTime);
     builder.setEndTime(endTime);
     builder.setLogisticChainElement(logisticChainElement);
     builder.setResourceId(resource.getId());
     builder.setCarrierId(carrierId);
-    ShipmentPlanElement unload = builder.build();
+    LspShipmentPlanElement unload = builder.build();
     String idString =
         unload.getResourceId().toString()
             + unload.getLogisticChainElement().getId()
             + unload.getElementType();
-    Id<ShipmentPlanElement> unloadId = Id.create(idString, ShipmentPlanElement.class);
+    Id<LspShipmentPlanElement> unloadId = Id.create(idString, LspShipmentPlanElement.class);
     lspShipment.getShipmentLog().addPlanElement(unloadId, unload);
   }
 
   private void logTransport(double endTime, Id<Link> endLinkId) {
     String idString = resource.getId().toString() + logisticChainElement.getId() + "TRANSPORT";
-    ShipmentPlanElement abstractPlanElement =
+    LspShipmentPlanElement abstractPlanElement =
         lspShipment
             .getShipmentLog()
             .getPlanElements()
-            .get(Id.create(idString, ShipmentPlanElement.class));
-    if (abstractPlanElement instanceof ShipmentLeg transport) {
+            .get(Id.create(idString, LspShipmentPlanElement.class));
+    if (abstractPlanElement instanceof LspShipmentLeg transport) {
       transport.setEndTime(endTime);
       transport.setToLinkId(endLinkId);
     }
@@ -134,7 +134,7 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
     return carrierService;
   }
 
-  public LSPShipment getLspShipment() {
+  public LspShipment getLspShipment() {
     return lspShipment;
   }
 
@@ -147,7 +147,7 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
   }
 
   @Override
-  public void setEmbeddingContainer(LSPShipment pointer) {
+  public void setEmbeddingContainer(LspShipment pointer) {
     this.lspShipment = pointer;
   }
 

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/LSPTourStartEventHandler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/LSPTourStartEventHandler.java
@@ -34,22 +34,22 @@ import org.matsim.freight.logistics.LSPCarrierResource;
 import org.matsim.freight.logistics.LSPResource;
 import org.matsim.freight.logistics.LSPSimulationTracker;
 import org.matsim.freight.logistics.LogisticChainElement;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentLeg;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentLeg;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 
 /*package-private*/ class LSPTourStartEventHandler
-    implements CarrierTourStartEventHandler, LSPSimulationTracker<LSPShipment> {
+    implements CarrierTourStartEventHandler, LSPSimulationTracker<LspShipment> {
 
   private final Tour tour;
   private final CarrierService carrierService;
   private final LogisticChainElement logisticChainElement;
   private final LSPCarrierResource resource;
-  private LSPShipment lspShipment;
+  private LspShipment lspShipment;
 
   public LSPTourStartEventHandler(
-      LSPShipment lspShipment,
+      LspShipment lspShipment,
       CarrierService carrierService,
       LogisticChainElement logisticChainElement,
       LSPCarrierResource resource,
@@ -101,41 +101,41 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
 
   private void logLoad(Id<Carrier> carrierId, Id<Link> linkId,
       double startTime, double endTime) {
-    ShipmentUtils.LoggedShipmentLoadBuilder builder =
-        ShipmentUtils.LoggedShipmentLoadBuilder.newInstance();
+    LspShipmentUtils.LoggedShipmentLoadBuilder builder =
+        LspShipmentUtils.LoggedShipmentLoadBuilder.newInstance();
     builder.setCarrierId(carrierId);
     builder.setLinkId(linkId);
     builder.setLogisticsChainElement(logisticChainElement);
     builder.setResourceId(resource.getId());
     builder.setStartTime(startTime);
     builder.setEndTime(endTime);
-    ShipmentPlanElement loggedShipmentLoad = builder.build();
+    LspShipmentPlanElement loggedShipmentLoad = builder.build();
     String idString =
         loggedShipmentLoad.getResourceId()
             + ""
             + loggedShipmentLoad.getLogisticChainElement().getId()
             + loggedShipmentLoad.getElementType();
-    Id<ShipmentPlanElement> loadId = Id.create(idString, ShipmentPlanElement.class);
+    Id<LspShipmentPlanElement> loadId = Id.create(idString, LspShipmentPlanElement.class);
     lspShipment.getShipmentLog().addPlanElement(loadId, loggedShipmentLoad);
   }
 
   private void logTransport(Id<Carrier> carrierId, Id<Link> fromLinkId,
       Id<Link> toLinkId, double startTime) {
-    ShipmentUtils.LoggedShipmentTransportBuilder builder =
-        ShipmentUtils.LoggedShipmentTransportBuilder.newInstance();
+    LspShipmentUtils.LoggedShipmentTransportBuilder builder =
+        LspShipmentUtils.LoggedShipmentTransportBuilder.newInstance();
     builder.setCarrierId(carrierId);
     builder.setFromLinkId(fromLinkId);
     builder.setToLinkId(toLinkId);
     builder.setLogisticChainElement(logisticChainElement);
     builder.setResourceId(resource.getId());
     builder.setStartTime(startTime);
-    ShipmentLeg transport = builder.build();
+    LspShipmentLeg transport = builder.build();
     String idString =
         transport.getResourceId()
             + ""
             + transport.getLogisticChainElement().getId()
             + transport.getElementType();
-    Id<ShipmentPlanElement> transportId = Id.create(idString, ShipmentPlanElement.class);
+    Id<LspShipmentPlanElement> transportId = Id.create(idString, LspShipmentPlanElement.class);
     lspShipment.getShipmentLog().addPlanElement(transportId, transport);
   }
 
@@ -153,7 +153,7 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
     return carrierService;
   }
 
-  public LSPShipment getLspShipment() {
+  public LspShipment getLspShipment() {
     return lspShipment;
   }
 
@@ -166,7 +166,7 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
   }
 
   @Override
-  public void setEmbeddingContainer(LSPShipment pointer) {
+  public void setEmbeddingContainer(LspShipment pointer) {
     this.lspShipment = pointer;
   }
 }

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/MainRunCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/MainRunCarrierScheduler.java
@@ -32,8 +32,8 @@ import org.matsim.freight.carriers.Tour.TourElement;
 import org.matsim.freight.carriers.jsprit.NetworkBasedTransportCosts;
 import org.matsim.freight.carriers.jsprit.NetworkRouter;
 import org.matsim.freight.logistics.*;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.VehicleType;
 
 /**
@@ -260,8 +260,8 @@ import org.matsim.vehicles.VehicleType;
 
   private void addShipmentLoadElement(
       LspShipmentWithTime tuple, Tour tour) {
-    ShipmentUtils.ScheduledShipmentLoadBuilder builder =
-        ShipmentUtils.ScheduledShipmentLoadBuilder.newInstance();
+    LspShipmentUtils.ScheduledShipmentLoadBuilder builder =
+        LspShipmentUtils.ScheduledShipmentLoadBuilder.newInstance();
     builder.setResourceId(resource.getId());
     for (LogisticChainElement element : resource.getClientElements()) {
       if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
@@ -281,20 +281,20 @@ import org.matsim.vehicles.VehicleType;
     builder.setStartTime(startTimeOfTransport - cumulatedLoadingTime);
     builder.setEndTime(startTimeOfTransport);
 
-    ShipmentPlanElement load = builder.build();
+    LspShipmentPlanElement load = builder.build();
     String idString =
         load.getResourceId()
             + String.valueOf(load.getLogisticChainElement().getId())
             + load.getElementType();
-    Id<ShipmentPlanElement> id = Id.create(idString, ShipmentPlanElement.class);
-    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
+    Id<LspShipmentPlanElement> id = Id.create(idString, LspShipmentPlanElement.class);
+    LspShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
         .addPlanElement(id, load);
   }
 
   private void addShipmentTransportElement(
       LspShipmentWithTime tuple, Tour tour, Tour.ServiceActivity serviceActivity) {
-    ShipmentUtils.ScheduledShipmentTransportBuilder builder =
-        ShipmentUtils.ScheduledShipmentTransportBuilder.newInstance();
+    LspShipmentUtils.ScheduledShipmentTransportBuilder builder =
+        LspShipmentUtils.ScheduledShipmentTransportBuilder.newInstance();
     builder.setResourceId(resource.getId());
     for (LogisticChainElement element : resource.getClientElements()) {
       if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
@@ -311,20 +311,20 @@ import org.matsim.vehicles.VehicleType;
     builder.setFromLinkId(tour.getStartLinkId());
     builder.setToLinkId(tour.getEndLinkId());
     builder.setCarrierService(serviceActivity.getService());
-    ShipmentPlanElement transport = builder.build();
+    LspShipmentPlanElement transport = builder.build();
     String idString =
         transport.getResourceId()
             + String.valueOf(transport.getLogisticChainElement().getId())
             + transport.getElementType();
-    Id<ShipmentPlanElement> id = Id.create(idString, ShipmentPlanElement.class);
-    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
+    Id<LspShipmentPlanElement> id = Id.create(idString, LspShipmentPlanElement.class);
+    LspShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
         .addPlanElement(id, transport);
   }
 
   private void addShipmentUnloadElement(
       LspShipmentWithTime tuple, Tour tour, Tour.ServiceActivity serviceActivity) {
-    ShipmentUtils.ScheduledShipmentUnloadBuilder builder =
-        ShipmentUtils.ScheduledShipmentUnloadBuilder.newInstance();
+    LspShipmentUtils.ScheduledShipmentUnloadBuilder builder =
+        LspShipmentUtils.ScheduledShipmentUnloadBuilder.newInstance();
     builder.setResourceId(resource.getId());
     for (LogisticChainElement element : resource.getClientElements()) {
       if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
@@ -347,13 +347,13 @@ import org.matsim.vehicles.VehicleType;
             + legAfterStart.getExpectedTransportTime()
             + cumulatedLoadingTime);
 
-    ShipmentPlanElement unload = builder.build();
+    LspShipmentPlanElement unload = builder.build();
     String idString =
         unload.getResourceId()
             + String.valueOf(unload.getLogisticChainElement().getId())
             + unload.getElementType();
-    Id<ShipmentPlanElement> id = Id.create(idString, ShipmentPlanElement.class);
-    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
+    Id<LspShipmentPlanElement> id = Id.create(idString, LspShipmentPlanElement.class);
+    LspShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
         .addPlanElement(id, unload);
   }
 

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/ResourceImplementationUtils.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/ResourceImplementationUtils.java
@@ -36,9 +36,9 @@ import org.matsim.freight.logistics.LSPPlan;
 import org.matsim.freight.logistics.LSPResource;
 import org.matsim.freight.logistics.LSPResourceScheduler;
 import org.matsim.freight.logistics.LogisticChainElement;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.VehicleType;
 
 @SuppressWarnings("ClassEscapesDefinedScope")
@@ -82,7 +82,7 @@ public class ResourceImplementationUtils {
       final String str0 = "LSP: " + lsp.getId();
       System.out.println(str0);
       writer.write(str0 + "\n");
-      for (LSPShipment lspShipment : lsp.getLspShipments()) {
+      for (LspShipment lspShipment : lsp.getLspShipments()) {
         final String str1 = "Shipment: " + lspShipment;
         System.out.println(str1);
         writer.write(str1 + "\n");
@@ -99,13 +99,13 @@ public class ResourceImplementationUtils {
       final String str0 = "LSP: " + lsp.getId();
       System.out.println(str0);
       writer.write(str0 + "\n");
-      for (LSPShipment shipment : lsp.getLspShipments()) {
-        ArrayList<ShipmentPlanElement> elementList =
+      for (LspShipment shipment : lsp.getLspShipments()) {
+        ArrayList<LspShipmentPlanElement> elementList =
             new ArrayList<>(
-                ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId())
+                LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId())
                     .getPlanElements()
                     .values());
-        elementList.sort(ShipmentUtils.createShipmentPlanElementComparator());
+        elementList.sort(LspShipmentUtils.createShipmentPlanElementComparator());
         writeShipmentWithPlanElements(writer, shipment, elementList);
       }
     } catch (IOException e) {
@@ -114,12 +114,12 @@ public class ResourceImplementationUtils {
   }
 
   private static void writeShipmentWithPlanElements(
-      BufferedWriter writer, LSPShipment lspShipment, ArrayList<ShipmentPlanElement> elementList)
+          BufferedWriter writer, LspShipment lspShipment, ArrayList<LspShipmentPlanElement> elementList)
       throws IOException {
     final String str1 = "Shipment: " + lspShipment;
     System.out.println(str1);
     writer.write(str1 + "\n");
-    for (ShipmentPlanElement element : elementList) {
+    for (LspShipmentPlanElement element : elementList) {
       final String str2 =
           element.getLogisticChainElement().getId()
               + "\t\t"
@@ -151,10 +151,10 @@ public class ResourceImplementationUtils {
       final String str0 = "LSP: " + lsp.getId();
       System.out.println(str0);
       writer.write(str0 + "\n");
-      for (LSPShipment lspShipment : lsp.getLspShipments()) {
-        ArrayList<ShipmentPlanElement> elementList =
+      for (LspShipment lspShipment : lsp.getLspShipments()) {
+        ArrayList<LspShipmentPlanElement> elementList =
             new ArrayList<>(lspShipment.getShipmentLog().getPlanElements().values());
-        elementList.sort(ShipmentUtils.createShipmentPlanElementComparator());
+        elementList.sort(LspShipmentUtils.createShipmentPlanElementComparator());
         writeShipmentWithPlanElements(writer, lspShipment, elementList);
       }
     } catch (IOException e) {

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/SimpleForwardLogisticChainScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/SimpleForwardLogisticChainScheduler.java
@@ -23,19 +23,19 @@ package org.matsim.freight.logistics.resourceImplementations;
 import java.util.List;
 import org.matsim.api.core.v01.Id;
 import org.matsim.freight.logistics.*;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /**
  * In the class SimpleForwardSolutionScheduler two tasks are performed:
  *
- * <p>1.) the {@link LSPShipment}s that were assigned to the suitable {@link LogisticChain} by the
+ * <p>1.) the {@link LspShipment}s that were assigned to the suitable {@link LogisticChain} by the
  * {@link InitialShipmentAssigner} in a previous step are handed over to the first {@link
  * LogisticChainElement}.
  *
  * <p>2.) all {@link LSPResource}s that were handed over to the SimpleForwardSolutionScheduler
  * exogenously, are now scheduled sequentially in an order that was also specified exogenously. This
  * order ensures that each {@link LogisticChain} is traversed from the first to the last {@link
- * LogisticChainElement}. During this procedure, the concerned {@link LSPShipment}s are taken from
+ * LogisticChainElement}. During this procedure, the concerned {@link LspShipment}s are taken from
  * the collection of incoming shipments, handled by the {@link LSPResource} in charge and then added
  * to the collection of outgoing shipments of the client {@link LogisticChainElement}.
  *
@@ -76,7 +76,7 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
     for (LogisticChain solution : lsp.getSelectedPlan().getLogisticChains()) {
       LogisticChainElement firstElement = getFirstElement(solution);
       assert firstElement != null;
-      for (Id<LSPShipment> lspShipmentId : solution.getLspShipmentIds()) {
+      for (Id<LspShipment> lspShipmentId : solution.getLspShipmentIds()) {
         var shipment = LSPUtils.findLspShipment(lsp, lspShipmentId);
         assert shipment != null;
         firstElement

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/SingleLogisticChainShipmentAssigner.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/SingleLogisticChainShipmentAssigner.java
@@ -24,13 +24,13 @@ import org.matsim.core.gbl.Gbl;
 import org.matsim.freight.logistics.InitialShipmentAssigner;
 import org.matsim.freight.logistics.LSPPlan;
 import org.matsim.freight.logistics.LogisticChain;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /**
  * Ganz einfacher {@link InitialShipmentAssigner}: Voraussetzung: Der {@link LSPPlan} hat genau 1 {@link
  * LogisticChain}.
  *
- * <p>Dann wird das {@link LSPShipment} diesem zugeordnet.
+ * <p>Dann wird das {@link LspShipment} diesem zugeordnet.
  *
  * <p>(Falls die Voraussetzung "exakt 1 LogisticChain pro Plan" nicht erfüllt ist, kommt eine
  * RuntimeException)
@@ -40,7 +40,7 @@ class SingleLogisticChainShipmentAssigner implements InitialShipmentAssigner {
   SingleLogisticChainShipmentAssigner() {}
 
   @Override
-  public void assignToPlan(LSPPlan lspPlan, LSPShipment lspShipment) {
+  public void assignToPlan(LSPPlan lspPlan, LspShipment lspShipment) {
     Gbl.assertIf(lspPlan.getLogisticChains().size() == 1);
     LogisticChain singleSolution = lspPlan.getLogisticChains().iterator().next();
     singleSolution.addShipmentToChain(lspShipment);

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/TransshipmentHubResource.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/TransshipmentHubResource.java
@@ -31,6 +31,7 @@ import org.matsim.freight.logistics.LSPPlan;
 import org.matsim.freight.logistics.LSPResource;
 import org.matsim.freight.logistics.LogisticChainElement;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /**
  * {@link LSPResource} bei der die geplanten Tätigkeiten NICHT am Verkehr teilnehmen.
@@ -40,7 +41,7 @@ import org.matsim.freight.logistics.resourceImplementations.ResourceImplementati
  *
  * <p>An entry is added to the schedule of the shipments that is an instance of
  * ScheduledShipmentHandle. There, the name of the Resource and the client element are entered, so
- * that the way that the {@link org.matsim.freight.logistics.shipment.LSPShipment} takes is
+ * that the way that the {@link LspShipment} takes is
  * specified. In addition, the planned start and end time of the handling (i.e. cross-docking) of
  * the shipment is entered. In the example, cross-docking starts as soon as the considered
  * LSPShipment arrives at the {@link TransshipmentHubResource} and ends after a fixed and a size

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/TransshipmentHubScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/TransshipmentHubScheduler.java
@@ -30,9 +30,9 @@ import org.matsim.freight.logistics.LSPResourceScheduler;
 import org.matsim.freight.logistics.LogisticChainElement;
 import org.matsim.freight.logistics.LspShipmentWithTime;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
-import org.matsim.freight.logistics.shipment.ShipmentPlan;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipmentPlan;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 
 /*package-private*/ class TransshipmentHubScheduler extends LSPResourceScheduler {
 
@@ -72,8 +72,8 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
   }
 
   private void addShipmentHandleElement(LspShipmentWithTime tuple) {
-    ShipmentUtils.ScheduledShipmentHandleBuilder builder =
-        ShipmentUtils.ScheduledShipmentHandleBuilder.newInstance();
+    LspShipmentUtils.ScheduledShipmentHandleBuilder builder =
+        LspShipmentUtils.ScheduledShipmentHandleBuilder.newInstance();
     builder.setStartTime(tuple.getTime());
     builder.setEndTime(
         tuple.getTime() + capacityNeedFixed + capacityNeedLinear * tuple.getLspShipment().getSize());
@@ -83,22 +83,22 @@ import org.matsim.freight.logistics.shipment.ShipmentUtils;
         builder.setLogisticsChainElement(element);
       }
     }
-    ShipmentPlanElement handle = builder.build();
+    LspShipmentPlanElement handle = builder.build();
     String idString =
         handle.getResourceId()
             + String.valueOf(handle.getLogisticChainElement().getId())
             + handle.getElementType();
-    Id<ShipmentPlanElement> id = Id.create(idString, ShipmentPlanElement.class);
-    ShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
+    Id<LspShipmentPlanElement> id = Id.create(idString, LspShipmentPlanElement.class);
+    LspShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, tuple.getLspShipment().getId())
         .addPlanElement(id, handle);
   }
 
   private void addShipmentToEventHandler(LspShipmentWithTime tuple) {
     for (LogisticChainElement element : transshipmentHubResource.getClientElements()) {
       if (element.getIncomingShipments().getLspShipmentsWTime().contains(tuple)) {
-        ShipmentPlan shipmentPlan =
-            ShipmentUtils.getOrCreateShipmentPlan(lspPlan, tuple.getLspShipment().getId());
-        eventHandler.addShipment(tuple.getLspShipment(), element, shipmentPlan);
+        LspShipmentPlan lspShipmentPlan =
+            LspShipmentUtils.getOrCreateShipmentPlan(lspPlan, tuple.getLspShipment().getId());
+        eventHandler.addShipment(tuple.getLspShipment(), element, lspShipmentPlan);
         break;
       }
     }

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/TransshipmentHubTourEndEventHandler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/TransshipmentHubTourEndEventHandler.java
@@ -96,12 +96,12 @@ import org.matsim.freight.logistics.shipment.*;
   }
 
   public void addShipment(
-      LSPShipment lspShipment, LogisticChainElement logisticChainElement, ShipmentPlan shipmentPlan) {
+          LspShipment lspShipment, LogisticChainElement logisticChainElement, LspShipmentPlan lspShipmentPlan) {
     TransshipmentHubEventHandlerPair pair =
         new TransshipmentHubEventHandlerPair(lspShipment, logisticChainElement);
 
-    for (ShipmentPlanElement planElement : shipmentPlan.getPlanElements().values()) {
-      if (planElement instanceof ShipmentLeg transport) {
+    for (LspShipmentPlanElement planElement : lspShipmentPlan.getPlanElements().values()) {
+      if (planElement instanceof LspShipmentLeg transport) {
         if (transport.getLogisticChainElement().getNextElement() == logisticChainElement) {
           servicesWaitedFor.put(transport.getCarrierService(), pair);
         }
@@ -133,7 +133,7 @@ import org.matsim.freight.logistics.shipment.*;
                   && (tour.getStartLinkId() != transshipmentHubResource.getStartLinkId())) {
 
                 final CarrierService carrierService = serviceActivity.getService();
-                final LSPShipment lspShipment = servicesWaitedFor.get(carrierService).lspShipment;
+                final LspShipment lspShipment = servicesWaitedFor.get(carrierService).lspShipment;
                 // NOTE: Do NOT add time vor unloading all goods, because they are included for the
                 // main run (Service activity at end of tour)
                 final double expHandlingDuration =
@@ -156,7 +156,7 @@ import org.matsim.freight.logistics.shipment.*;
             if (tour.getEndLinkId() == transshipmentHubResource.getStartLinkId()) {
 
               final CarrierService carrierService = serviceActivity.getService();
-              final LSPShipment lspShipment = servicesWaitedFor.get(carrierService).lspShipment;
+              final LspShipment lspShipment = servicesWaitedFor.get(carrierService).lspShipment;
 
               // TODO: Adding this here to be more in line with the schedule and have the shipment
               // log fitting to it.
@@ -204,23 +204,23 @@ import org.matsim.freight.logistics.shipment.*;
   private void logHandlingInHub(
           CarrierService carrierService, double startTime, double endTime) {
 
-    LSPShipment lspShipment = servicesWaitedFor.get(carrierService).lspShipment;
+    LspShipment lspShipment = servicesWaitedFor.get(carrierService).lspShipment;
 
     { // Old logging approach - will be removed at some point in time
-      ShipmentPlanElement handle =
-          ShipmentUtils.LoggedShipmentHandleBuilder.newInstance()
+      LspShipmentPlanElement handle =
+          LspShipmentUtils.LoggedShipmentHandleBuilder.newInstance()
               .setLinkId(linkId)
               .setResourceId(resourceId)
               .setStartTime(startTime)
               .setEndTime(endTime)
               .setLogisticsChainElement(servicesWaitedFor.get(carrierService).element)
               .build();
-      Id<ShipmentPlanElement> loadId =
+      Id<LspShipmentPlanElement> loadId =
           Id.create(
               handle.getResourceId()
                   + String.valueOf(handle.getLogisticChainElement().getId())
                   + handle.getElementType(),
-              ShipmentPlanElement.class);
+              LspShipmentPlanElement.class);
       if (!lspShipment.getShipmentLog().getPlanElements().containsKey(loadId)) {
         lspShipment.getShipmentLog().addPlanElement(loadId, handle);
       }
@@ -228,7 +228,7 @@ import org.matsim.freight.logistics.shipment.*;
   }
 
   private void throwHandlingEvent(
-      CarrierTourEndEvent event, LSPShipment lspShipment, double expHandlingDuration) {
+          CarrierTourEndEvent event, LspShipment lspShipment, double expHandlingDuration) {
     // New event-based approach
     // Todo: We need to decide what we write into the exp. handling duration: See #175 for
     // discussion.
@@ -267,10 +267,10 @@ import org.matsim.freight.logistics.shipment.*;
   }
 
   public static class TransshipmentHubEventHandlerPair {
-    public final LSPShipment lspShipment;
+    public final LspShipment lspShipment;
     public final LogisticChainElement element;
 
-    public TransshipmentHubEventHandlerPair(LSPShipment lspShipment, LogisticChainElement element) {
+    public TransshipmentHubEventHandlerPair(LspShipment lspShipment, LogisticChainElement element) {
       this.lspShipment = lspShipment;
       this.element = element;
     }

--- a/src/main/java/org/matsim/freight/logistics/shipment/LoggedLspShipmentHandle.java
+++ b/src/main/java/org/matsim/freight/logistics/shipment/LoggedLspShipmentHandle.java
@@ -20,44 +20,46 @@
 
 package org.matsim.freight.logistics.shipment;
 
-import java.util.Collection;
 import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.Identifiable;
-import org.matsim.api.core.v01.network.Link;
-import org.matsim.freight.carriers.TimeWindow;
-import org.matsim.freight.logistics.HasSimulationTrackers;
-import org.matsim.utils.objectattributes.attributable.Attributable;
+import org.matsim.freight.logistics.LSPResource;
+import org.matsim.freight.logistics.LogisticChainElement;
 
-/**
- * This is, for example, a shipment that DHL moves from A to B. It may use multiple carriers to
- * achieve that.
- *
- * <p>Questions/comments:
- *
- * <ul>
- *   <li>Within more modern MATSim, we would probably prefer to have from and to in coordinates, not
- *       link IDs.
- * </ul>
- */
-public interface LSPShipment
-    extends Identifiable<LSPShipment>, Attributable, HasSimulationTrackers<LSPShipment> {
+/*package*/ class LoggedLspShipmentHandle implements LspShipmentPlanElement {
 
-  Id<Link> getFrom(); // same as in CarrierShipment
+  private final double startTime;
+  private final double endTime;
+  private final LogisticChainElement element;
+  private final Id<LSPResource> resourceId;
 
-  Id<Link> getTo(); // same as in CarrierShipment
+  LoggedLspShipmentHandle(LspShipmentUtils.LoggedShipmentHandleBuilder builder) {
+    this.startTime = builder.startTime;
+    this.endTime = builder.endTime;
+    this.element = builder.element;
+    this.resourceId = builder.resourceId;
+  }
 
-  TimeWindow getPickupTimeWindow(); // same as in CarrierShipment
+  @Override
+  public LogisticChainElement getLogisticChainElement() {
+    return element;
+  }
 
-  TimeWindow getDeliveryTimeWindow(); // same as in CarrierShipment
+  @Override
+  public Id<LSPResource> getResourceId() {
+    return resourceId;
+  }
 
-  int getSize(); // same as in CarrierShipment
+  @Override
+  public String getElementType() {
+    return "HANDLE";
+  }
 
-  double getDeliveryServiceTime(); // same as in CarrierShipment
+  @Override
+  public double getStartTime() {
+    return startTime;
+  }
 
-  double getPickupServiceTime(); // same as in CarrierShipment
-
-  ShipmentPlan getShipmentLog();
-
-  Collection<LSPShipmentRequirement> getRequirements();
-
+  @Override
+  public double getEndTime() {
+    return endTime;
+  }
 }

--- a/src/main/java/org/matsim/freight/logistics/shipment/LoggedLspShipmentLoad.java
+++ b/src/main/java/org/matsim/freight/logistics/shipment/LoggedLspShipmentLoad.java
@@ -24,19 +24,19 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.freight.logistics.LSPResource;
 import org.matsim.freight.logistics.LogisticChainElement;
 
-class ScheduledShipmentLoad implements ShipmentPlanElement {
+/*package-private*/ class LoggedLspShipmentLoad implements LspShipmentPlanElement {
 
   private final double startTime;
   private final double endTime;
   private final LogisticChainElement element;
   private final Id<LSPResource> resourceId;
 
-    ScheduledShipmentLoad(ShipmentUtils.ScheduledShipmentLoadBuilder builder) {
-    this.startTime = builder.startTime;
-    this.endTime = builder.endTime;
-    this.element = builder.element;
-    this.resourceId = builder.resourceId;
-    }
+  LoggedLspShipmentLoad(LspShipmentUtils.LoggedShipmentLoadBuilder builder) {
+    this.startTime = builder.getStartTime();
+    this.endTime = builder.getEndTime();
+    this.element = builder.getElement();
+    this.resourceId = builder.getResourceId();
+  }
 
   @Override
   public String getElementType() {
@@ -62,5 +62,4 @@ class ScheduledShipmentLoad implements ShipmentPlanElement {
   public Id<LSPResource> getResourceId() {
     return resourceId;
   }
-
 }

--- a/src/main/java/org/matsim/freight/logistics/shipment/LoggedLspShipmentTransport.java
+++ b/src/main/java/org/matsim/freight/logistics/shipment/LoggedLspShipmentTransport.java
@@ -21,21 +21,27 @@
 package org.matsim.freight.logistics.shipment;
 
 import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.freight.carriers.Carrier;
+import org.matsim.freight.carriers.CarrierService;
 import org.matsim.freight.logistics.LSPResource;
 import org.matsim.freight.logistics.LogisticChainElement;
 
-class LoggedShipmentUnload implements ShipmentPlanElement {
+final class LoggedLspShipmentTransport implements LspShipmentLeg {
 
   private final double startTime;
-  private final double endTime;
   private final LogisticChainElement element;
   private final Id<LSPResource> resourceId;
+  private final Id<Link> fromLinkId;
+  private double endTime;
+  private Id<Link> toLinkId;
 
-  LoggedShipmentUnload(ShipmentUtils.LoggedShipmentUnloadBuilder builder) {
-    this.startTime = builder.startTime;
-    this.endTime = builder.endTime;
-    this.element = builder.element;
-    this.resourceId = builder.resourceId;
+  LoggedLspShipmentTransport(LspShipmentUtils.LoggedShipmentTransportBuilder builder) {
+    this.startTime = builder.getStartTime();
+    this.element = builder.getElement();
+    this.resourceId = builder.getResourceId();
+    this.fromLinkId = builder.getFromLinkId();
+    this.toLinkId = builder.getToLinkId();
   }
 
   @Override
@@ -50,7 +56,7 @@ class LoggedShipmentUnload implements ShipmentPlanElement {
 
   @Override
   public String getElementType() {
-    return "UNLOAD";
+    return "TRANSPORT";
   }
 
   @Override
@@ -61,5 +67,31 @@ class LoggedShipmentUnload implements ShipmentPlanElement {
   @Override
   public double getEndTime() {
     return endTime;
+  }
+
+  public void setEndTime(double endTime) {
+    this.endTime = endTime;
+  }
+
+  public Id<Link> getFromLinkId() {
+    return fromLinkId;
+  }
+
+  @Override
+  public CarrierService getCarrierService() {
+    throw new RuntimeException("not implemented");
+  }
+
+  public Id<Link> getToLinkId() {
+    return toLinkId;
+  }
+
+  public void setToLinkId(Id<Link> toLinkId) {
+    this.toLinkId = toLinkId;
+  }
+
+  @Override
+  public Id<Carrier> getCarrierId() {
+    throw new RuntimeException("not implemented");
   }
 }

--- a/src/main/java/org/matsim/freight/logistics/shipment/LoggedLspShipmentUnload.java
+++ b/src/main/java/org/matsim/freight/logistics/shipment/LoggedLspShipmentUnload.java
@@ -24,18 +24,42 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.freight.logistics.LSPResource;
 import org.matsim.freight.logistics.LogisticChainElement;
 
-public interface ShipmentPlanElement {
+class LoggedLspShipmentUnload implements LspShipmentPlanElement {
 
-  LogisticChainElement getLogisticChainElement();
+  private final double startTime;
+  private final double endTime;
+  private final LogisticChainElement element;
+  private final Id<LSPResource> resourceId;
 
-  Id<LSPResource> getResourceId();
+  LoggedLspShipmentUnload(LspShipmentUtils.LoggedShipmentUnloadBuilder builder) {
+    this.startTime = builder.startTime;
+    this.endTime = builder.endTime;
+    this.element = builder.element;
+    this.resourceId = builder.resourceId;
+  }
 
-  // yyyy "type" feels like this makes it a tagged class.  These should be avoided (Effective Java
-  // 2018, Item 23).  It is, however, probably not
-  // used as a type, but rather as a description.  Rename?
-  String getElementType();
+  @Override
+  public LogisticChainElement getLogisticChainElement() {
+    return element;
+  }
 
-  double getStartTime();
+  @Override
+  public Id<LSPResource> getResourceId() {
+    return resourceId;
+  }
 
-  double getEndTime();
+  @Override
+  public String getElementType() {
+    return "UNLOAD";
+  }
+
+  @Override
+  public double getStartTime() {
+    return startTime;
+  }
+
+  @Override
+  public double getEndTime() {
+    return endTime;
+  }
 }

--- a/src/main/java/org/matsim/freight/logistics/shipment/LspShipment.java
+++ b/src/main/java/org/matsim/freight/logistics/shipment/LspShipment.java
@@ -20,19 +20,44 @@
 
 package org.matsim.freight.logistics.shipment;
 
-import java.util.Map;
+import java.util.Collection;
 import org.matsim.api.core.v01.Id;
-import org.matsim.freight.logistics.HasBackpointer;
+import org.matsim.api.core.v01.Identifiable;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.freight.carriers.TimeWindow;
+import org.matsim.freight.logistics.HasSimulationTrackers;
+import org.matsim.utils.objectattributes.attributable.Attributable;
 
-public interface ShipmentPlan extends HasBackpointer<Id<LSPShipment>> {
+/**
+ * This is, for example, a shipment that DHL moves from A to B. It may use multiple carriers to
+ * achieve that.
+ *
+ * <p>Questions/comments:
+ *
+ * <ul>
+ *   <li>Within more modern MATSim, we would probably prefer to have from and to in coordinates, not
+ *       link IDs.
+ * </ul>
+ */
+public interface LspShipment
+    extends Identifiable<LspShipment>, Attributable, HasSimulationTrackers<LspShipment> {
 
-  Id<LSPShipment> getLspShipmentId();
+  Id<Link> getFrom(); // same as in CarrierShipment
 
-  Map<Id<ShipmentPlanElement>, ShipmentPlanElement> getPlanElements();
+  Id<Link> getTo(); // same as in CarrierShipment
 
-  void addPlanElement(Id<ShipmentPlanElement> id, ShipmentPlanElement element);
+  TimeWindow getPickupTimeWindow(); // same as in CarrierShipment
 
-  ShipmentPlanElement getMostRecentEntry();
+  TimeWindow getDeliveryTimeWindow(); // same as in CarrierShipment
 
-  void clear();
+  int getSize(); // same as in CarrierShipment
+
+  double getDeliveryServiceTime(); // same as in CarrierShipment
+
+  double getPickupServiceTime(); // same as in CarrierShipment
+
+  LspShipmentPlan getShipmentLog();
+
+  Collection<LspShipmentRequirement> getRequirements();
+
 }

--- a/src/main/java/org/matsim/freight/logistics/shipment/LspShipmentImpl.java
+++ b/src/main/java/org/matsim/freight/logistics/shipment/LspShipmentImpl.java
@@ -28,7 +28,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.freight.carriers.TimeWindow;
 import org.matsim.freight.logistics.LSPDataObject;
 
-class LSPShipmentImpl extends LSPDataObject<LSPShipment> implements LSPShipment {
+class LspShipmentImpl extends LSPDataObject<LspShipment> implements LspShipment {
 
   private final Id<Link> fromLinkId;
   private final Id<Link> toLinkId;
@@ -39,12 +39,12 @@ class LSPShipmentImpl extends LSPDataObject<LSPShipment> implements LSPShipment 
   private final double pickupServiceTime;
   //	private final ShipmentPlan shipmentPlan;
   @Deprecated // This will be removed in the future and replaced by using the events. KMT, Mai'23
-  private final ShipmentPlan shipmentLog;
-  private final List<LSPShipmentRequirement> lspShipmentRequirements;
+  private final LspShipmentPlan shipmentLog;
+  private final List<LspShipmentRequirement> lspShipmentRequirements;
 
   //	private Id<LSP> lspId;
 
-  LSPShipmentImpl(ShipmentUtils.LSPShipmentBuilder builder) {
+  LspShipmentImpl(LspShipmentUtils.LspShipmentBuilder builder) {
     super(builder.id);
     this.fromLinkId = builder.fromLinkId;
     this.toLinkId = builder.toLinkId;
@@ -54,7 +54,7 @@ class LSPShipmentImpl extends LSPDataObject<LSPShipment> implements LSPShipment 
     this.deliveryServiceTime = builder.deliveryServiceTime;
     this.pickupServiceTime = builder.pickupServiceTime;
     //		this.shipmentPlan = new ShipmentPlanImpl(this.getId());
-    this.shipmentLog = new ShipmentPlanImpl(this.getId());
+    this.shipmentLog = new LspShipmentPlanImpl(this.getId());
     this.lspShipmentRequirements = new ArrayList<>();
     this.lspShipmentRequirements.addAll(builder.lspShipmentRequirements);
   }
@@ -81,7 +81,7 @@ class LSPShipmentImpl extends LSPDataObject<LSPShipment> implements LSPShipment 
 
     @Deprecated // This will be removed in the future and replaced by using the events. KMT, Mai'23
   @Override
-  public ShipmentPlan getShipmentLog() {
+  public LspShipmentPlan getShipmentLog() {
     return shipmentLog;
   }
 
@@ -96,7 +96,7 @@ class LSPShipmentImpl extends LSPDataObject<LSPShipment> implements LSPShipment 
   }
 
   @Override
-  public Collection<LSPShipmentRequirement> getRequirements() {
+  public Collection<LspShipmentRequirement> getRequirements() {
     return lspShipmentRequirements;
   }
 

--- a/src/main/java/org/matsim/freight/logistics/shipment/LspShipmentLeg.java
+++ b/src/main/java/org/matsim/freight/logistics/shipment/LspShipmentLeg.java
@@ -5,7 +5,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.freight.carriers.Carrier;
 import org.matsim.freight.carriers.CarrierService;
 
-public interface ShipmentLeg extends ShipmentPlanElement {
+public interface LspShipmentLeg extends LspShipmentPlanElement {
   Id<Link> getToLinkId();
 
   void setToLinkId(Id<Link> endLinkId);

--- a/src/main/java/org/matsim/freight/logistics/shipment/LspShipmentPlan.java
+++ b/src/main/java/org/matsim/freight/logistics/shipment/LspShipmentPlan.java
@@ -20,46 +20,19 @@
 
 package org.matsim.freight.logistics.shipment;
 
+import java.util.Map;
 import org.matsim.api.core.v01.Id;
-import org.matsim.freight.logistics.LSPResource;
-import org.matsim.freight.logistics.LogisticChainElement;
+import org.matsim.freight.logistics.HasBackpointer;
 
-/*package*/ class LoggedShipmentHandle implements ShipmentPlanElement {
+public interface LspShipmentPlan extends HasBackpointer<Id<LspShipment>> {
 
-  private final double startTime;
-  private final double endTime;
-  private final LogisticChainElement element;
-  private final Id<LSPResource> resourceId;
+  Id<LspShipment> getLspShipmentId();
 
-  LoggedShipmentHandle(ShipmentUtils.LoggedShipmentHandleBuilder builder) {
-    this.startTime = builder.startTime;
-    this.endTime = builder.endTime;
-    this.element = builder.element;
-    this.resourceId = builder.resourceId;
-  }
+  Map<Id<LspShipmentPlanElement>, LspShipmentPlanElement> getPlanElements();
 
-  @Override
-  public LogisticChainElement getLogisticChainElement() {
-    return element;
-  }
+  void addPlanElement(Id<LspShipmentPlanElement> id, LspShipmentPlanElement element);
 
-  @Override
-  public Id<LSPResource> getResourceId() {
-    return resourceId;
-  }
+  LspShipmentPlanElement getMostRecentEntry();
 
-  @Override
-  public String getElementType() {
-    return "HANDLE";
-  }
-
-  @Override
-  public double getStartTime() {
-    return startTime;
-  }
-
-  @Override
-  public double getEndTime() {
-    return endTime;
-  }
+  void clear();
 }

--- a/src/main/java/org/matsim/freight/logistics/shipment/LspShipmentPlanElement.java
+++ b/src/main/java/org/matsim/freight/logistics/shipment/LspShipmentPlanElement.java
@@ -20,9 +20,22 @@
 
 package org.matsim.freight.logistics.shipment;
 
-import org.matsim.freight.logistics.LogisticChain;
+import org.matsim.api.core.v01.Id;
+import org.matsim.freight.logistics.LSPResource;
+import org.matsim.freight.logistics.LogisticChainElement;
 
-public interface LSPShipmentRequirement {
+public interface LspShipmentPlanElement {
 
-  boolean checkRequirement(LogisticChain solution);
+  LogisticChainElement getLogisticChainElement();
+
+  Id<LSPResource> getResourceId();
+
+  // yyyy "type" feels like this makes it a tagged class.  These should be avoided (Effective Java
+  // 2018, Item 23).  It is, however, probably not
+  // used as a type, but rather as a description.  Rename?
+  String getElementType();
+
+  double getStartTime();
+
+  double getEndTime();
 }

--- a/src/main/java/org/matsim/freight/logistics/shipment/LspShipmentPlanImpl.java
+++ b/src/main/java/org/matsim/freight/logistics/shipment/LspShipmentPlanImpl.java
@@ -23,39 +23,39 @@ package org.matsim.freight.logistics.shipment;
 import java.util.*;
 import org.matsim.api.core.v01.Id;
 
-/*package-private*/ class ShipmentPlanImpl implements ShipmentPlan {
+/*package-private*/ class LspShipmentPlanImpl implements LspShipmentPlan {
 
-  private final Id<LSPShipment> lspShipmentId;
-  private final LinkedHashMap<Id<ShipmentPlanElement>, ShipmentPlanElement> planElements;
+  private final Id<LspShipment> lspShipmentId;
+  private final LinkedHashMap<Id<LspShipmentPlanElement>, LspShipmentPlanElement> planElements;
 
-  ShipmentPlanImpl(Id<LSPShipment> lspShipmentId) {
+  LspShipmentPlanImpl(Id<LspShipment> lspShipmentId) {
     this.lspShipmentId = lspShipmentId;
     this.planElements = new LinkedHashMap<>();
   }
 
   // TODO: Ist kein embedding container!
   @Override
-  public void setEmbeddingContainer(Id<LSPShipment> pointer) {
+  public void setEmbeddingContainer(Id<LspShipment> pointer) {
     throw new RuntimeException("not implemented");
   }
 
   @Override
-  public Id<LSPShipment> getLspShipmentId() {
+  public Id<LspShipment> getLspShipmentId() {
     return lspShipmentId;
   }
 
   @Override
-  public void addPlanElement(Id<ShipmentPlanElement> id, ShipmentPlanElement element) {
+  public void addPlanElement(Id<LspShipmentPlanElement> id, LspShipmentPlanElement element) {
     planElements.put(id, element);
   }
 
   @Override
-  public Map<Id<ShipmentPlanElement>, ShipmentPlanElement> getPlanElements() {
+  public Map<Id<LspShipmentPlanElement>, LspShipmentPlanElement> getPlanElements() {
     return Collections.unmodifiableMap(planElements);
   }
 
   @Override
-  public ShipmentPlanElement getMostRecentEntry() {
+  public LspShipmentPlanElement getMostRecentEntry() {
 
     // there is no method to remove entries.  in consequence, the only way to change the result of
     // this method is to "add" additional material into the plan.  Possibly,
@@ -63,7 +63,7 @@ import org.matsim.api.core.v01.Id;
     // figure out how the next one can be added.  However, this then
     // should be sorted by sequence of addition, not by timing.  ???   kai/kai, apr'21
 
-    ArrayList<ShipmentPlanElement> logList = new ArrayList<>(planElements.values());
+    ArrayList<LspShipmentPlanElement> logList = new ArrayList<>(planElements.values());
     logList.sort(new LogElementComparator());
     Collections.reverse(logList);
     return logList.getFirst();
@@ -74,10 +74,10 @@ import org.matsim.api.core.v01.Id;
     planElements.clear();
   }
 
-  static class LogElementComparator implements Comparator<ShipmentPlanElement> {
+  static class LogElementComparator implements Comparator<LspShipmentPlanElement> {
 
     @Override
-    public int compare(ShipmentPlanElement o1, ShipmentPlanElement o2) {
+    public int compare(LspShipmentPlanElement o1, LspShipmentPlanElement o2) {
       if (o1.getStartTime() > o2.getStartTime()) {
         return 1;
       }

--- a/src/main/java/org/matsim/freight/logistics/shipment/LspShipmentRequirement.java
+++ b/src/main/java/org/matsim/freight/logistics/shipment/LspShipmentRequirement.java
@@ -20,46 +20,9 @@
 
 package org.matsim.freight.logistics.shipment;
 
-import org.matsim.api.core.v01.Id;
-import org.matsim.freight.logistics.LSPResource;
-import org.matsim.freight.logistics.LogisticChainElement;
+import org.matsim.freight.logistics.LogisticChain;
 
-class ScheduledShipmentHandle implements ShipmentPlanElement {
+public interface LspShipmentRequirement {
 
-  private final double startTime;
-  private final double endTime;
-  private final LogisticChainElement element;
-  private final Id<LSPResource> resourceId;
-
-  ScheduledShipmentHandle(ShipmentUtils.ScheduledShipmentHandleBuilder builder) {
-    this.startTime = builder.startTime;
-    this.endTime = builder.endTime;
-    this.element = builder.element;
-    this.resourceId = builder.resourceId;
-  }
-
-  @Override
-  public String getElementType() {
-    return "HANDLE";
-  }
-
-  @Override
-  public double getStartTime() {
-    return startTime;
-  }
-
-  @Override
-  public double getEndTime() {
-    return endTime;
-  }
-
-  @Override
-  public LogisticChainElement getLogisticChainElement() {
-    return element;
-  }
-
-  @Override
-  public Id<LSPResource> getResourceId() {
-    return resourceId;
-  }
+  boolean checkRequirement(LogisticChain solution);
 }

--- a/src/main/java/org/matsim/freight/logistics/shipment/LspShipmentUtils.java
+++ b/src/main/java/org/matsim/freight/logistics/shipment/LspShipmentUtils.java
@@ -32,37 +32,37 @@ import org.matsim.freight.logistics.LSPPlan;
 import org.matsim.freight.logistics.LSPResource;
 import org.matsim.freight.logistics.LogisticChainElement;
 
-public final class ShipmentUtils {
-  private ShipmentUtils() {} // do not instantiate
+public final class LspShipmentUtils {
+  private LspShipmentUtils() {} // do not instantiate
 
-  public static Comparator<ShipmentPlanElement> createShipmentPlanElementComparator() {
+  public static Comparator<LspShipmentPlanElement> createShipmentPlanElementComparator() {
     return new ShipmentPlanElementComparator();
   }
 
   /**
-   * Gives back the {@link ShipmentPlan} object of the {@link LSPPlan}, which matches to the id of
-   * the {@link LSPShipment}
+   * Gives back the {@link LspShipmentPlan} object of the {@link LSPPlan}, which matches to the id of
+   * the {@link LspShipment}
    *
    * @param lspPlan The lspPlan in which this method tries to find the shipmentPlan.
    * @param shipmentId Id of the shipment for which the Plan should be found.
    * @return the ShipmentPlan object or null, if it is not found.
    */
-  public static ShipmentPlan getOrCreateShipmentPlan(LSPPlan lspPlan, Id<LSPShipment> shipmentId) {
+  public static LspShipmentPlan getOrCreateShipmentPlan(LSPPlan lspPlan, Id<LspShipment> shipmentId) {
     // Return shipmentPlan if already existing in LspPlan
-    for (ShipmentPlan shipmentPlan : lspPlan.getShipmentPlans()) {
-      if (shipmentPlan.getLspShipmentId().equals(shipmentId)) {
-        return shipmentPlan;
+    for (LspShipmentPlan lspShipmentPlan : lspPlan.getShipmentPlans()) {
+      if (lspShipmentPlan.getLspShipmentId().equals(shipmentId)) {
+        return lspShipmentPlan;
       }
     }
     // ShipmentPlan does not exist in LspPlan. Will create one, add it to the LspPlan.
-    ShipmentPlan newShipmentPlan = new ShipmentPlanImpl(shipmentId);
-    lspPlan.addShipmentPlan(newShipmentPlan);
-    return newShipmentPlan;
+    LspShipmentPlan newLspShipmentPlan = new LspShipmentPlanImpl(shipmentId);
+    lspPlan.addShipmentPlan(newLspShipmentPlan);
+    return newLspShipmentPlan;
   }
 
-  public static final class LSPShipmentBuilder {
-    final Id<LSPShipment> id;
-    final List<LSPShipmentRequirement> lspShipmentRequirements;
+  public static final class LspShipmentBuilder {
+    final Id<LspShipment> id;
+    final List<LspShipmentRequirement> lspShipmentRequirements;
     Id<Link> fromLinkId;
     Id<Link> toLinkId;
     TimeWindow startTimeWindow;
@@ -71,13 +71,13 @@ public final class ShipmentUtils {
     double deliveryServiceTime;
     double pickupServiceTime;
 
-    private LSPShipmentBuilder(Id<LSPShipment> id) {
+    private LspShipmentBuilder(Id<LspShipment> id) {
       this.lspShipmentRequirements = new ArrayList<>();
       this.id = id;
     }
 
-    public static LSPShipmentBuilder newInstance(Id<LSPShipment> id) {
-      return new LSPShipmentBuilder(id);
+    public static LspShipmentBuilder newInstance(Id<LspShipment> id) {
+      return new LspShipmentBuilder(id);
     }
 
     public void setFromLinkId(Id<Link> fromLinkId) {
@@ -104,17 +104,17 @@ public final class ShipmentUtils {
       this.deliveryServiceTime = serviceTime;
     }
 
-    public LSPShipmentBuilder setPickupServiceTime(double serviceTime) {
+    public LspShipmentBuilder setPickupServiceTime(double serviceTime) {
       this.pickupServiceTime = serviceTime;
       return this;
     }
 
-    public void addRequirement(LSPShipmentRequirement requirement) {
+    public void addRequirement(LspShipmentRequirement requirement) {
       lspShipmentRequirements.add(requirement);
     }
 
-    public LSPShipment build() {
-      return new LSPShipmentImpl(this);
+    public LspShipment build() {
+      return new LspShipmentImpl(this);
     }
   }
 
@@ -141,8 +141,8 @@ public final class ShipmentUtils {
       this.element = element;
     }
 
-    public LoggedShipmentLoad build() {
-      return new LoggedShipmentLoad(this);
+    public LoggedLspShipmentLoad build() {
+      return new LoggedLspShipmentLoad(this);
     }
 
     public double getStartTime() {
@@ -211,8 +211,8 @@ public final class ShipmentUtils {
       this.element = element;
     }
 
-    public LoggedShipmentTransport build() {
-      return new LoggedShipmentTransport(this);
+    public LoggedLspShipmentTransport build() {
+      return new LoggedLspShipmentTransport(this);
     }
 
     // --- Getters --- //
@@ -300,8 +300,8 @@ public final class ShipmentUtils {
       this.carrierId = carrierId;
     }
 
-    public LoggedShipmentUnload build() {
-      return new LoggedShipmentUnload(this);
+    public LoggedLspShipmentUnload build() {
+      return new LoggedLspShipmentUnload(this);
     }
   }
 
@@ -343,8 +343,8 @@ public final class ShipmentUtils {
       return this;
     }
 
-    public ShipmentPlanElement build() {
-      return new LoggedShipmentHandle(this);
+    public LspShipmentPlanElement build() {
+      return new LoggedLspShipmentHandle(this);
     }
   }
 
@@ -381,8 +381,8 @@ public final class ShipmentUtils {
       this.resourceId = resourceId;
     }
 
-    public ScheduledShipmentLoad build() {
-      return new ScheduledShipmentLoad(this);
+    public ScheduledLspShipmentLoad build() {
+      return new ScheduledLspShipmentLoad(this);
     }
   }
 
@@ -435,8 +435,8 @@ public final class ShipmentUtils {
       this.carrierService = carrierService;
     }
 
-    public ScheduledShipmentTransport build() {
-      return new ScheduledShipmentTransport(this);
+    public ScheduledLspShipmentTransport build() {
+      return new ScheduledLspShipmentTransport(this);
     }
   }
 
@@ -469,8 +469,8 @@ public final class ShipmentUtils {
       this.resourceId = resourceId;
     }
 
-    public ScheduledShipmentUnload build() {
-      return new ScheduledShipmentUnload(this);
+    public ScheduledLspShipmentUnload build() {
+      return new ScheduledLspShipmentUnload(this);
     }
   }
 
@@ -503,8 +503,8 @@ public final class ShipmentUtils {
       this.resourceId = resourceId;
     }
 
-    public ScheduledShipmentHandle build() {
-      return new ScheduledShipmentHandle(this);
+    public ScheduledLspShipmentHandle build() {
+      return new ScheduledLspShipmentHandle(this);
     }
   }
 

--- a/src/main/java/org/matsim/freight/logistics/shipment/ScheduledLspShipmentHandle.java
+++ b/src/main/java/org/matsim/freight/logistics/shipment/ScheduledLspShipmentHandle.java
@@ -24,23 +24,23 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.freight.logistics.LSPResource;
 import org.matsim.freight.logistics.LogisticChainElement;
 
-/*package-private*/ class LoggedShipmentLoad implements ShipmentPlanElement {
+class ScheduledLspShipmentHandle implements LspShipmentPlanElement {
 
   private final double startTime;
   private final double endTime;
   private final LogisticChainElement element;
   private final Id<LSPResource> resourceId;
 
-  LoggedShipmentLoad(ShipmentUtils.LoggedShipmentLoadBuilder builder) {
-    this.startTime = builder.getStartTime();
-    this.endTime = builder.getEndTime();
-    this.element = builder.getElement();
-    this.resourceId = builder.getResourceId();
+  ScheduledLspShipmentHandle(LspShipmentUtils.ScheduledShipmentHandleBuilder builder) {
+    this.startTime = builder.startTime;
+    this.endTime = builder.endTime;
+    this.element = builder.element;
+    this.resourceId = builder.resourceId;
   }
 
   @Override
   public String getElementType() {
-    return "LOAD";
+    return "HANDLE";
   }
 
   @Override

--- a/src/main/java/org/matsim/freight/logistics/shipment/ScheduledLspShipmentLoad.java
+++ b/src/main/java/org/matsim/freight/logistics/shipment/ScheduledLspShipmentLoad.java
@@ -21,37 +21,26 @@
 package org.matsim.freight.logistics.shipment;
 
 import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.network.Link;
-import org.matsim.freight.carriers.Carrier;
-import org.matsim.freight.carriers.CarrierService;
 import org.matsim.freight.logistics.LSPResource;
 import org.matsim.freight.logistics.LogisticChainElement;
 
-final class ScheduledShipmentTransport implements ShipmentLeg {
+class ScheduledLspShipmentLoad implements LspShipmentPlanElement {
 
   private final double startTime;
   private final double endTime;
   private final LogisticChainElement element;
   private final Id<LSPResource> resourceId;
-  private final Id<Carrier> carrierId;
-  private final Id<Link> fromLinkId;
-  private final Id<Link> toLinkId;
-  private final CarrierService carrierService;
 
-  ScheduledShipmentTransport(ShipmentUtils.ScheduledShipmentTransportBuilder builder) {
+    ScheduledLspShipmentLoad(LspShipmentUtils.ScheduledShipmentLoadBuilder builder) {
     this.startTime = builder.startTime;
     this.endTime = builder.endTime;
     this.element = builder.element;
     this.resourceId = builder.resourceId;
-    this.carrierId = builder.carrierId;
-    this.fromLinkId = builder.fromLinkId;
-    this.toLinkId = builder.toLinkId;
-    this.carrierService = builder.carrierService;
-  }
+    }
 
   @Override
   public String getElementType() {
-    return "TRANSPORT";
+    return "LOAD";
   }
 
   @Override
@@ -65,11 +54,6 @@ final class ScheduledShipmentTransport implements ShipmentLeg {
   }
 
   @Override
-  public void setEndTime(double time) {
-    throw new RuntimeException("not implemented");
-  }
-
-  @Override
   public LogisticChainElement getLogisticChainElement() {
     return element;
   }
@@ -79,28 +63,4 @@ final class ScheduledShipmentTransport implements ShipmentLeg {
     return resourceId;
   }
 
-  @Override
-  public Id<Link> getToLinkId() {
-    return toLinkId;
-  }
-
-  @Override
-  public void setToLinkId(Id<Link> endLinkId) {
-    throw new RuntimeException("not implemented");
-  }
-
-  @Override
-  public Id<Carrier> getCarrierId() {
-    return carrierId;
-  }
-
-  @Override
-  public Id<Link> getFromLinkId() {
-    return fromLinkId;
-  }
-
-  @Override
-  public CarrierService getCarrierService() {
-    return carrierService;
-  }
 }

--- a/src/main/java/org/matsim/freight/logistics/shipment/ScheduledLspShipmentTransport.java
+++ b/src/main/java/org/matsim/freight/logistics/shipment/ScheduledLspShipmentTransport.java
@@ -21,28 +21,37 @@
 package org.matsim.freight.logistics.shipment;
 
 import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
 import org.matsim.freight.carriers.Carrier;
 import org.matsim.freight.carriers.CarrierService;
 import org.matsim.freight.logistics.LSPResource;
 import org.matsim.freight.logistics.LogisticChainElement;
 
-class ScheduledShipmentUnload implements ShipmentPlanElement {
+final class ScheduledLspShipmentTransport implements LspShipmentLeg {
 
   private final double startTime;
   private final double endTime;
   private final LogisticChainElement element;
   private final Id<LSPResource> resourceId;
+  private final Id<Carrier> carrierId;
+  private final Id<Link> fromLinkId;
+  private final Id<Link> toLinkId;
+  private final CarrierService carrierService;
 
-    ScheduledShipmentUnload(ShipmentUtils.ScheduledShipmentUnloadBuilder builder) {
+  ScheduledLspShipmentTransport(LspShipmentUtils.ScheduledShipmentTransportBuilder builder) {
     this.startTime = builder.startTime;
     this.endTime = builder.endTime;
     this.element = builder.element;
     this.resourceId = builder.resourceId;
-    }
+    this.carrierId = builder.carrierId;
+    this.fromLinkId = builder.fromLinkId;
+    this.toLinkId = builder.toLinkId;
+    this.carrierService = builder.carrierService;
+  }
 
   @Override
   public String getElementType() {
-    return "UNLOAD";
+    return "TRANSPORT";
   }
 
   @Override
@@ -56,6 +65,11 @@ class ScheduledShipmentUnload implements ShipmentPlanElement {
   }
 
   @Override
+  public void setEndTime(double time) {
+    throw new RuntimeException("not implemented");
+  }
+
+  @Override
   public LogisticChainElement getLogisticChainElement() {
     return element;
   }
@@ -65,4 +79,28 @@ class ScheduledShipmentUnload implements ShipmentPlanElement {
     return resourceId;
   }
 
+  @Override
+  public Id<Link> getToLinkId() {
+    return toLinkId;
+  }
+
+  @Override
+  public void setToLinkId(Id<Link> endLinkId) {
+    throw new RuntimeException("not implemented");
+  }
+
+  @Override
+  public Id<Carrier> getCarrierId() {
+    return carrierId;
+  }
+
+  @Override
+  public Id<Link> getFromLinkId() {
+    return fromLinkId;
+  }
+
+  @Override
+  public CarrierService getCarrierService() {
+    return carrierService;
+  }
 }

--- a/src/main/java/org/matsim/freight/logistics/shipment/ScheduledLspShipmentUnload.java
+++ b/src/main/java/org/matsim/freight/logistics/shipment/ScheduledLspShipmentUnload.java
@@ -21,42 +21,26 @@
 package org.matsim.freight.logistics.shipment;
 
 import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.network.Link;
-import org.matsim.freight.carriers.Carrier;
-import org.matsim.freight.carriers.CarrierService;
 import org.matsim.freight.logistics.LSPResource;
 import org.matsim.freight.logistics.LogisticChainElement;
 
-final class LoggedShipmentTransport implements ShipmentLeg {
+class ScheduledLspShipmentUnload implements LspShipmentPlanElement {
 
   private final double startTime;
+  private final double endTime;
   private final LogisticChainElement element;
   private final Id<LSPResource> resourceId;
-  private final Id<Link> fromLinkId;
-  private double endTime;
-  private Id<Link> toLinkId;
 
-  LoggedShipmentTransport(ShipmentUtils.LoggedShipmentTransportBuilder builder) {
-    this.startTime = builder.getStartTime();
-    this.element = builder.getElement();
-    this.resourceId = builder.getResourceId();
-    this.fromLinkId = builder.getFromLinkId();
-    this.toLinkId = builder.getToLinkId();
-  }
-
-  @Override
-  public LogisticChainElement getLogisticChainElement() {
-    return element;
-  }
-
-  @Override
-  public Id<LSPResource> getResourceId() {
-    return resourceId;
-  }
+    ScheduledLspShipmentUnload(LspShipmentUtils.ScheduledShipmentUnloadBuilder builder) {
+    this.startTime = builder.startTime;
+    this.endTime = builder.endTime;
+    this.element = builder.element;
+    this.resourceId = builder.resourceId;
+    }
 
   @Override
   public String getElementType() {
-    return "TRANSPORT";
+    return "UNLOAD";
   }
 
   @Override
@@ -69,29 +53,14 @@ final class LoggedShipmentTransport implements ShipmentLeg {
     return endTime;
   }
 
-  public void setEndTime(double endTime) {
-    this.endTime = endTime;
-  }
-
-  public Id<Link> getFromLinkId() {
-    return fromLinkId;
+  @Override
+  public LogisticChainElement getLogisticChainElement() {
+    return element;
   }
 
   @Override
-  public CarrierService getCarrierService() {
-    throw new RuntimeException("not implemented");
+  public Id<LSPResource> getResourceId() {
+    return resourceId;
   }
 
-  public Id<Link> getToLinkId() {
-    return toLinkId;
-  }
-
-  public void setToLinkId(Id<Link> toLinkId) {
-    this.toLinkId = toLinkId;
-  }
-
-  @Override
-  public Id<Carrier> getCarrierId() {
-    throw new RuntimeException("not implemented");
-  }
 }

--- a/src/main/java/org/matsim/freight/logistics/shipment/ShipmentPlanElementComparator.java
+++ b/src/main/java/org/matsim/freight/logistics/shipment/ShipmentPlanElementComparator.java
@@ -22,11 +22,11 @@ package org.matsim.freight.logistics.shipment;
 
 import java.util.Comparator;
 
-final class ShipmentPlanElementComparator implements Comparator<ShipmentPlanElement> {
+final class ShipmentPlanElementComparator implements Comparator<LspShipmentPlanElement> {
 
   ShipmentPlanElementComparator() {}
 
-  public int compare(ShipmentPlanElement o1, ShipmentPlanElement o2) {
+  public int compare(LspShipmentPlanElement o1, LspShipmentPlanElement o2) {
     if (o1.getStartTime() > o2.getStartTime()) {
       return 1;
     }

--- a/src/test/java/org/matsim/freight/logistics/events/LspEventsReaderTest.java
+++ b/src/test/java/org/matsim/freight/logistics/events/LspEventsReaderTest.java
@@ -17,7 +17,7 @@ import org.matsim.freight.carriers.Tour;
 import org.matsim.freight.carriers.events.CarrierTourEndEvent;
 import org.matsim.freight.carriers.events.eventhandler.CarrierTourEndEventHandler;
 import org.matsim.freight.logistics.LSPResource;
-import org.matsim.freight.logistics.shipment.LSPShipment;
+import org.matsim.freight.logistics.shipment.LspShipment;
 
 /**
  * @author Kai Martins-Turner (kturner)
@@ -25,8 +25,8 @@ import org.matsim.freight.logistics.shipment.LSPShipment;
 public class LspEventsReaderTest {
 
 	private final List<Event> lspEvents = List.of(
-			new HandlingInHubStartsEvent(110.0, Id.createLinkId("TestLink1"), Id.create("shipment1", LSPShipment.class), Id.create("Hub1", LSPResource.class), 42.0),
-			new HandlingInHubStartsEvent(142.0, Id.createLinkId("TestLink2"), Id.create("shipment2", LSPShipment.class), Id.create("Hub2", LSPResource.class), 13.0),
+			new HandlingInHubStartsEvent(110.0, Id.createLinkId("TestLink1"), Id.create("shipment1", LspShipment.class), Id.create("Hub1", LSPResource.class), 42.0),
+			new HandlingInHubStartsEvent(142.0, Id.createLinkId("TestLink2"), Id.create("shipment2", LspShipment.class), Id.create("Hub2", LSPResource.class), 13.0),
 
 			//Check if also some of the regular CarrierEvents get read correctly -> Load their mapping in the LspEventsReaderMapping via createCustomEventMappers() works
 			new CarrierTourEndEvent(500, Id.create("c1", Carrier.class), Id.createLinkId("TestLinkC1"), Id.createVehicleId("myVehicle"), Id.create("myCarrierTour", Tour.class))

--- a/src/test/java/org/matsim/freight/logistics/examples/lspReplanning/CollectionLSPReplanningTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/lspReplanning/CollectionLSPReplanningTest.java
@@ -49,8 +49,8 @@ import org.matsim.freight.carriers.controler.CarrierStrategyManager;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.CollectionCarrierResourceBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.VehicleType;
 
@@ -149,8 +149,8 @@ public class CollectionLSPReplanningTest {
 
 
 		for (int i = 1; i < 21; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			Random random = new Random(1);
 			int capacityDemand = random.nextInt(10);
 			builder.setCapacityDemand(capacityDemand);
@@ -173,7 +173,7 @@ public class CollectionLSPReplanningTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			collectionLSP.assignShipmentToLSP(shipment);
 		}
 		collectionLSP.scheduleLogisticChains();

--- a/src/test/java/org/matsim/freight/logistics/examples/lspScoring/CollectionLSPScoringTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/lspScoring/CollectionLSPScoringTest.java
@@ -45,8 +45,8 @@ import org.matsim.freight.carriers.*;
 import org.matsim.freight.carriers.CarrierCapabilities.FleetSize;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.VehicleType;
 
@@ -108,8 +108,8 @@ public class CollectionLSPScoringTest {
 		List<Link> linkList = new LinkedList<>(network.getLinks().values());
 
 		for (int i = 1; i < (numberOfShipments + 1); i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			Random random = new Random(1);
 			int capacityDemand = random.nextInt(10);
 			builder.setCapacityDemand(capacityDemand);
@@ -132,7 +132,7 @@ public class CollectionLSPScoringTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			collectionLSP.assignShipmentToLSP(shipment);
 		}
 

--- a/src/test/java/org/matsim/freight/logistics/examples/lspScoring/MultipleIterationsCollectionLSPScoringTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/lspScoring/MultipleIterationsCollectionLSPScoringTest.java
@@ -48,8 +48,8 @@ import org.matsim.freight.carriers.controler.CarrierControlerUtils;
 import org.matsim.freight.carriers.controler.CarrierStrategyManager;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.VehicleType;
 
@@ -135,8 +135,8 @@ public class MultipleIterationsCollectionLSPScoringTest {
 		List<Link> linkList = new LinkedList<>(network.getLinks().values());
 
 		for (int i = 1; i < (numberOfShipments + 1); i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			Random random = new Random(1);
 			int capacityDemand = random.nextInt(10);
 			builder.setCapacityDemand(capacityDemand);
@@ -159,7 +159,7 @@ public class MultipleIterationsCollectionLSPScoringTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			collectionLSP.assignShipmentToLSP(shipment);
 		}
 

--- a/src/test/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsReplanningTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsReplanningTest.java
@@ -51,9 +51,9 @@ import org.matsim.freight.carriers.controler.CarrierScoringFunctionFactory;
 import org.matsim.freight.carriers.controler.CarrierStrategyManager;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlan;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlan;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.VehicleType;
 
@@ -151,7 +151,7 @@ public class MultipleChainsReplanningTest {
 				.setLogisticChainScheduler(ResourceImplementationUtils.createDefaultSimpleForwardLogisticChainScheduler(createResourcesListFromLSPPlans(lspPlans)))
 				.build();
 
-		for (LSPShipment shipment : createInitialLSPShipments()) {
+		for (LspShipment shipment : createInitialLSPShipments()) {
 			lsp.assignShipmentToLSP(shipment);
 		}
 
@@ -160,14 +160,14 @@ public class MultipleChainsReplanningTest {
 		return lsp;
 	}
 
-	private static Collection<LSPShipment> createInitialLSPShipments() {
-		List<LSPShipment> shipmentList = new ArrayList<>();
+	private static Collection<LspShipment> createInitialLSPShipments() {
+		List<LspShipment> shipmentList = new ArrayList<>();
 		int capacityDemand = 1;
 
 		for (int i = 1; i <= 10; i++) {
 			if (i % 2 != 0) {
-				Id<LSPShipment> id = Id.create("ShipmentLeft_" + i, LSPShipment.class);
-				ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+				Id<LspShipment> id = Id.create("ShipmentLeft_" + i, LspShipment.class);
+				LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 
 				builder.setCapacityDemand(capacityDemand);
 				builder.setFromLinkId(DEPOT_LINK_ID);
@@ -180,8 +180,8 @@ public class MultipleChainsReplanningTest {
 
 				shipmentList.add(builder.build());
 			} else {
-				Id<LSPShipment> id = Id.create("ShipmentRight_" + i, LSPShipment.class);
-				ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+				Id<LspShipment> id = Id.create("ShipmentRight_" + i, LspShipment.class);
+				LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 
 				builder.setCapacityDemand(capacityDemand);
 				builder.setFromLinkId(DEPOT_LINK_ID);
@@ -257,8 +257,8 @@ public class MultipleChainsReplanningTest {
 		innovatedPlanShipmentPlanCount = lsp.getPlans().get(1).getShipmentPlans().size();
 
 		innovatedPlanFirstLogisticChainShipmentCount = lsp.getPlans().get(1).getLogisticChains().iterator().next().getLspShipmentIds().size();
-		for (ShipmentPlan shipmentPlan : lsp.getPlans().get(1).getShipmentPlans()) {
-			if (shipmentPlan.getPlanElements().isEmpty()) {
+		for (LspShipmentPlan lspShipmentPlan : lsp.getPlans().get(1).getShipmentPlans()) {
+			if (lspShipmentPlan.getPlanElements().isEmpty()) {
 				innovatedPlanHasEmptyShipmentPlanElements = true;
 			}
 		}

--- a/src/test/java/org/matsim/freight/logistics/examples/multipleChains/WorstPlanSelectorTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/multipleChains/WorstPlanSelectorTest.java
@@ -52,8 +52,8 @@ import org.matsim.freight.carriers.controler.CarrierScoringFunctionFactory;
 import org.matsim.freight.carriers.controler.CarrierStrategyManager;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.VehicleType;
 
@@ -182,7 +182,7 @@ public class WorstPlanSelectorTest {
 				.build();
 		lsp.addPlan(lspPlan_twoChains);
 
-		for (LSPShipment shipment : createInitialLSPShipments(network)) {
+		for (LspShipment shipment : createInitialLSPShipments(network)) {
 			lsp.assignShipmentToLSP(shipment);
 		}
 
@@ -191,8 +191,8 @@ public class WorstPlanSelectorTest {
 		return lsp;
 	}
 
-	private static Collection<LSPShipment> createInitialLSPShipments(Network network) {
-		List<LSPShipment> shipmentList = new ArrayList<>();
+	private static Collection<LspShipment> createInitialLSPShipments(Network network) {
+		List<LspShipment> shipmentList = new ArrayList<>();
 
 		Random rand2 = MatsimRandom.getLocalInstance();
 
@@ -208,8 +208,8 @@ public class WorstPlanSelectorTest {
 		}
 
 		for(int i = 1; i <= 10; i++) {
-			Id<LSPShipment> id = Id.create("Shipment_" + i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create("Shipment_" + i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 
 			int capacityDemand = 1;
 			builder.setCapacityDemand(capacityDemand);

--- a/src/test/java/org/matsim/freight/logistics/examples/requirementsChecking/AssignerRequirementsTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/requirementsChecking/AssignerRequirementsTest.java
@@ -60,8 +60,8 @@ import org.matsim.freight.carriers.*;
 import org.matsim.freight.carriers.CarrierCapabilities.FleetSize;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 
@@ -164,8 +164,8 @@ public class AssignerRequirementsTest {
 		Random rand = new Random(1);
 
 		for (int i = 1; i < 11; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			int capacityDemand = rand.nextInt(10);
 			builder.setCapacityDemand(capacityDemand);
 
@@ -194,19 +194,19 @@ public class AssignerRequirementsTest {
 				builder.addRequirement(new RedRequirement());
 			}
 
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			collectionLSP.assignShipmentToLSP(shipment);
 		}
 	}
 
 	@Test
 	public void testAssignerRequirements() {
-		for (Id<LSPShipment> shipmentId : blueChain.getLspShipmentIds()) {
-			LSPShipment shipment = LSPUtils.findLspShipment(blueChain.getLSP(), shipmentId);
+		for (Id<LspShipment> shipmentId : blueChain.getLspShipmentIds()) {
+			LspShipment shipment = LSPUtils.findLspShipment(blueChain.getLSP(), shipmentId);
 			assertTrue(shipment.getRequirements().iterator().next() instanceof BlueRequirement);
 		}
-		for (Id<LSPShipment> shipmentId : redChain.getLspShipmentIds()) {
-			LSPShipment shipment = LSPUtils.findLspShipment(redChain.getLSP(), shipmentId);
+		for (Id<LspShipment> shipmentId : redChain.getLspShipmentIds()) {
+			LspShipment shipment = LSPUtils.findLspShipment(redChain.getLSP(), shipmentId);
 			assertTrue(shipment.getRequirements().iterator().next() instanceof RedRequirement);
 		}
 	}

--- a/src/test/java/org/matsim/freight/logistics/examples/simulationTrackers/CollectionTrackerTest.java
+++ b/src/test/java/org/matsim/freight/logistics/examples/simulationTrackers/CollectionTrackerTest.java
@@ -52,8 +52,8 @@ import org.matsim.freight.carriers.Tour.TourElement;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.CollectionCarrierResourceBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
@@ -150,8 +150,8 @@ public class CollectionTrackerTest {
 
 
 		for (int i = 1; i < 2; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			Random random = new Random(1);
 			int capacityDemand = random.nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
@@ -174,7 +174,7 @@ public class CollectionTrackerTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			collectionLSP.assignShipmentToLSP(shipment);
 		}
 		collectionLSP.scheduleLogisticChains();

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CollectionLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CollectionLSPMobsimTest.java
@@ -49,9 +49,9 @@ import org.matsim.freight.carriers.*;
 import org.matsim.freight.carriers.CarrierCapabilities.FleetSize;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
@@ -148,8 +148,8 @@ public class CollectionLSPMobsimTest {
 		{
 			List<Link> linkList = new LinkedList<>(scenario.getNetwork().getLinks().values());
 			for (int i = 1; i < 2; i++) {
-				Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-				ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+				Id<LspShipment> id = Id.create(i, LspShipment.class);
+				LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 				int capacityDemand = 1 + MatsimRandom.getRandom().nextInt(4);
 				builder.setCapacityDemand(capacityDemand);
 
@@ -171,7 +171,7 @@ public class CollectionLSPMobsimTest {
 				TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 				builder.setStartTimeWindow(startTimeWindow);
 				builder.setDeliveryServiceTime(capacityDemand * 60);
-				LSPShipment shipment = builder.build();
+				LspShipment shipment = builder.build();
 				collectionLSP.assignShipmentToLSP(shipment);
 			}
 			collectionLSP.scheduleLogisticChains();
@@ -205,26 +205,26 @@ public class CollectionLSPMobsimTest {
 
 	@Test
 	public void testCollectionLSPMobsim() {
-		for (LSPShipment shipment : collectionLSP.getLspShipments()) {
+		for (LspShipment shipment : collectionLSP.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
 
 			log.warn("");
 			log.warn("shipment schedule plan elements:");
-			for (ShipmentPlanElement planElement : ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values()) {
+			for (LspShipmentPlanElement planElement : LspShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values()) {
 				log.warn(planElement);
 			}
 			log.warn("");
 			log.warn("shipment log plan elements:");
-			for (ShipmentPlanElement planElement : shipment.getShipmentLog().getPlanElements().values()) {
+			for (LspShipmentPlanElement planElement : shipment.getShipmentLog().getPlanElements().values()) {
 				log.warn(planElement);
 			}
 			log.warn("");
 
-			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
-			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
-			ArrayList<ShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
-			logElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+			assertEquals(LspShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
+			ArrayList<LspShipmentPlanElement> scheduleElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
+			logElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
 			//Das muss besser in den SchedulingTest rein
 			assertSame(collectionLSP.getResources().iterator().next(), collectionResource);
@@ -232,8 +232,8 @@ public class CollectionLSPMobsimTest {
 			assertSame(carrierResource.getCarrier(), carrier);
 			assertEquals(1, carrier.getServices().size());
 
-			for (ShipmentPlanElement scheduleElement : scheduleElements) {
-				ShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
+			for (LspShipmentPlanElement scheduleElement : scheduleElements) {
+				LspShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
 				assertEquals(scheduleElement.getElementType(), logElement.getElementType());
 				assertSame(scheduleElement.getResourceId(), logElement.getResourceId());
 				assertSame(scheduleElement.getLogisticChainElement(), logElement.getLogisticChainElement());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CompleteLSPMobsimTest.java
@@ -44,9 +44,9 @@ import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
@@ -239,8 +239,8 @@ public class CompleteLSPMobsimTest {
 		List<Link> linkList = new LinkedList<>(network.getLinks().values());
 		Random rand = new Random(1);
 		for (int i = 1; i < 2; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			int capacityDemand = 1 + rand.nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
 
@@ -277,7 +277,7 @@ public class CompleteLSPMobsimTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			completeLSP.assignShipmentToLSP(shipment);
 		}
 		completeLSP.scheduleLogisticChains();
@@ -310,15 +310,15 @@ public class CompleteLSPMobsimTest {
 
 	@Test
 	public void testFirstReloadLSPMobsim() {
-		for (LSPShipment shipment : completeLSP.getLspShipments()) {
+		for (LspShipment shipment : completeLSP.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
-			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(completeLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
-			ArrayList<ShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
-			logElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> scheduleElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(completeLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
+			logElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
-			for (ShipmentPlanElement scheduleElement : scheduleElements) {
-				ShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
+			for (LspShipmentPlanElement scheduleElement : scheduleElements) {
+				LspShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
 				assertEquals(scheduleElement.getElementType(), logElement.getElementType());
 				assertSame(scheduleElement.getResourceId(), logElement.getResourceId());
 				assertSame(scheduleElement.getLogisticChainElement(), logElement.getLogisticChainElement());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstAndSecondReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstAndSecondReloadLSPMobsimTest.java
@@ -48,9 +48,9 @@ import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
@@ -211,8 +211,8 @@ public class FirstAndSecondReloadLSPMobsimTest {
 		List<Link> linkList = new LinkedList<>(network.getLinks().values());
 
 		for (int i = 1; i < 2; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			int capacityDemand = 1 + MatsimRandom.getRandom().nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
 
@@ -249,7 +249,7 @@ public class FirstAndSecondReloadLSPMobsimTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			lsp.assignShipmentToLSP(shipment);
 		}
 		lsp.scheduleLogisticChains();
@@ -279,16 +279,16 @@ public class FirstAndSecondReloadLSPMobsimTest {
 
 	@Test
 	public void testFirstReloadLSPMobsim() {
-		for (LSPShipment shipment : lsp.getLspShipments()) {
+		for (LspShipment shipment : lsp.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
-			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
-			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
-			ArrayList<ShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
-			logElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+			assertEquals(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
+			ArrayList<LspShipmentPlanElement> scheduleElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
+			logElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
-			for (ShipmentPlanElement scheduleElement : scheduleElements) {
-				ShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
+			for (LspShipmentPlanElement scheduleElement : scheduleElements) {
+				LspShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
 				assertEquals(scheduleElement.getElementType(), logElement.getElementType());
 				assertSame(scheduleElement.getResourceId(), logElement.getResourceId());
 				assertSame(scheduleElement.getLogisticChainElement(), logElement.getLogisticChainElement());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstReloadLSPMobsimTest.java
@@ -48,9 +48,9 @@ import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
@@ -154,8 +154,8 @@ public class FirstReloadLSPMobsimTest {
 		List<Link> linkList = new LinkedList<>(network.getLinks().values());
 
 		for (int i = 1; i < 2; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			//Random random = new Random(1);
 			int capacityDemand = 1 + MatsimRandom.getRandom().nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
@@ -193,7 +193,7 @@ public class FirstReloadLSPMobsimTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			lsp.assignShipmentToLSP(shipment);
 		}
 		lsp.scheduleLogisticChains();
@@ -223,16 +223,16 @@ public class FirstReloadLSPMobsimTest {
 	@Test
 	public void testFirstReloadLSPMobsim() {
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
+		for (LspShipment shipment : lsp.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
-			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
-			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
-			ArrayList<ShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
-			logElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+			assertEquals(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
+			ArrayList<LspShipmentPlanElement> scheduleElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
+			logElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
-			for (ShipmentPlanElement scheduleElement : scheduleElements) {
-				ShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
+			for (LspShipmentPlanElement scheduleElement : scheduleElements) {
+				LspShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
 				assertEquals(scheduleElement.getElementType(), logElement.getElementType());
 				assertSame(scheduleElement.getResourceId(), logElement.getResourceId());
 				assertSame(scheduleElement.getLogisticChainElement(), logElement.getLogisticChainElement());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunLSPMobsimTest.java
@@ -48,9 +48,9 @@ import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
@@ -187,8 +187,8 @@ public class MainRunLSPMobsimTest {
 		List<Link> linkList = new LinkedList<>(network.getLinks().values());
 
 		for (int i = 1; i < 2; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			int capacityDemand = 1 + MatsimRandom.getRandom().nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
 
@@ -225,7 +225,7 @@ public class MainRunLSPMobsimTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			lsp.assignShipmentToLSP(shipment);
 		}
 		lsp.scheduleLogisticChains();
@@ -255,16 +255,16 @@ public class MainRunLSPMobsimTest {
 
 	@Test
 	public void testFirstReloadLSPMobsim() {
-		for (LSPShipment shipment : lsp.getLspShipments()) {
+		for (LspShipment shipment : lsp.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
-			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
-			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
-			ArrayList<ShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
-			logElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+			assertEquals(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
+			ArrayList<LspShipmentPlanElement> scheduleElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
+			logElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
-			for (ShipmentPlanElement scheduleElement : scheduleElements) {
-				ShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
+			for (LspShipmentPlanElement scheduleElement : scheduleElements) {
+				LspShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
 				assertEquals(scheduleElement.getElementType(), logElement.getElementType());
 				assertSame(scheduleElement.getResourceId(), logElement.getResourceId());
 				assertSame(scheduleElement.getLogisticChainElement(), logElement.getLogisticChainElement());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunOnlyLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunOnlyLSPMobsimTest.java
@@ -46,9 +46,9 @@ import org.matsim.freight.carriers.*;
 import org.matsim.freight.carriers.CarrierCapabilities.FleetSize;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
@@ -133,8 +133,8 @@ public class MainRunOnlyLSPMobsimTest {
 		List<Link> linkList = new LinkedList<>(network.getLinks().values());
 
 		for (int i = 1; i < 2; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			int capacityDemand = 1 + MatsimRandom.getRandom().nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
 
@@ -171,7 +171,7 @@ public class MainRunOnlyLSPMobsimTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			lsp.assignShipmentToLSP(shipment);
 		}
 		lsp.scheduleLogisticChains();
@@ -201,16 +201,16 @@ public class MainRunOnlyLSPMobsimTest {
 
 	@Test
 	public void testFirstReloadLSPMobsim() {
-		for (LSPShipment shipment : lsp.getLspShipments()) {
+		for (LspShipment shipment : lsp.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
-			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
-			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
-			ArrayList<ShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
-			logElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+			assertEquals(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
+			ArrayList<LspShipmentPlanElement> scheduleElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
+			logElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
-			for (ShipmentPlanElement scheduleElement : scheduleElements) {
-				ShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
+			for (LspShipmentPlanElement scheduleElement : scheduleElements) {
+				LspShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
 				assertEquals(scheduleElement.getElementType(), logElement.getElementType());
 				assertSame(scheduleElement.getResourceId(), logElement.getResourceId());
 				assertSame(scheduleElement.getLogisticChainElement(), logElement.getLogisticChainElement());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCollectionLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCollectionLSPMobsimTest.java
@@ -51,9 +51,9 @@ import org.matsim.freight.carriers.controler.CarrierStrategyManager;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.CollectionCarrierResourceBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.VehicleType;
 
@@ -136,8 +136,8 @@ public class MultipleIterationsCollectionLSPMobsimTest {
 
 		int numberOfShipments = 1 + MatsimRandom.getRandom().nextInt(50);
 		for (int i = 1; i < 1 + numberOfShipments; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			//Random random = new Random(1);
 			int capacityDemand = 1 + MatsimRandom.getRandom().nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
@@ -160,7 +160,7 @@ public class MultipleIterationsCollectionLSPMobsimTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			collectionLSP.assignShipmentToLSP(shipment);
 		}
 		collectionLSP.scheduleLogisticChains();
@@ -200,16 +200,16 @@ public class MultipleIterationsCollectionLSPMobsimTest {
 	@Test
 	public void testCollectionLSPMobsim() {
 
-		for (LSPShipment shipment : collectionLSP.getLspShipments()) {
+		for (LspShipment shipment : collectionLSP.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
-			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
-			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
-			ArrayList<ShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
-			logElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+			assertEquals(LspShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
+			ArrayList<LspShipmentPlanElement> scheduleElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
+			logElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
-			for (ShipmentPlanElement scheduleElement : scheduleElements) {
-				ShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
+			for (LspShipmentPlanElement scheduleElement : scheduleElements) {
+				LspShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
 				assertEquals(scheduleElement.getElementType(), logElement.getElementType());
 				assertSame(scheduleElement.getResourceId(), logElement.getResourceId());
 				assertSame(scheduleElement.getLogisticChainElement(), logElement.getLogisticChainElement());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCompleteLSPMobsimTest.java
@@ -53,9 +53,9 @@ import org.matsim.freight.logistics.examples.lspReplanning.AssignmentStrategyFac
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
@@ -253,8 +253,8 @@ public class MultipleIterationsCompleteLSPMobsimTest {
 		int numberOfShipments = MatsimRandom.getRandom().nextInt(50);
 
 		for (int i = 1; i < 1 + numberOfShipments; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			int capacityDemand = 1 + MatsimRandom.getRandom().nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
 
@@ -291,7 +291,7 @@ public class MultipleIterationsCompleteLSPMobsimTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			completeLSP.assignShipmentToLSP(shipment);
 		}
 		completeLSP.scheduleLogisticChains();
@@ -334,15 +334,15 @@ public class MultipleIterationsCompleteLSPMobsimTest {
 
 	@Test
 	public void testCompleteLSPMobsim() {
-		for (LSPShipment shipment : completeLSP.getLspShipments()) {
+		for (LspShipment shipment : completeLSP.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
-			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(completeLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
-			ArrayList<ShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
-			logElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> scheduleElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(completeLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
+			logElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
-			for (ShipmentPlanElement scheduleElement : scheduleElements) {
-				ShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
+			for (LspShipmentPlanElement scheduleElement : scheduleElements) {
+				LspShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
 				assertEquals(scheduleElement.getElementType(), logElement.getElementType());
 				assertSame(scheduleElement.getResourceId(), logElement.getResourceId());
 				assertSame(scheduleElement.getLogisticChainElement(), logElement.getLogisticChainElement());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstAndSecondReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstAndSecondReloadLSPMobsimTest.java
@@ -53,9 +53,9 @@ import org.matsim.freight.logistics.examples.lspReplanning.AssignmentStrategyFac
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
@@ -217,8 +217,8 @@ public class MultipleIterationsFirstAndSecondReloadLSPMobsimTest {
 		List<Link> linkList = new LinkedList<>(network.getLinks().values());
 		int numberOfShipments = 1 + MatsimRandom.getRandom().nextInt(50);
 		for (int i = 1; i < 1 + numberOfShipments; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			int capacityDemand = 1 + MatsimRandom.getRandom().nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
 
@@ -255,7 +255,7 @@ public class MultipleIterationsFirstAndSecondReloadLSPMobsimTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			lsp.assignShipmentToLSP(shipment);
 		}
 		lsp.scheduleLogisticChains();
@@ -293,16 +293,16 @@ public class MultipleIterationsFirstAndSecondReloadLSPMobsimTest {
 
 	@Test
 	public void testFirstReloadLSPMobsim() {
-		for (LSPShipment shipment : lsp.getLspShipments()) {
+		for (LspShipment shipment : lsp.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
-			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
-			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
-			ArrayList<ShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
-			logElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+			assertEquals(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
+			ArrayList<LspShipmentPlanElement> scheduleElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
+			logElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
-			for (ShipmentPlanElement scheduleElement : scheduleElements) {
-				ShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
+			for (LspShipmentPlanElement scheduleElement : scheduleElements) {
+				LspShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
 				assertEquals(scheduleElement.getElementType(), logElement.getElementType());
 				assertSame(scheduleElement.getResourceId(), logElement.getResourceId());
 				assertSame(scheduleElement.getLogisticChainElement(), logElement.getLogisticChainElement());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstReloadLSPMobsimTest.java
@@ -53,9 +53,9 @@ import org.matsim.freight.logistics.examples.lspReplanning.AssignmentStrategyFac
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.VehicleType;
 
@@ -158,8 +158,8 @@ public class MultipleIterationsFirstReloadLSPMobsimTest {
 		int numberOfShipments = 1 + MatsimRandom.getRandom().nextInt(50);
 
 		for (int i = 1; i < 1 + numberOfShipments; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			//Random random = new Random(1);
 			int capacityDemand = 1 + MatsimRandom.getRandom().nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
@@ -197,7 +197,7 @@ public class MultipleIterationsFirstReloadLSPMobsimTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			lsp.assignShipmentToLSP(shipment);
 		}
 		lsp.scheduleLogisticChains();
@@ -236,16 +236,16 @@ public class MultipleIterationsFirstReloadLSPMobsimTest {
 	@Test
 	public void testFirstReloadLSPMobsim() {
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
+		for (LspShipment shipment : lsp.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
-			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
-			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
-			ArrayList<ShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
-			logElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+			assertEquals(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
+			ArrayList<LspShipmentPlanElement> scheduleElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
+			logElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
-			for (ShipmentPlanElement scheduleElement : scheduleElements) {
-				ShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
+			for (LspShipmentPlanElement scheduleElement : scheduleElements) {
+				LspShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
 				assertEquals(scheduleElement.getElementType(), logElement.getElementType());
 				assertSame(scheduleElement.getResourceId(), logElement.getResourceId());
 				assertSame(scheduleElement.getLogisticChainElement(), logElement.getLogisticChainElement());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
@@ -53,9 +53,9 @@ import org.matsim.freight.logistics.examples.lspReplanning.AssignmentStrategyFac
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
@@ -195,8 +195,8 @@ public class MultipleIterationsMainRunLSPMobsimTest {
 
 		int numberOfShipments = 1 + MatsimRandom.getRandom().nextInt(50);
 		for (int i = 1; i < 1 + numberOfShipments; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			int capacityDemand = 1 + MatsimRandom.getRandom().nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
 
@@ -233,7 +233,7 @@ public class MultipleIterationsMainRunLSPMobsimTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			lsp.assignShipmentToLSP(shipment);
 		}
 		lsp.scheduleLogisticChains();
@@ -277,16 +277,16 @@ public class MultipleIterationsMainRunLSPMobsimTest {
 
 	@Test
 	public void testFirstReloadLSPMobsim() {
-		for (LSPShipment shipment : lsp.getLspShipments()) {
+		for (LspShipment shipment : lsp.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
-			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
-			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
-			ArrayList<ShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
-			logElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+			assertEquals(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
+			ArrayList<LspShipmentPlanElement> scheduleElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
+			logElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
-			for (ShipmentPlanElement scheduleElement : scheduleElements) {
-				ShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
+			for (LspShipmentPlanElement scheduleElement : scheduleElements) {
+				LspShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
 				assertEquals(scheduleElement.getElementType(), logElement.getElementType());
 				assertSame(scheduleElement.getResourceId(), logElement.getResourceId());
 				assertSame(scheduleElement.getLogisticChainElement(), logElement.getLogisticChainElement());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCollectionLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCollectionLSPMobsimTest.java
@@ -47,9 +47,9 @@ import org.matsim.freight.carriers.CarrierCapabilities.FleetSize;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.CollectionCarrierResourceBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.VehicleType;
 
@@ -131,8 +131,8 @@ public class MultipleShipmentsCollectionLSPMobsimTest {
 
 		int numberOfShipments = 1 + MatsimRandom.getRandom().nextInt(50);
 		for (int i = 1; i < 1 + numberOfShipments; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			//Random random = new Random(1);
 			int capacityDemand = 1 + MatsimRandom.getRandom().nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
@@ -155,7 +155,7 @@ public class MultipleShipmentsCollectionLSPMobsimTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			collectionLSP.assignShipmentToLSP(shipment);
 		}
 		collectionLSP.scheduleLogisticChains();
@@ -185,16 +185,16 @@ public class MultipleShipmentsCollectionLSPMobsimTest {
 	@Test
 	public void testCollectionLSPMobsim() {
 
-		for (LSPShipment shipment : collectionLSP.getLspShipments()) {
+		for (LspShipment shipment : collectionLSP.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
-			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
-			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
-			ArrayList<ShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
-			logElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+			assertEquals(LspShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
+			ArrayList<LspShipmentPlanElement> scheduleElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
+			logElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
-			for (ShipmentPlanElement scheduleElement : scheduleElements) {
-				ShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
+			for (LspShipmentPlanElement scheduleElement : scheduleElements) {
+				LspShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
 				assertEquals(scheduleElement.getElementType(), logElement.getElementType());
 				assertSame(scheduleElement.getResourceId(), logElement.getResourceId());
 				assertSame(scheduleElement.getLogisticChainElement(), logElement.getLogisticChainElement());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
@@ -55,9 +55,9 @@ import org.matsim.freight.logistics.examples.lspReplanning.AssignmentStrategyFac
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
@@ -256,8 +256,8 @@ public class MultipleShipmentsCompleteLSPMobsimTest {
 		int numberOfShipments = MatsimRandom.getRandom().nextInt(50);
 
 		for (int i = 1; i < 1 + numberOfShipments; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			int capacityDemand = 1 + MatsimRandom.getRandom().nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
 
@@ -294,7 +294,7 @@ public class MultipleShipmentsCompleteLSPMobsimTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			completeLSP.assignShipmentToLSP(shipment);
 		}
 		completeLSP.scheduleLogisticChains();
@@ -337,16 +337,16 @@ public class MultipleShipmentsCompleteLSPMobsimTest {
 
 	@Test
 	public void testCompleteLSPMobsim() {
-		for (LSPShipment shipment : completeLSP.getLspShipments()) {
+		for (LspShipment shipment : completeLSP.getLspShipments()) {
 			log.info("comparing shipment: " + shipment.getId());
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
-			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(completeLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
-			ArrayList<ShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
-			logElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> scheduleElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(completeLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
+			logElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
-			for (ShipmentPlanElement scheduleElement : scheduleElements) {
-				ShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
+			for (LspShipmentPlanElement scheduleElement : scheduleElements) {
+				LspShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
 				assertEquals(scheduleElement.getElementType(), logElement.getElementType());
 				assertSame(scheduleElement.getResourceId(), logElement.getResourceId());
 				assertSame(scheduleElement.getLogisticChainElement(), logElement.getLogisticChainElement());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstAndSecondReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstAndSecondReloadLSPMobsimTest.java
@@ -53,9 +53,9 @@ import org.matsim.freight.logistics.examples.lspReplanning.AssignmentStrategyFac
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
@@ -216,8 +216,8 @@ public class MultipleShipmentsFirstAndSecondReloadLSPMobsimTest {
 		List<Link> linkList = new LinkedList<>(network.getLinks().values());
 		int numberOfShipments = 1 + MatsimRandom.getRandom().nextInt(50);
 		for (int i = 1; i < 1 + numberOfShipments; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			int capacityDemand = 1 + MatsimRandom.getRandom().nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
 
@@ -254,7 +254,7 @@ public class MultipleShipmentsFirstAndSecondReloadLSPMobsimTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			lsp.assignShipmentToLSP(shipment);
 		}
 		lsp.scheduleLogisticChains();
@@ -292,16 +292,16 @@ public class MultipleShipmentsFirstAndSecondReloadLSPMobsimTest {
 
 	@Test
 	public void testFirstReloadLSPMobsim() {
-		for (LSPShipment shipment : lsp.getLspShipments()) {
+		for (LspShipment shipment : lsp.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
-			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
-			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
-			ArrayList<ShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
-			logElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+			assertEquals(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
+			ArrayList<LspShipmentPlanElement> scheduleElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
+			logElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
-			for (ShipmentPlanElement scheduleElement : scheduleElements) {
-				ShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
+			for (LspShipmentPlanElement scheduleElement : scheduleElements) {
+				LspShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
 				assertEquals(scheduleElement.getElementType(), logElement.getElementType());
 				assertSame(scheduleElement.getResourceId(), logElement.getResourceId());
 				assertSame(scheduleElement.getLogisticChainElement(), logElement.getLogisticChainElement());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstReloadLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstReloadLSPMobsimTest.java
@@ -48,9 +48,9 @@ import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
@@ -154,8 +154,8 @@ public class MultipleShipmentsFirstReloadLSPMobsimTest {
 		int numberOfShipments = 1 + MatsimRandom.getRandom().nextInt(50);
 
 		for (int i = 1; i < 1 + numberOfShipments; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			//Random random = new Random(1);
 			int capacityDemand = 1 + MatsimRandom.getRandom().nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
@@ -193,7 +193,7 @@ public class MultipleShipmentsFirstReloadLSPMobsimTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			lsp.assignShipmentToLSP(shipment);
 		}
 		lsp.scheduleLogisticChains();
@@ -228,16 +228,16 @@ public class MultipleShipmentsFirstReloadLSPMobsimTest {
 	@Test
 	public void testFirstReloadLSPMobsim() {
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
+		for (LspShipment shipment : lsp.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
-			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
-			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
-			ArrayList<ShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
-			logElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+			assertEquals(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
+			ArrayList<LspShipmentPlanElement> scheduleElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
+			logElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
-			for (ShipmentPlanElement scheduleElement : scheduleElements) {
-				ShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
+			for (LspShipmentPlanElement scheduleElement : scheduleElements) {
+				LspShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
 				assertEquals(scheduleElement.getElementType(), logElement.getElementType());
 				assertSame(scheduleElement.getResourceId(), logElement.getResourceId());
 				assertSame(scheduleElement.getLogisticChainElement(), logElement.getLogisticChainElement());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsMainRunLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsMainRunLSPMobsimTest.java
@@ -48,9 +48,9 @@ import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
@@ -189,8 +189,8 @@ public class MultipleShipmentsMainRunLSPMobsimTest {
 
 		int numberOfShipments = 1 + MatsimRandom.getRandom().nextInt(50);
 		for (int i = 1; i < 1 + numberOfShipments; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			int capacityDemand = 1 + MatsimRandom.getRandom().nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
 
@@ -227,7 +227,7 @@ public class MultipleShipmentsMainRunLSPMobsimTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			lsp.assignShipmentToLSP(shipment);
 		}
 		lsp.scheduleLogisticChains();
@@ -261,16 +261,16 @@ public class MultipleShipmentsMainRunLSPMobsimTest {
 
 	@Test
 	public void testFirstReloadLSPMobsim() {
-		for (LSPShipment shipment : lsp.getLspShipments()) {
+		for (LspShipment shipment : lsp.getLspShipments()) {
 			assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
-			assertEquals(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
-			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
-			ArrayList<ShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
-			logElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+			assertEquals(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(), shipment.getShipmentLog().getPlanElements().size());
+			ArrayList<LspShipmentPlanElement> scheduleElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
+			logElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
-			for (ShipmentPlanElement scheduleElement : scheduleElements) {
-				ShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
+			for (LspShipmentPlanElement scheduleElement : scheduleElements) {
+				LspShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
 				assertEquals(scheduleElement.getElementType(), logElement.getElementType());
 				assertSame(scheduleElement.getResourceId(), logElement.getResourceId());
 				assertSame(scheduleElement.getLogisticChainElement(), logElement.getLogisticChainElement());

--- a/src/test/java/org/matsim/freight/logistics/lspMobsimTests/RepeatedMultipleShipmentsCompleteLSPMobsimTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspMobsimTests/RepeatedMultipleShipmentsCompleteLSPMobsimTest.java
@@ -48,9 +48,9 @@ import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
@@ -247,8 +247,8 @@ public class RepeatedMultipleShipmentsCompleteLSPMobsimTest {
 		int numberOfShipments = MatsimRandom.getRandom().nextInt(50);
 
 		for (int i = 1; i < 1 + numberOfShipments; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			int capacityDemand = 1 + MatsimRandom.getRandom().nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
 
@@ -285,7 +285,7 @@ public class RepeatedMultipleShipmentsCompleteLSPMobsimTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			completeLSP.assignShipmentToLSP(shipment);
 		}
 		completeLSP.scheduleLogisticChains();
@@ -317,19 +317,19 @@ public class RepeatedMultipleShipmentsCompleteLSPMobsimTest {
 		int numberOfIterations = 1 + MatsimRandom.getRandom().nextInt(10);
 		for (int i = 0; i < numberOfIterations; i++) {
 			initialize();
-			for (LSPShipment shipment : completeLSP.getLspShipments()) {
+			for (LspShipment shipment : completeLSP.getLspShipments()) {
 				assertFalse(shipment.getShipmentLog().getPlanElements().isEmpty());
-				ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(completeLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-				scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
-				ArrayList<ShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
-				logElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+				ArrayList<LspShipmentPlanElement> scheduleElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(completeLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+				scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
+				ArrayList<LspShipmentPlanElement> logElements = new ArrayList<>(shipment.getShipmentLog().getPlanElements().values());
+				logElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
-				for (ShipmentPlanElement scheduleElement : scheduleElements) {
-					ShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
+				for (LspShipmentPlanElement scheduleElement : scheduleElements) {
+					LspShipmentPlanElement logElement = logElements.get(scheduleElements.indexOf(scheduleElement));
 					if (!scheduleElement.getElementType().equals(logElement.getElementType())) {
 						System.out.println(scheduleElement.getElementType());
 						System.out.println(logElement.getElementType());
-						for (int j = 0; j < ShipmentUtils.getOrCreateShipmentPlan(completeLSP.getSelectedPlan(), shipment.getId()).getPlanElements().size(); j++) {
+						for (int j = 0; j < LspShipmentUtils.getOrCreateShipmentPlan(completeLSP.getSelectedPlan(), shipment.getId()).getPlanElements().size(); j++) {
 							System.out.println("Scheduled: " + scheduleElements.get(j).getLogisticChainElement().getId() + "  " + scheduleElements.get(j).getResourceId() + "  " + scheduleElements.get(j).getElementType() + " Start: " + scheduleElements.get(j).getStartTime() + " End: " + scheduleElements.get(j).getEndTime());
 						}
 						System.out.println();

--- a/src/test/java/org/matsim/freight/logistics/lspShipmentAssignmentTests/CollectionLspShipmentAssigmentTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspShipmentAssignmentTests/CollectionLspShipmentAssigmentTest.java
@@ -39,11 +39,11 @@ import org.matsim.freight.carriers.CarrierCapabilities.FleetSize;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.CollectionCarrierResourceBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.VehicleType;
 
-public class CollectionLSPShipmentAssigmentTest {
+public class CollectionLspShipmentAssigmentTest {
 
 	private LSPPlan collectionPlan;
 	private LSP collectionLSP;
@@ -113,8 +113,8 @@ public class CollectionLSPShipmentAssigmentTest {
 
 
 		for (int i = 1; i < 11; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			int capacityDemand = MatsimRandom.getRandom().nextInt(10);
 			builder.setCapacityDemand(capacityDemand);
 
@@ -136,7 +136,7 @@ public class CollectionLSPShipmentAssigmentTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			collectionLSP.assignShipmentToLSP(shipment);
 		}
 	}

--- a/src/test/java/org/matsim/freight/logistics/lspShipmentAssignmentTests/CompleteLspShipmentAssignerTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspShipmentAssignmentTests/CompleteLspShipmentAssignerTest.java
@@ -40,12 +40,12 @@ import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 
-public class CompleteLSPShipmentAssignerTest {
+public class CompleteLspShipmentAssignerTest {
 
 	private LSPPlan completePlan;
 	private LSP completeLSP;
@@ -226,8 +226,8 @@ public class CompleteLSPShipmentAssignerTest {
 		ArrayList<Link> linkList = new ArrayList<>(network.getLinks().values());
 
 		for (int i = 1; i < 11; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			int capacityDemand = MatsimRandom.getRandom().nextInt(10);
 			builder.setCapacityDemand(capacityDemand);
 

--- a/src/test/java/org/matsim/freight/logistics/lspShipmentTest/CollectionShipmentBuilderTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspShipmentTest/CollectionShipmentBuilderTest.java
@@ -35,13 +35,13 @@ import org.matsim.core.gbl.MatsimRandom;
 import org.matsim.core.network.io.MatsimNetworkReader;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.freight.carriers.TimeWindow;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 
 public class CollectionShipmentBuilderTest {
 
 	private Network network;
-	private ArrayList<LSPShipment> shipments;
+	private ArrayList<LspShipment> shipments;
 
 
 	@BeforeEach
@@ -57,8 +57,8 @@ public class CollectionShipmentBuilderTest {
 		this.shipments = new ArrayList<>();
 
 		for (int i = 1; i < 11; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			int capacityDemand = MatsimRandom.getRandom().nextInt(10);
 			builder.setCapacityDemand(capacityDemand);
 
@@ -88,7 +88,7 @@ public class CollectionShipmentBuilderTest {
 	@Test
 	public void testShipments() {
 		assertEquals(10, shipments.size());
-		for (LSPShipment shipment : shipments) {
+		for (LspShipment shipment : shipments) {
 			assertNotNull(shipment.getId());
 			assertNotNull(shipment.getSize());
 			assertNotNull(shipment.getDeliveryTimeWindow());

--- a/src/test/java/org/matsim/freight/logistics/lspShipmentTest/CompleteShipmentBuilderTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspShipmentTest/CompleteShipmentBuilderTest.java
@@ -35,13 +35,13 @@ import org.matsim.core.gbl.MatsimRandom;
 import org.matsim.core.network.io.MatsimNetworkReader;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.freight.carriers.TimeWindow;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 
 public class CompleteShipmentBuilderTest {
 
 	private Network network;
-	private ArrayList<LSPShipment> shipments;
+	private ArrayList<LspShipment> shipments;
 
 	@BeforeEach
 	public void initialize() {
@@ -54,8 +54,8 @@ public class CompleteShipmentBuilderTest {
 		this.shipments = new ArrayList<>();
 
 		for (int i = 1; i < 11; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			int capacityDemand = MatsimRandom.getRandom().nextInt(10);
 			builder.setCapacityDemand(capacityDemand);
 
@@ -100,7 +100,7 @@ public class CompleteShipmentBuilderTest {
 	@Test
 	public void testShipments() {
 		assertEquals(10, shipments.size());
-		for (LSPShipment shipment : shipments) {
+		for (LspShipment shipment : shipments) {
 			assertNotNull(shipment.getId());
 			assertNotNull(shipment.getSize());
 			assertNotNull(shipment.getDeliveryTimeWindow());

--- a/src/test/java/org/matsim/freight/logistics/lspShipmentTest/DistributionShipmentBuilderTest.java
+++ b/src/test/java/org/matsim/freight/logistics/lspShipmentTest/DistributionShipmentBuilderTest.java
@@ -35,13 +35,13 @@ import org.matsim.core.gbl.MatsimRandom;
 import org.matsim.core.network.io.MatsimNetworkReader;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.freight.carriers.TimeWindow;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 
 public class DistributionShipmentBuilderTest {
 
 	private Network network;
-	private ArrayList<LSPShipment> shipments;
+	private ArrayList<LspShipment> shipments;
 
 
 	@BeforeEach
@@ -57,8 +57,8 @@ public class DistributionShipmentBuilderTest {
 		this.shipments = new ArrayList<>();
 
 		for (int i = 1; i < 11; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			int capacityDemand = MatsimRandom.getRandom().nextInt(10);
 			builder.setCapacityDemand(capacityDemand);
 
@@ -90,7 +90,7 @@ public class DistributionShipmentBuilderTest {
 	@Test
 	public void testShipments() {
 		assertEquals(10, shipments.size());
-		for (LSPShipment shipment : shipments) {
+		for (LspShipment shipment : shipments) {
 			assertNotNull(shipment.getId());
 			assertNotNull(shipment.getSize());
 			assertNotNull(shipment.getDeliveryTimeWindow());

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/CollectionLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/CollectionLSPSchedulingTest.java
@@ -39,9 +39,9 @@ import org.matsim.freight.carriers.*;
 import org.matsim.freight.carriers.CarrierCapabilities.FleetSize;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.CollectionCarrierResourceBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.VehicleType;
 
 public class CollectionLSPSchedulingTest {
@@ -115,8 +115,8 @@ public class CollectionLSPSchedulingTest {
 
 
 		for (int i = 1; i < 2; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			Random random = new Random(1);
 			int capacityDemand = random.nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
@@ -139,7 +139,7 @@ public class CollectionLSPSchedulingTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			collectionLSP.assignShipmentToLSP(shipment);
 		}
 		collectionLSP.scheduleLogisticChains();
@@ -149,20 +149,20 @@ public class CollectionLSPSchedulingTest {
 	@Test
 	public void testCollectionLSPScheduling() {
 
-		for (LSPShipment shipment : collectionLSP.getLspShipments()) {
-			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+		for (LspShipment shipment : collectionLSP.getLspShipments()) {
+			ArrayList<LspShipmentPlanElement> scheduleElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
 			System.out.println();
-			for (int i = 0; i < ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().size(); i++) {
+			for (int i = 0; i < LspShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().size(); i++) {
 				System.out.println("Scheduled: " + scheduleElements.get(i).getLogisticChainElement().getId() + "  " + scheduleElements.get(i).getResourceId() + "  " + scheduleElements.get(i).getElementType() + " Start: " + scheduleElements.get(i).getStartTime() + " End: " + scheduleElements.get(i).getEndTime());
 			}
 			System.out.println();
 		}
 
-		for (LSPShipment shipment : collectionLSP.getLspShipments()) {
-			assertEquals(3, ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().size());
-			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+		for (LspShipment shipment : collectionLSP.getLspShipments()) {
+			assertEquals(3, LspShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().size());
+			ArrayList<LspShipmentPlanElement> planElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 			assertEquals("UNLOAD", planElements.get(2).getElementType());
 			assertTrue(planElements.get(2).getEndTime() >= (0));
 			assertTrue(planElements.get(2).getEndTime() <= (24*3600));

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
@@ -42,9 +42,9 @@ import org.matsim.freight.carriers.CarrierCapabilities.FleetSize;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 
@@ -240,8 +240,8 @@ public class CompleteLSPSchedulingTest {
 		ArrayList<Link> linkList = new ArrayList<>(network.getLinks().values());
 		Random rand = new Random(1);
 		for (int i = 1; i < 2; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			int capacityDemand = rand.nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
 
@@ -278,7 +278,7 @@ public class CompleteLSPSchedulingTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			lsp.assignShipmentToLSP(shipment);
 		}
 		lsp.scheduleLogisticChains();
@@ -288,11 +288,11 @@ public class CompleteLSPSchedulingTest {
 	@Test
 	public void testCompletedLSPScheduling() {
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
-			ArrayList<ShipmentPlanElement> elementList = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			elementList.sort(ShipmentUtils.createShipmentPlanElementComparator());
+		for (LspShipment shipment : lsp.getLspShipments()) {
+			ArrayList<LspShipmentPlanElement> elementList = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			elementList.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 			System.out.println();
-			for (ShipmentPlanElement element : elementList) {
+			for (LspShipmentPlanElement element : elementList) {
 				System.out.println(element.getLogisticChainElement().getId() + "\t\t" + element.getResourceId() + "\t\t" + element.getElementType() + "\t\t" + element.getStartTime() + "\t\t" + element.getEndTime());
 			}
 			System.out.println();
@@ -301,10 +301,10 @@ public class CompleteLSPSchedulingTest {
 		ArrayList<LogisticChainElement> solutionElements = new ArrayList<>(lsp.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements());
 		ArrayList<LSPResource> resources = new ArrayList<>(lsp.getResources());
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
-			assertEquals(11, ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
-			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			planElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+		for (LspShipment shipment : lsp.getLspShipments()) {
+			assertEquals(11, LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
+			ArrayList<LspShipmentPlanElement> planElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			planElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
 			assertEquals("UNLOAD", planElements.get(10).getElementType());
 			assertTrue(planElements.get(10).getEndTime() >= (0));
@@ -435,7 +435,7 @@ public class CompleteLSPSchedulingTest {
 		while (iter.hasNext()) {
 			Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry = iter.next();
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().lspShipment;
+			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), shipment.getFrom());
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -462,7 +462,7 @@ public class CompleteLSPSchedulingTest {
 		while (iter.hasNext()) {
 			Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry = iter.next();
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().lspShipment;
+			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), toLinkId);
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -480,11 +480,11 @@ public class CompleteLSPSchedulingTest {
 			assertFalse(element.getIncomingShipments().getLspShipmentsWTime().contains(shipment));
 		}
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
+		for (LspShipment shipment : lsp.getLspShipments()) {
 			assertEquals(6, shipment.getSimulationTrackers().size());
 			eventHandlers = new ArrayList<>(shipment.getSimulationTrackers());
-			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			planElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> planElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			planElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
 			assertTrue(eventHandlers.get(0) instanceof LSPTourEndEventHandler);
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.get(0);

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/FirstReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/FirstReloadLSPSchedulingTest.java
@@ -41,9 +41,9 @@ import org.matsim.freight.carriers.CarrierCapabilities.FleetSize;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 
@@ -141,8 +141,8 @@ public class FirstReloadLSPSchedulingTest {
 		ArrayList<Link> linkList = new ArrayList<>(network.getLinks().values());
 
 		for (int i = 1; i < 2; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			//Random random = new Random(1);
 			int capacityDemand = MatsimRandom.getRandom().nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
@@ -180,7 +180,7 @@ public class FirstReloadLSPSchedulingTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			lsp.assignShipmentToLSP(shipment);
 		}
 		lsp.scheduleLogisticChains();
@@ -190,22 +190,22 @@ public class FirstReloadLSPSchedulingTest {
 	@Test
 	public void testFirstReloadLSPScheduling() {
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
-			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+		for (LspShipment shipment : lsp.getLspShipments()) {
+			ArrayList<LspShipmentPlanElement> scheduleElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
 			System.out.println();
-			for (int i = 0; i < ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(); i++) {
+			for (int i = 0; i < LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(); i++) {
 				System.out.println("Scheduled: " + scheduleElements.get(i).getLogisticChainElement().getId() + "  " + scheduleElements.get(i).getResourceId() + "  " + scheduleElements.get(i).getElementType() + " Start: " + scheduleElements.get(i).getStartTime() + " End: " + scheduleElements.get(i).getEndTime());
 			}
 			System.out.println();
 		}
 
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
-			assertEquals(4, ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
-			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			planElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+		for (LspShipment shipment : lsp.getLspShipments()) {
+			assertEquals(4, LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
+			ArrayList<LspShipmentPlanElement> planElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			planElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 			assertEquals("HANDLE", planElements.get(3).getElementType());
 			assertTrue(planElements.get(3).getEndTime() >= (0));
 			assertTrue(planElements.get(3).getEndTime() <= (24*3600));
@@ -257,7 +257,7 @@ public class FirstReloadLSPSchedulingTest {
 
 		for (Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry : reloadEventHandler.getServicesWaitedFor().entrySet()) {
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().lspShipment;
+			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), shipment.getFrom());
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -276,10 +276,10 @@ public class FirstReloadLSPSchedulingTest {
 		}
 
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
+		for (LspShipment shipment : lsp.getLspShipments()) {
 			assertEquals(2, shipment.getSimulationTrackers().size());
 			eventHandlers = new ArrayList<>(shipment.getSimulationTrackers());
-			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			ArrayList<LspShipmentPlanElement> planElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 
 			assertTrue(eventHandlers.get(0) instanceof LSPTourEndEventHandler);
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.get(0);

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MainRunLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MainRunLSPSchedulingTest.java
@@ -41,9 +41,9 @@ import org.matsim.freight.carriers.CarrierCapabilities.FleetSize;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 
@@ -176,8 +176,8 @@ public class MainRunLSPSchedulingTest {
 		ArrayList<Link> linkList = new ArrayList<>(network.getLinks().values());
 
 		for (int i = 1; i < 2; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			//Random random = new Random(1);
 			int capacityDemand = MatsimRandom.getRandom().nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
@@ -215,7 +215,7 @@ public class MainRunLSPSchedulingTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			lsp.assignShipmentToLSP(shipment);
 		}
 		lsp.scheduleLogisticChains();
@@ -225,22 +225,22 @@ public class MainRunLSPSchedulingTest {
 	@Test
 	public void testMainRunLSPScheduling() {
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
-			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+		for (LspShipment shipment : lsp.getLspShipments()) {
+			ArrayList<LspShipmentPlanElement> scheduleElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
 			System.out.println();
-			for (int i = 0; i < ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(); i++) {
+			for (int i = 0; i < LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(); i++) {
 				System.out.println("Scheduled: " + scheduleElements.get(i).getLogisticChainElement().getId() + "  " + scheduleElements.get(i).getResourceId() + "  " + scheduleElements.get(i).getElementType() + " Start: " + scheduleElements.get(i).getStartTime() + " End: " + scheduleElements.get(i).getEndTime());
 			}
 			System.out.println();
 		}
 
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
-			assertEquals(7, ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
-			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			planElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+		for (LspShipment shipment : lsp.getLspShipments()) {
+			assertEquals(7, LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
+			ArrayList<LspShipmentPlanElement> planElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			planElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 			assertEquals("UNLOAD", planElements.get(6).getElementType());
 			assertTrue(planElements.get(6).getEndTime() >= (0));
 			assertTrue(planElements.get(6).getEndTime() <= (24*3600));
@@ -324,7 +324,7 @@ public class MainRunLSPSchedulingTest {
 
 		for (Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry : reloadEventHandler.getServicesWaitedFor().entrySet()) {
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().lspShipment;
+			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), shipment.getFrom());
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -342,11 +342,11 @@ public class MainRunLSPSchedulingTest {
 			assertFalse(element.getIncomingShipments().getLspShipmentsWTime().contains(shipment));
 		}
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
+		for (LspShipment shipment : lsp.getLspShipments()) {
 			assertEquals(4, shipment.getSimulationTrackers().size());
 			eventHandlers = new ArrayList<>(shipment.getSimulationTrackers());
-			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			planElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> planElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			planElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 			ArrayList<LogisticChainElement> solutionElements = new ArrayList<>(lsp.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements());
 			ArrayList<LSPResource> resources = new ArrayList<>(lsp.getResources());
 

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCollectionLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCollectionLSPSchedulingTest.java
@@ -39,9 +39,9 @@ import org.matsim.freight.carriers.*;
 import org.matsim.freight.carriers.CarrierCapabilities.FleetSize;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.CollectionCarrierResourceBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 
@@ -118,8 +118,8 @@ public class MultipleShipmentsCollectionLSPSchedulingTest {
 
 
 		for (int i = 1; i < 100; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			Random random = new Random(1);
 			int capacityDemand = random.nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
@@ -142,7 +142,7 @@ public class MultipleShipmentsCollectionLSPSchedulingTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			collectionLSP.assignShipmentToLSP(shipment);
 		}
 		collectionLSP.scheduleLogisticChains();
@@ -152,20 +152,20 @@ public class MultipleShipmentsCollectionLSPSchedulingTest {
 	@Test
 	public void testCollectionLSPScheduling() {
 
-		for (LSPShipment shipment : collectionLSP.getLspShipments()) {
-			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+		for (LspShipment shipment : collectionLSP.getLspShipments()) {
+			ArrayList<LspShipmentPlanElement> scheduleElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
 			System.out.println();
-			for (int i = 0; i < ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().size(); i++) {
+			for (int i = 0; i < LspShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().size(); i++) {
 				System.out.println("Scheduled: " + scheduleElements.get(i).getLogisticChainElement().getId() + "  " + scheduleElements.get(i).getResourceId() + "  " + scheduleElements.get(i).getElementType() + " Start: " + scheduleElements.get(i).getStartTime() + " End: " + scheduleElements.get(i).getEndTime());
 			}
 			System.out.println();
 		}
 
-		for (LSPShipment shipment : collectionLSP.getLspShipments()) {
-			assertEquals(3, ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().size());
-			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+		for (LspShipment shipment : collectionLSP.getLspShipments()) {
+			assertEquals(3, LspShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().size());
+			ArrayList<LspShipmentPlanElement> planElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(collectionLSP.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 			assertEquals("UNLOAD", planElements.get(2).getElementType());
 			assertTrue(planElements.get(2).getEndTime() >= (0));
 			assertTrue(planElements.get(2).getEndTime() <= (24*3600));

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
@@ -42,9 +42,9 @@ import org.matsim.freight.carriers.CarrierCapabilities.FleetSize;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 
@@ -243,8 +243,8 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 		ArrayList<Link> linkList = new ArrayList<>(network.getLinks().values());
 		Random rand = new Random(1);
 		for (int i = 1; i < 100; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			int capacityDemand = rand.nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
 
@@ -281,7 +281,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			lsp.assignShipmentToLSP(shipment);
 		}
 		lsp.scheduleLogisticChains();
@@ -291,11 +291,11 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 	@Test
 	public void testCompletedLSPScheduling() {
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
-			ArrayList<ShipmentPlanElement> elementList = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			elementList.sort(ShipmentUtils.createShipmentPlanElementComparator());
+		for (LspShipment shipment : lsp.getLspShipments()) {
+			ArrayList<LspShipmentPlanElement> elementList = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			elementList.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 			System.out.println();
-			for (ShipmentPlanElement element : elementList) {
+			for (LspShipmentPlanElement element : elementList) {
 				System.out.println(element.getLogisticChainElement().getId() + "\t\t" + element.getResourceId() + "\t\t" + element.getElementType() + "\t\t" + element.getStartTime() + "\t\t" + element.getEndTime());
 			}
 			System.out.println();
@@ -304,10 +304,10 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 		ArrayList<LogisticChainElement> solutionElements = new ArrayList<>(lsp.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements());
 		ArrayList<LSPResource> resources = new ArrayList<>(lsp.getResources());
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
-			assertEquals(11, ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
-			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			planElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+		for (LspShipment shipment : lsp.getLspShipments()) {
+			assertEquals(11, LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
+			ArrayList<LspShipmentPlanElement> planElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			planElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
 			assertEquals("UNLOAD", planElements.get(10).getElementType());
 			assertTrue(planElements.get(10).getEndTime() >= (0));
@@ -438,7 +438,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 		while (iter.hasNext()) {
 			Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry = iter.next();
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().lspShipment;
+			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), shipment.getFrom());
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -465,7 +465,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 		while (iter.hasNext()) {
 			Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry = iter.next();
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().lspShipment;
+			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), toLinkId);
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -483,11 +483,11 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			assertFalse(element.getIncomingShipments().getLspShipmentsWTime().contains(shipment));
 		}
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
+		for (LspShipment shipment : lsp.getLspShipments()) {
 			assertEquals(6, shipment.getSimulationTrackers().size());
 			eventHandlers = new ArrayList<>(shipment.getSimulationTrackers());
-			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			planElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> planElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			planElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
 			assertTrue(eventHandlers.get(0) instanceof LSPTourEndEventHandler);
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.get(0);

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsFirstReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsFirstReloadLSPSchedulingTest.java
@@ -41,9 +41,9 @@ import org.matsim.freight.carriers.CarrierCapabilities.FleetSize;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 
@@ -140,8 +140,8 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 		ArrayList<Link> linkList = new ArrayList<>(network.getLinks().values());
 
 		for (int i = 1; i < 100; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			//Random random = new Random(1);
 			int capacityDemand = MatsimRandom.getRandom().nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
@@ -179,7 +179,7 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			lsp.assignShipmentToLSP(shipment);
 		}
 		lsp.scheduleLogisticChains();
@@ -189,22 +189,22 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 	@Test
 	public void testFirstReloadLSPScheduling() {
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
-			ArrayList<ShipmentPlanElement> scheduleElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			scheduleElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+		for (LspShipment shipment : lsp.getLspShipments()) {
+			ArrayList<LspShipmentPlanElement> scheduleElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			scheduleElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
 			System.out.println();
-			for (int i = 0; i < ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(); i++) {
+			for (int i = 0; i < LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size(); i++) {
 				System.out.println("Scheduled: " + scheduleElements.get(i).getLogisticChainElement().getId() + "  " + scheduleElements.get(i).getResourceId() + "  " + scheduleElements.get(i).getElementType() + " Start: " + scheduleElements.get(i).getStartTime() + " End: " + scheduleElements.get(i).getEndTime());
 			}
 			System.out.println();
 		}
 
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
-			assertEquals(4, ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
-			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			planElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+		for (LspShipment shipment : lsp.getLspShipments()) {
+			assertEquals(4, LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
+			ArrayList<LspShipmentPlanElement> planElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			planElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 			assertEquals("HANDLE", planElements.get(3).getElementType());
 			assertTrue(planElements.get(3).getEndTime() >= (0));
 			assertTrue(planElements.get(3).getEndTime() <= (24*3600));
@@ -256,7 +256,7 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 
 		for (Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry : reloadEventHandler.getServicesWaitedFor().entrySet()) {
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().lspShipment;
+			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), shipment.getFrom());
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -275,10 +275,10 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 		}
 
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
+		for (LspShipment shipment : lsp.getLspShipments()) {
 			assertEquals(2, shipment.getSimulationTrackers().size());
 			eventHandlers = new ArrayList<>(shipment.getSimulationTrackers());
-			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			ArrayList<LspShipmentPlanElement> planElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
 
 			assertTrue(eventHandlers.get(0) instanceof LSPTourEndEventHandler);
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.get(0);

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsMainRunLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsMainRunLSPSchedulingTest.java
@@ -41,9 +41,9 @@ import org.matsim.freight.carriers.CarrierCapabilities.FleetSize;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 
@@ -176,8 +176,8 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 		ArrayList<Link> linkList = new ArrayList<>(network.getLinks().values());
 
 		for (int i = 1; i < 100; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			//Random random = new Random(1);
 			int capacityDemand = MatsimRandom.getRandom().nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
@@ -215,7 +215,7 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			lsp.assignShipmentToLSP(shipment);
 		}
 		lsp.scheduleLogisticChains();
@@ -237,10 +237,10 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 		}*/
 
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
-			assertEquals(7, ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
-			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			planElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+		for (LspShipment shipment : lsp.getLspShipments()) {
+			assertEquals(7, LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
+			ArrayList<LspShipmentPlanElement> planElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			planElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 			assertEquals("UNLOAD", planElements.get(6).getElementType());
 			assertTrue(planElements.get(6).getEndTime() >= (0));
 			assertTrue(planElements.get(6).getEndTime() <= (24*3600));
@@ -324,7 +324,7 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 
 		for (Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry : reloadEventHandler.getServicesWaitedFor().entrySet()) {
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().lspShipment;
+			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), shipment.getFrom());
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -342,11 +342,11 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 			assertFalse(element.getIncomingShipments().getLspShipmentsWTime().contains(shipment));
 		}
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
+		for (LspShipment shipment : lsp.getLspShipments()) {
 			assertEquals(4, shipment.getSimulationTrackers().size());
 			eventHandlers = new ArrayList<>(shipment.getSimulationTrackers());
-			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			planElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> planElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			planElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 			ArrayList<LogisticChainElement> solutionElements = new ArrayList<>(lsp.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements());
 			ArrayList<LSPResource> resources = new ArrayList<>(lsp.getResources());
 

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsSecondReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsSecondReloadLSPSchedulingTest.java
@@ -42,9 +42,9 @@ import org.matsim.freight.carriers.CarrierCapabilities.FleetSize;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 
@@ -206,8 +206,8 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 		ArrayList<Link> linkList = new ArrayList<>(network.getLinks().values());
 
 		for (int i = 1; i < 100; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			int capacityDemand = MatsimRandom.getRandom().nextInt(4);
 			builder.setCapacityDemand(capacityDemand);
 
@@ -244,7 +244,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			lsp.assignShipmentToLSP(shipment);
 		}
 		lsp.scheduleLogisticChains();
@@ -264,10 +264,10 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			System.out.println();
 		}*/
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
-			assertEquals(8, ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
-			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			planElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+		for (LspShipment shipment : lsp.getLspShipments()) {
+			assertEquals(8, LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
+			ArrayList<LspShipmentPlanElement> planElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			planElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
 			assertEquals("HANDLE", planElements.get(7).getElementType());
 			assertTrue(planElements.get(7).getEndTime() >= (0));
@@ -365,7 +365,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 		while (iter.hasNext()) {
 			Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry = iter.next();
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().lspShipment;
+			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), shipment.getFrom());
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -392,7 +392,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 		while (iter.hasNext()) {
 			Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry = iter.next();
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().lspShipment;
+			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), toLinkId);
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -410,11 +410,11 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			assertFalse(element.getIncomingShipments().getLspShipmentsWTime().contains(shipment));
 		}
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
+		for (LspShipment shipment : lsp.getLspShipments()) {
 			assertEquals(4, shipment.getSimulationTrackers().size());
 			eventHandlers = new ArrayList<>(shipment.getSimulationTrackers());
-			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			planElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> planElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			planElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 			ArrayList<LogisticChainElement> solutionElements = new ArrayList<>(lsp.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements());
 			ArrayList<LSPResource> resources = new ArrayList<>(lsp.getResources());
 

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/SecondReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/SecondReloadLSPSchedulingTest.java
@@ -42,9 +42,9 @@ import org.matsim.freight.carriers.CarrierCapabilities.FleetSize;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TranshipmentHubSchedulerBuilder;
 import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils.TransshipmentHubBuilder;
-import org.matsim.freight.logistics.shipment.LSPShipment;
-import org.matsim.freight.logistics.shipment.ShipmentPlanElement;
-import org.matsim.freight.logistics.shipment.ShipmentUtils;
+import org.matsim.freight.logistics.shipment.LspShipment;
+import org.matsim.freight.logistics.shipment.LspShipmentPlanElement;
+import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 
@@ -206,8 +206,8 @@ public class SecondReloadLSPSchedulingTest {
 		ArrayList<Link> linkList = new ArrayList<>(network.getLinks().values());
 
 		for (int i = 1; i < 2; i++) {
-			Id<LSPShipment> id = Id.create(i, LSPShipment.class);
-			ShipmentUtils.LSPShipmentBuilder builder = ShipmentUtils.LSPShipmentBuilder.newInstance(id);
+			Id<LspShipment> id = Id.create(i, LspShipment.class);
+			LspShipmentUtils.LspShipmentBuilder builder = LspShipmentUtils.LspShipmentBuilder.newInstance(id);
 			int capacityDemand = MatsimRandom.getRandom().nextInt(10);
 			builder.setCapacityDemand(capacityDemand);
 
@@ -244,7 +244,7 @@ public class SecondReloadLSPSchedulingTest {
 			TimeWindow startTimeWindow = TimeWindow.newInstance(0, (24 * 3600));
 			builder.setStartTimeWindow(startTimeWindow);
 			builder.setDeliveryServiceTime(capacityDemand * 60);
-			LSPShipment shipment = builder.build();
+			LspShipment shipment = builder.build();
 			lsp.assignShipmentToLSP(shipment);
 		}
 		lsp.scheduleLogisticChains();
@@ -254,20 +254,20 @@ public class SecondReloadLSPSchedulingTest {
 	@Test
 	public void testSecondReloadLSPScheduling() {
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
-			ArrayList<ShipmentPlanElement> elementList = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			elementList.sort(ShipmentUtils.createShipmentPlanElementComparator());
+		for (LspShipment shipment : lsp.getLspShipments()) {
+			ArrayList<LspShipmentPlanElement> elementList = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			elementList.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 			System.out.println();
-			for (ShipmentPlanElement element : elementList) {
+			for (LspShipmentPlanElement element : elementList) {
 				System.out.println(element.getLogisticChainElement().getId() + " " + element.getResourceId() + " " + element.getElementType() + " " + element.getStartTime() + " " + element.getEndTime());
 			}
 			System.out.println();
 		}
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
-			assertEquals(8, ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
-			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			planElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+		for (LspShipment shipment : lsp.getLspShipments()) {
+			assertEquals(8, LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().size());
+			ArrayList<LspShipmentPlanElement> planElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			planElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 
 			assertEquals("HANDLE", planElements.get(7).getElementType());
 			assertTrue(planElements.get(7).getEndTime() >= (0));
@@ -365,7 +365,7 @@ public class SecondReloadLSPSchedulingTest {
 		while (iter.hasNext()) {
 			Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry = iter.next();
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().lspShipment;
+			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), shipment.getFrom());
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -392,7 +392,7 @@ public class SecondReloadLSPSchedulingTest {
 		while (iter.hasNext()) {
 			Entry<CarrierService, TransshipmentHubTourEndEventHandler.TransshipmentHubEventHandlerPair> entry = iter.next();
 			CarrierService service = entry.getKey();
-			LSPShipment shipment = entry.getValue().lspShipment;
+			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().element;
 			assertSame(service.getLocationLinkId(), toLinkId);
 			assertEquals(service.getCapacityDemand(), shipment.getSize());
@@ -410,11 +410,11 @@ public class SecondReloadLSPSchedulingTest {
 			assertFalse(element.getIncomingShipments().getLspShipmentsWTime().contains(shipment));
 		}
 
-		for (LSPShipment shipment : lsp.getLspShipments()) {
+		for (LspShipment shipment : lsp.getLspShipments()) {
 			assertEquals(4, shipment.getSimulationTrackers().size());
 			eventHandlers = new ArrayList<>(shipment.getSimulationTrackers());
-			ArrayList<ShipmentPlanElement> planElements = new ArrayList<>(ShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
-			planElements.sort(ShipmentUtils.createShipmentPlanElementComparator());
+			ArrayList<LspShipmentPlanElement> planElements = new ArrayList<>(LspShipmentUtils.getOrCreateShipmentPlan(lsp.getSelectedPlan(), shipment.getId()).getPlanElements().values());
+			planElements.sort(LspShipmentUtils.createShipmentPlanElementComparator());
 			ArrayList<LogisticChainElement> solutionElements = new ArrayList<>(lsp.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements());
 			ArrayList<LSPResource> resources = new ArrayList<>(lsp.getResources());
 

--- a/test/input/org/matsim/freight/logistics/io/lsps.xml
+++ b/test/input/org/matsim/freight/logistics/io/lsps.xml
@@ -20,16 +20,16 @@
 					</logisticChain>
 				</logisticChains>
 				<shipmentPlans>
-					<shipmentPlan shipmentId="shipmentSouth" chainId="singleChain">
+					<lspShipmentPlan shipmentId="shipmentSouth" chainId="singleChain">
 						<element id="singleCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="120.0" resourceId="singleCarrier"/>
 						<element id="singleCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="120.0" endTime="3540.0" resourceId="singleCarrier"/>
 						<element id="singleCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="3540.0" endTime="3600.0" resourceId="singleCarrier"/>
-					</shipmentPlan>
-					<shipmentPlan shipmentId="shipmentNorth" chainId="singleChain">
+					</lspShipmentPlan>
+					<lspShipmentPlan shipmentId="shipmentNorth" chainId="singleChain">
 						<element id="singleCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="120.0" resourceId="singleCarrier"/>
 						<element id="singleCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="120.0" endTime="2040.0" resourceId="singleCarrier"/>
 						<element id="singleCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="2040.0" endTime="2100.0" resourceId="singleCarrier"/>
-					</shipmentPlan>
+					</lspShipmentPlan>
 				</shipmentPlans>
 			</LspPlan>
 			<LspPlan score="-649.2" selected="false">
@@ -42,16 +42,16 @@
 					</logisticChain>
 				</logisticChains>
 				<shipmentPlans>
-					<shipmentPlan shipmentId="shipmentSouth" chainId="southChain">
+					<lspShipmentPlan shipmentId="shipmentSouth" chainId="southChain">
 						<element id="carrierSouthsouthCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="60.0" resourceId="carrierSouth"/>
 						<element id="carrierSouthsouthCarrierElementTRANSPORT" type="TRANSPORT" startTime="60.0" endTime="1020.0" resourceId="carrierSouth"/>
 						<element id="carrierSouthsouthCarrierElementUNLOAD" type="UNLOAD" startTime="1020.0" endTime="1080.0" resourceId="carrierSouth"/>
-					</shipmentPlan>
-					<shipmentPlan shipmentId="shipmentNorth" chainId="northChain">
+					</lspShipmentPlan>
+					<lspShipmentPlan shipmentId="shipmentNorth" chainId="northChain">
 						<element id="CarrierNorthnorthCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="60.0" resourceId="CarrierNorth"/>
 						<element id="CarrierNorthnorthCarrierElementTRANSPORT" type="TRANSPORT" startTime="60.0" endTime="1020.0" resourceId="CarrierNorth"/>
 						<element id="CarrierNorthnorthCarrierElementUNLOAD" type="UNLOAD" startTime="1020.0" endTime="1080.0" resourceId="CarrierNorth"/>
-					</shipmentPlan>
+					</lspShipmentPlan>
 				</shipmentPlans>
 			</LspPlan>
 		</LspPlans>
@@ -87,7 +87,7 @@
 					</logisticChain>
 				</logisticChains>
 				<shipmentPlans>
-					<shipmentPlan shipmentId="Shipment_1" chainId="hubChain">
+					<lspShipmentPlan shipmentId="Shipment_1" chainId="hubChain">
 						<element id="mainCarriermainCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2040.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementUNLOAD" type="UNLOAD" startTime="2040.0" endTime="2640.0" resourceId="mainCarrier"/>
@@ -95,8 +95,8 @@
 						<element id="distributionCarrierdistributionCarrierElementLOAD" type="LOAD" startTime="2651.0" endTime="2951.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementTRANSPORT" type="TRANSPORT" startTime="2951.0" endTime="3791.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementUNLOAD" type="UNLOAD" startTime="3791.0" endTime="3851.0" resourceId="distributionCarrier"/>
-					</shipmentPlan>
-					<shipmentPlan shipmentId="Shipment_2" chainId="hubChain">
+					</lspShipmentPlan>
+					<lspShipmentPlan shipmentId="Shipment_2" chainId="hubChain">
 						<element id="mainCarriermainCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2040.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementUNLOAD" type="UNLOAD" startTime="2040.0" endTime="2640.0" resourceId="mainCarrier"/>
@@ -104,8 +104,8 @@
 						<element id="distributionCarrierdistributionCarrierElementLOAD" type="LOAD" startTime="2651.0" endTime="2951.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementTRANSPORT" type="TRANSPORT" startTime="2951.0" endTime="3431.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementUNLOAD" type="UNLOAD" startTime="3431.0" endTime="3491.0" resourceId="distributionCarrier"/>
-					</shipmentPlan>
-					<shipmentPlan shipmentId="Shipment_3" chainId="hubChain">
+					</lspShipmentPlan>
+					<lspShipmentPlan shipmentId="Shipment_3" chainId="hubChain">
 						<element id="mainCarriermainCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2040.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementUNLOAD" type="UNLOAD" startTime="2040.0" endTime="2640.0" resourceId="mainCarrier"/>
@@ -113,8 +113,8 @@
 						<element id="distributionCarrierdistributionCarrierElementLOAD" type="LOAD" startTime="2651.0" endTime="2951.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementTRANSPORT" type="TRANSPORT" startTime="2951.0" endTime="4691.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementUNLOAD" type="UNLOAD" startTime="4691.0" endTime="4751.0" resourceId="distributionCarrier"/>
-					</shipmentPlan>
-					<shipmentPlan shipmentId="Shipment_4" chainId="hubChain">
+					</lspShipmentPlan>
+					<lspShipmentPlan shipmentId="Shipment_4" chainId="hubChain">
 						<element id="mainCarriermainCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2040.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementUNLOAD" type="UNLOAD" startTime="2040.0" endTime="2640.0" resourceId="mainCarrier"/>
@@ -122,8 +122,8 @@
 						<element id="distributionCarrierdistributionCarrierElementLOAD" type="LOAD" startTime="2651.0" endTime="2951.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementTRANSPORT" type="TRANSPORT" startTime="2951.0" endTime="5231.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementUNLOAD" type="UNLOAD" startTime="5231.0" endTime="5291.0" resourceId="distributionCarrier"/>
-					</shipmentPlan>
-					<shipmentPlan shipmentId="Shipment_5" chainId="hubChain">
+					</lspShipmentPlan>
+					<lspShipmentPlan shipmentId="Shipment_5" chainId="hubChain">
 						<element id="mainCarriermainCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2040.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementUNLOAD" type="UNLOAD" startTime="2040.0" endTime="2640.0" resourceId="mainCarrier"/>
@@ -131,8 +131,8 @@
 						<element id="distributionCarrierdistributionCarrierElementLOAD" type="LOAD" startTime="2651.0" endTime="2951.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementTRANSPORT" type="TRANSPORT" startTime="2951.0" endTime="3611.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementUNLOAD" type="UNLOAD" startTime="3611.0" endTime="3671.0" resourceId="distributionCarrier"/>
-					</shipmentPlan>
-					<shipmentPlan shipmentId="Shipment_6" chainId="hubChain">
+					</lspShipmentPlan>
+					<lspShipmentPlan shipmentId="Shipment_6" chainId="hubChain">
 						<element id="mainCarriermainCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2040.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementUNLOAD" type="UNLOAD" startTime="2040.0" endTime="2640.0" resourceId="mainCarrier"/>
@@ -140,8 +140,8 @@
 						<element id="distributionCarrierdistributionCarrierElementLOAD" type="LOAD" startTime="2651.0" endTime="2951.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementTRANSPORT" type="TRANSPORT" startTime="2951.0" endTime="3791.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementUNLOAD" type="UNLOAD" startTime="3791.0" endTime="3851.0" resourceId="distributionCarrier"/>
-					</shipmentPlan>
-					<shipmentPlan shipmentId="Shipment_7" chainId="hubChain">
+					</lspShipmentPlan>
+					<lspShipmentPlan shipmentId="Shipment_7" chainId="hubChain">
 						<element id="mainCarriermainCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2040.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementUNLOAD" type="UNLOAD" startTime="2040.0" endTime="2640.0" resourceId="mainCarrier"/>
@@ -149,8 +149,8 @@
 						<element id="distributionCarrierdistributionCarrierElementLOAD" type="LOAD" startTime="2651.0" endTime="2951.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementTRANSPORT" type="TRANSPORT" startTime="2951.0" endTime="5171.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementUNLOAD" type="UNLOAD" startTime="5171.0" endTime="5231.0" resourceId="distributionCarrier"/>
-					</shipmentPlan>
-					<shipmentPlan shipmentId="Shipment_8" chainId="hubChain">
+					</lspShipmentPlan>
+					<lspShipmentPlan shipmentId="Shipment_8" chainId="hubChain">
 						<element id="mainCarriermainCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2040.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementUNLOAD" type="UNLOAD" startTime="2040.0" endTime="2640.0" resourceId="mainCarrier"/>
@@ -158,8 +158,8 @@
 						<element id="distributionCarrierdistributionCarrierElementLOAD" type="LOAD" startTime="2651.0" endTime="2951.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementTRANSPORT" type="TRANSPORT" startTime="2951.0" endTime="4391.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementUNLOAD" type="UNLOAD" startTime="4391.0" endTime="4451.0" resourceId="distributionCarrier"/>
-					</shipmentPlan>
-					<shipmentPlan shipmentId="Shipment_9" chainId="hubChain">
+					</lspShipmentPlan>
+					<lspShipmentPlan shipmentId="Shipment_9" chainId="hubChain">
 						<element id="mainCarriermainCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2040.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementUNLOAD" type="UNLOAD" startTime="2040.0" endTime="2640.0" resourceId="mainCarrier"/>
@@ -167,8 +167,8 @@
 						<element id="distributionCarrierdistributionCarrierElementLOAD" type="LOAD" startTime="2651.0" endTime="2951.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementTRANSPORT" type="TRANSPORT" startTime="2951.0" endTime="3971.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementUNLOAD" type="UNLOAD" startTime="3971.0" endTime="4031.0" resourceId="distributionCarrier"/>
-					</shipmentPlan>
-					<shipmentPlan shipmentId="Shipment_10" chainId="hubChain">
+					</lspShipmentPlan>
+					<lspShipmentPlan shipmentId="Shipment_10" chainId="hubChain">
 						<element id="mainCarriermainCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2040.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementUNLOAD" type="UNLOAD" startTime="2040.0" endTime="2640.0" resourceId="mainCarrier"/>
@@ -176,7 +176,7 @@
 						<element id="distributionCarrierdistributionCarrierElementLOAD" type="LOAD" startTime="2651.0" endTime="2951.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementTRANSPORT" type="TRANSPORT" startTime="2951.0" endTime="5711.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementUNLOAD" type="UNLOAD" startTime="5711.0" endTime="5771.0" resourceId="distributionCarrier"/>
-					</shipmentPlan>
+					</lspShipmentPlan>
 				</shipmentPlans>
 			</LspPlan>
 			<LspPlan score="-509.2" selected="true">
@@ -186,56 +186,56 @@
 					</logisticChain>
 				</logisticChains>
 				<shipmentPlans>
-					<shipmentPlan shipmentId="Shipment_1" chainId="directChain">
+					<lspShipmentPlan shipmentId="Shipment_1" chainId="directChain">
 						<element id="directCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="3060.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="3060.0" endTime="3120.0" resourceId="directCarrier"/>
-					</shipmentPlan>
-					<shipmentPlan shipmentId="Shipment_2" chainId="directChain">
+					</lspShipmentPlan>
+					<lspShipmentPlan shipmentId="Shipment_2" chainId="directChain">
 						<element id="directCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="4020.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="4020.0" endTime="4080.0" resourceId="directCarrier"/>
-					</shipmentPlan>
-					<shipmentPlan shipmentId="Shipment_3" chainId="directChain">
+					</lspShipmentPlan>
+					<lspShipmentPlan shipmentId="Shipment_3" chainId="directChain">
 						<element id="directCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2340.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="2340.0" endTime="2400.0" resourceId="directCarrier"/>
-					</shipmentPlan>
-					<shipmentPlan shipmentId="Shipment_4" chainId="directChain">
+					</lspShipmentPlan>
+					<lspShipmentPlan shipmentId="Shipment_4" chainId="directChain">
 						<element id="directCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="1680.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="1680.0" endTime="1740.0" resourceId="directCarrier"/>
-					</shipmentPlan>
-					<shipmentPlan shipmentId="Shipment_5" chainId="directChain">
+					</lspShipmentPlan>
+					<lspShipmentPlan shipmentId="Shipment_5" chainId="directChain">
 						<element id="directCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2880.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="2880.0" endTime="2940.0" resourceId="directCarrier"/>
-					</shipmentPlan>
-					<shipmentPlan shipmentId="Shipment_6" chainId="directChain">
+					</lspShipmentPlan>
+					<lspShipmentPlan shipmentId="Shipment_6" chainId="directChain">
 						<element id="directCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="3240.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="3240.0" endTime="3300.0" resourceId="directCarrier"/>
-					</shipmentPlan>
-					<shipmentPlan shipmentId="Shipment_7" chainId="directChain">
+					</lspShipmentPlan>
+					<lspShipmentPlan shipmentId="Shipment_7" chainId="directChain">
 						<element id="directCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2280.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="2280.0" endTime="2340.0" resourceId="directCarrier"/>
-					</shipmentPlan>
-					<shipmentPlan shipmentId="Shipment_8" chainId="directChain">
+					</lspShipmentPlan>
+					<lspShipmentPlan shipmentId="Shipment_8" chainId="directChain">
 						<element id="directCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="3840.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="3840.0" endTime="3900.0" resourceId="directCarrier"/>
-					</shipmentPlan>
-					<shipmentPlan shipmentId="Shipment_9" chainId="directChain">
+					</lspShipmentPlan>
+					<lspShipmentPlan shipmentId="Shipment_9" chainId="directChain">
 						<element id="directCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="3420.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="3420.0" endTime="3480.0" resourceId="directCarrier"/>
-					</shipmentPlan>
-					<shipmentPlan shipmentId="Shipment_10" chainId="directChain">
+					</lspShipmentPlan>
+					<lspShipmentPlan shipmentId="Shipment_10" chainId="directChain">
 						<element id="directCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="1740.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="1740.0" endTime="1800.0" resourceId="directCarrier"/>
-					</shipmentPlan>
+					</lspShipmentPlan>
 				</shipmentPlans>
 			</LspPlan>
 		</LspPlans>

--- a/test/input/org/matsim/freight/logistics/io/lsps.xml
+++ b/test/input/org/matsim/freight/logistics/io/lsps.xml
@@ -20,16 +20,16 @@
 					</logisticChain>
 				</logisticChains>
 				<shipmentPlans>
-					<lspShipmentPlan shipmentId="shipmentSouth" chainId="singleChain">
+					<shipmentPlan shipmentId="shipmentSouth" chainId="singleChain">
 						<element id="singleCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="120.0" resourceId="singleCarrier"/>
 						<element id="singleCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="120.0" endTime="3540.0" resourceId="singleCarrier"/>
 						<element id="singleCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="3540.0" endTime="3600.0" resourceId="singleCarrier"/>
-					</lspShipmentPlan>
-					<lspShipmentPlan shipmentId="shipmentNorth" chainId="singleChain">
+					</shipmentPlan>
+					<shipmentPlan shipmentId="shipmentNorth" chainId="singleChain">
 						<element id="singleCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="120.0" resourceId="singleCarrier"/>
 						<element id="singleCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="120.0" endTime="2040.0" resourceId="singleCarrier"/>
 						<element id="singleCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="2040.0" endTime="2100.0" resourceId="singleCarrier"/>
-					</lspShipmentPlan>
+					</shipmentPlan>
 				</shipmentPlans>
 			</LspPlan>
 			<LspPlan score="-649.2" selected="false">
@@ -42,16 +42,16 @@
 					</logisticChain>
 				</logisticChains>
 				<shipmentPlans>
-					<lspShipmentPlan shipmentId="shipmentSouth" chainId="southChain">
+					<shipmentPlan shipmentId="shipmentSouth" chainId="southChain">
 						<element id="carrierSouthsouthCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="60.0" resourceId="carrierSouth"/>
 						<element id="carrierSouthsouthCarrierElementTRANSPORT" type="TRANSPORT" startTime="60.0" endTime="1020.0" resourceId="carrierSouth"/>
 						<element id="carrierSouthsouthCarrierElementUNLOAD" type="UNLOAD" startTime="1020.0" endTime="1080.0" resourceId="carrierSouth"/>
-					</lspShipmentPlan>
-					<lspShipmentPlan shipmentId="shipmentNorth" chainId="northChain">
+					</shipmentPlan>
+					<shipmentPlan shipmentId="shipmentNorth" chainId="northChain">
 						<element id="CarrierNorthnorthCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="60.0" resourceId="CarrierNorth"/>
 						<element id="CarrierNorthnorthCarrierElementTRANSPORT" type="TRANSPORT" startTime="60.0" endTime="1020.0" resourceId="CarrierNorth"/>
 						<element id="CarrierNorthnorthCarrierElementUNLOAD" type="UNLOAD" startTime="1020.0" endTime="1080.0" resourceId="CarrierNorth"/>
-					</lspShipmentPlan>
+					</shipmentPlan>
 				</shipmentPlans>
 			</LspPlan>
 		</LspPlans>
@@ -87,7 +87,7 @@
 					</logisticChain>
 				</logisticChains>
 				<shipmentPlans>
-					<lspShipmentPlan shipmentId="Shipment_1" chainId="hubChain">
+					<shipmentPlan shipmentId="Shipment_1" chainId="hubChain">
 						<element id="mainCarriermainCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2040.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementUNLOAD" type="UNLOAD" startTime="2040.0" endTime="2640.0" resourceId="mainCarrier"/>
@@ -95,8 +95,8 @@
 						<element id="distributionCarrierdistributionCarrierElementLOAD" type="LOAD" startTime="2651.0" endTime="2951.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementTRANSPORT" type="TRANSPORT" startTime="2951.0" endTime="3791.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementUNLOAD" type="UNLOAD" startTime="3791.0" endTime="3851.0" resourceId="distributionCarrier"/>
-					</lspShipmentPlan>
-					<lspShipmentPlan shipmentId="Shipment_2" chainId="hubChain">
+					</shipmentPlan>
+					<shipmentPlan shipmentId="Shipment_2" chainId="hubChain">
 						<element id="mainCarriermainCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2040.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementUNLOAD" type="UNLOAD" startTime="2040.0" endTime="2640.0" resourceId="mainCarrier"/>
@@ -104,8 +104,8 @@
 						<element id="distributionCarrierdistributionCarrierElementLOAD" type="LOAD" startTime="2651.0" endTime="2951.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementTRANSPORT" type="TRANSPORT" startTime="2951.0" endTime="3431.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementUNLOAD" type="UNLOAD" startTime="3431.0" endTime="3491.0" resourceId="distributionCarrier"/>
-					</lspShipmentPlan>
-					<lspShipmentPlan shipmentId="Shipment_3" chainId="hubChain">
+					</shipmentPlan>
+					<shipmentPlan shipmentId="Shipment_3" chainId="hubChain">
 						<element id="mainCarriermainCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2040.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementUNLOAD" type="UNLOAD" startTime="2040.0" endTime="2640.0" resourceId="mainCarrier"/>
@@ -113,8 +113,8 @@
 						<element id="distributionCarrierdistributionCarrierElementLOAD" type="LOAD" startTime="2651.0" endTime="2951.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementTRANSPORT" type="TRANSPORT" startTime="2951.0" endTime="4691.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementUNLOAD" type="UNLOAD" startTime="4691.0" endTime="4751.0" resourceId="distributionCarrier"/>
-					</lspShipmentPlan>
-					<lspShipmentPlan shipmentId="Shipment_4" chainId="hubChain">
+					</shipmentPlan>
+					<shipmentPlan shipmentId="Shipment_4" chainId="hubChain">
 						<element id="mainCarriermainCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2040.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementUNLOAD" type="UNLOAD" startTime="2040.0" endTime="2640.0" resourceId="mainCarrier"/>
@@ -122,8 +122,8 @@
 						<element id="distributionCarrierdistributionCarrierElementLOAD" type="LOAD" startTime="2651.0" endTime="2951.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementTRANSPORT" type="TRANSPORT" startTime="2951.0" endTime="5231.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementUNLOAD" type="UNLOAD" startTime="5231.0" endTime="5291.0" resourceId="distributionCarrier"/>
-					</lspShipmentPlan>
-					<lspShipmentPlan shipmentId="Shipment_5" chainId="hubChain">
+					</shipmentPlan>
+					<shipmentPlan shipmentId="Shipment_5" chainId="hubChain">
 						<element id="mainCarriermainCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2040.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementUNLOAD" type="UNLOAD" startTime="2040.0" endTime="2640.0" resourceId="mainCarrier"/>
@@ -131,8 +131,8 @@
 						<element id="distributionCarrierdistributionCarrierElementLOAD" type="LOAD" startTime="2651.0" endTime="2951.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementTRANSPORT" type="TRANSPORT" startTime="2951.0" endTime="3611.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementUNLOAD" type="UNLOAD" startTime="3611.0" endTime="3671.0" resourceId="distributionCarrier"/>
-					</lspShipmentPlan>
-					<lspShipmentPlan shipmentId="Shipment_6" chainId="hubChain">
+					</shipmentPlan>
+					<shipmentPlan shipmentId="Shipment_6" chainId="hubChain">
 						<element id="mainCarriermainCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2040.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementUNLOAD" type="UNLOAD" startTime="2040.0" endTime="2640.0" resourceId="mainCarrier"/>
@@ -140,8 +140,8 @@
 						<element id="distributionCarrierdistributionCarrierElementLOAD" type="LOAD" startTime="2651.0" endTime="2951.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementTRANSPORT" type="TRANSPORT" startTime="2951.0" endTime="3791.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementUNLOAD" type="UNLOAD" startTime="3791.0" endTime="3851.0" resourceId="distributionCarrier"/>
-					</lspShipmentPlan>
-					<lspShipmentPlan shipmentId="Shipment_7" chainId="hubChain">
+					</shipmentPlan>
+					<shipmentPlan shipmentId="Shipment_7" chainId="hubChain">
 						<element id="mainCarriermainCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2040.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementUNLOAD" type="UNLOAD" startTime="2040.0" endTime="2640.0" resourceId="mainCarrier"/>
@@ -149,8 +149,8 @@
 						<element id="distributionCarrierdistributionCarrierElementLOAD" type="LOAD" startTime="2651.0" endTime="2951.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementTRANSPORT" type="TRANSPORT" startTime="2951.0" endTime="5171.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementUNLOAD" type="UNLOAD" startTime="5171.0" endTime="5231.0" resourceId="distributionCarrier"/>
-					</lspShipmentPlan>
-					<lspShipmentPlan shipmentId="Shipment_8" chainId="hubChain">
+					</shipmentPlan>
+					<shipmentPlan shipmentId="Shipment_8" chainId="hubChain">
 						<element id="mainCarriermainCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2040.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementUNLOAD" type="UNLOAD" startTime="2040.0" endTime="2640.0" resourceId="mainCarrier"/>
@@ -158,8 +158,8 @@
 						<element id="distributionCarrierdistributionCarrierElementLOAD" type="LOAD" startTime="2651.0" endTime="2951.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementTRANSPORT" type="TRANSPORT" startTime="2951.0" endTime="4391.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementUNLOAD" type="UNLOAD" startTime="4391.0" endTime="4451.0" resourceId="distributionCarrier"/>
-					</lspShipmentPlan>
-					<lspShipmentPlan shipmentId="Shipment_9" chainId="hubChain">
+					</shipmentPlan>
+					<shipmentPlan shipmentId="Shipment_9" chainId="hubChain">
 						<element id="mainCarriermainCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2040.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementUNLOAD" type="UNLOAD" startTime="2040.0" endTime="2640.0" resourceId="mainCarrier"/>
@@ -167,8 +167,8 @@
 						<element id="distributionCarrierdistributionCarrierElementLOAD" type="LOAD" startTime="2651.0" endTime="2951.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementTRANSPORT" type="TRANSPORT" startTime="2951.0" endTime="3971.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementUNLOAD" type="UNLOAD" startTime="3971.0" endTime="4031.0" resourceId="distributionCarrier"/>
-					</lspShipmentPlan>
-					<lspShipmentPlan shipmentId="Shipment_10" chainId="hubChain">
+					</shipmentPlan>
+					<shipmentPlan shipmentId="Shipment_10" chainId="hubChain">
 						<element id="mainCarriermainCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2040.0" resourceId="mainCarrier"/>
 						<element id="mainCarriermainCarrierElementUNLOAD" type="UNLOAD" startTime="2040.0" endTime="2640.0" resourceId="mainCarrier"/>
@@ -176,7 +176,7 @@
 						<element id="distributionCarrierdistributionCarrierElementLOAD" type="LOAD" startTime="2651.0" endTime="2951.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementTRANSPORT" type="TRANSPORT" startTime="2951.0" endTime="5711.0" resourceId="distributionCarrier"/>
 						<element id="distributionCarrierdistributionCarrierElementUNLOAD" type="UNLOAD" startTime="5711.0" endTime="5771.0" resourceId="distributionCarrier"/>
-					</lspShipmentPlan>
+					</shipmentPlan>
 				</shipmentPlans>
 			</LspPlan>
 			<LspPlan score="-509.2" selected="true">
@@ -186,56 +186,56 @@
 					</logisticChain>
 				</logisticChains>
 				<shipmentPlans>
-					<lspShipmentPlan shipmentId="Shipment_1" chainId="directChain">
+					<shipmentPlan shipmentId="Shipment_1" chainId="directChain">
 						<element id="directCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="3060.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="3060.0" endTime="3120.0" resourceId="directCarrier"/>
-					</lspShipmentPlan>
-					<lspShipmentPlan shipmentId="Shipment_2" chainId="directChain">
+					</shipmentPlan>
+					<shipmentPlan shipmentId="Shipment_2" chainId="directChain">
 						<element id="directCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="4020.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="4020.0" endTime="4080.0" resourceId="directCarrier"/>
-					</lspShipmentPlan>
-					<lspShipmentPlan shipmentId="Shipment_3" chainId="directChain">
+					</shipmentPlan>
+					<shipmentPlan shipmentId="Shipment_3" chainId="directChain">
 						<element id="directCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2340.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="2340.0" endTime="2400.0" resourceId="directCarrier"/>
-					</lspShipmentPlan>
-					<lspShipmentPlan shipmentId="Shipment_4" chainId="directChain">
+					</shipmentPlan>
+					<shipmentPlan shipmentId="Shipment_4" chainId="directChain">
 						<element id="directCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="1680.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="1680.0" endTime="1740.0" resourceId="directCarrier"/>
-					</lspShipmentPlan>
-					<lspShipmentPlan shipmentId="Shipment_5" chainId="directChain">
+					</shipmentPlan>
+					<shipmentPlan shipmentId="Shipment_5" chainId="directChain">
 						<element id="directCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2880.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="2880.0" endTime="2940.0" resourceId="directCarrier"/>
-					</lspShipmentPlan>
-					<lspShipmentPlan shipmentId="Shipment_6" chainId="directChain">
+					</shipmentPlan>
+					<shipmentPlan shipmentId="Shipment_6" chainId="directChain">
 						<element id="directCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="3240.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="3240.0" endTime="3300.0" resourceId="directCarrier"/>
-					</lspShipmentPlan>
-					<lspShipmentPlan shipmentId="Shipment_7" chainId="directChain">
+					</shipmentPlan>
+					<shipmentPlan shipmentId="Shipment_7" chainId="directChain">
 						<element id="directCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="2280.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="2280.0" endTime="2340.0" resourceId="directCarrier"/>
-					</lspShipmentPlan>
-					<lspShipmentPlan shipmentId="Shipment_8" chainId="directChain">
+					</shipmentPlan>
+					<shipmentPlan shipmentId="Shipment_8" chainId="directChain">
 						<element id="directCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="3840.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="3840.0" endTime="3900.0" resourceId="directCarrier"/>
-					</lspShipmentPlan>
-					<lspShipmentPlan shipmentId="Shipment_9" chainId="directChain">
+					</shipmentPlan>
+					<shipmentPlan shipmentId="Shipment_9" chainId="directChain">
 						<element id="directCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="3420.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="3420.0" endTime="3480.0" resourceId="directCarrier"/>
-					</lspShipmentPlan>
-					<lspShipmentPlan shipmentId="Shipment_10" chainId="directChain">
+					</shipmentPlan>
+					<shipmentPlan shipmentId="Shipment_10" chainId="directChain">
 						<element id="directCarriersingleCarrierElementLOAD" type="LOAD" startTime="0.0" endTime="600.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementTRANSPORT" type="TRANSPORT" startTime="600.0" endTime="1740.0" resourceId="directCarrier"/>
 						<element id="directCarriersingleCarrierElementUNLOAD" type="UNLOAD" startTime="1740.0" endTime="1800.0" resourceId="directCarrier"/>
-					</lspShipmentPlan>
+					</shipmentPlan>
 				</shipmentPlans>
 			</LspPlan>
 		</LspPlans>


### PR DESCRIPTION
More renaming to clarify that something belongs to a **LSP** Shipment.
--
Move getter/setter for VRP solving logic to a CarrierAttribute. Then it is more directly attached to the carrier itself, which is imo better for now. Let the prepared stuff in the ConfigGroup there but comment it out, in case we later decide to set it there..