### PR TITLE
Remove LSPCarrierPair from Schedulers

### DIFF
--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
@@ -27,10 +27,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
-import org.matsim.freight.carriers.Carrier;
-import org.matsim.freight.carriers.CarrierService;
-import org.matsim.freight.carriers.ScheduledTour;
-import org.matsim.freight.carriers.Tour;
+import org.matsim.freight.carriers.*;
 import org.matsim.freight.carriers.Tour.Leg;
 import org.matsim.freight.carriers.Tour.ServiceActivity;
 import org.matsim.freight.carriers.Tour.TourElement;
@@ -87,7 +84,7 @@ import org.matsim.freight.logistics.shipment.LspShipmentUtils;
   private CarrierService convertToCarrierService(LspShipment lspShipment) {
     Id<CarrierService> serviceId = Id.create(lspShipment.getId().toString(), CarrierService.class);
     CarrierService carrierService = CarrierService.Builder.newInstance(serviceId, lspShipment.getFrom())
-            .setServiceStartTimeWindow(lspShipment.getPickupTimeWindow())
+            .setServiceStartTimeWindow(TimeWindow.newInstance(lspShipment.getPickupTimeWindow().getStart(), lspShipment.getPickupTimeWindow().getEnd()))
             .setCapacityDemand(lspShipment.getSize())
             .setServiceDuration(lspShipment.getDeliveryServiceTime())
             .build();

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
@@ -29,6 +29,7 @@ import org.matsim.freight.carriers.CarrierService;
 import org.matsim.freight.carriers.ScheduledTour;
 import org.matsim.freight.carriers.Tour;
 import org.matsim.freight.carriers.Tour.Leg;
+import org.matsim.freight.carriers.Tour.ServiceActivity;
 import org.matsim.freight.carriers.Tour.TourElement;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.shipment.LspShipment;
@@ -82,14 +83,12 @@ import org.matsim.freight.logistics.shipment.LspShipmentUtils;
   }
 
   private CarrierService convertToCarrierService(LspShipment lspShipment) {
-    Id<CarrierService> serviceId =
-        Id.create(lspShipment.getId().toString(), CarrierService.class);
-    CarrierService.Builder builder =
-        CarrierService.Builder.newInstance(serviceId, lspShipment.getFrom());
-    builder.setServiceStartTimeWindow(lspShipment.getPickupTimeWindow());
-    builder.setCapacityDemand(lspShipment.getSize());
-    builder.setServiceDuration(lspShipment.getDeliveryServiceTime());
-    CarrierService carrierService = builder.build();
+    Id<CarrierService> serviceId = Id.create(lspShipment.getId().toString(), CarrierService.class);
+    CarrierService carrierService = CarrierService.Builder.newInstance(serviceId, lspShipment.getFrom())
+            .setServiceStartTimeWindow(lspShipment.getPickupTimeWindow())
+            .setCapacityDemand(lspShipment.getSize())
+            .setServiceDuration(lspShipment.getDeliveryServiceTime())
+            .build();
     pairs.add(new LSPCarrierPair(lspShipment, carrierService));
     return carrierService;
   }
@@ -100,11 +99,10 @@ import org.matsim.freight.logistics.shipment.LspShipmentUtils;
       for (ScheduledTour scheduledTour : carrier.getSelectedPlan().getScheduledTours()) {
         Tour tour = scheduledTour.getTour();
         for (TourElement element : tour.getTourElements()) {
-          if (element instanceof Tour.ServiceActivity serviceActivity) {
-            LSPCarrierPair carrierPair = new LSPCarrierPair(lspShipment, serviceActivity.getService());
+          if (element instanceof ServiceActivity serviceActivity) {
             for (LSPCarrierPair pair : pairs) {
-              if (pair.lspShipment == carrierPair.lspShipment
-                  && pair.carrierService.getId() == carrierPair.carrierService.getId()) {
+              if (pair.lspShipment == lspShipment
+                  && pair.carrierService.getId() == serviceActivity.getService().getId()) {
                 addShipmentLoadElement(lspShipment, tour, serviceActivity);
                 addShipmentTransportElement(lspShipment, tour, serviceActivity);
                 addShipmentUnloadElement(lspShipment, tour);
@@ -119,7 +117,7 @@ import org.matsim.freight.logistics.shipment.LspShipmentUtils;
   }
 
   private void addShipmentLoadElement(
-      LspShipment lspShipment, Tour tour, Tour.ServiceActivity serviceActivity) {
+      LspShipment lspShipment, Tour tour, ServiceActivity serviceActivity) {
 
     LspShipmentUtils.ScheduledShipmentLoadBuilder builder =
         LspShipmentUtils.ScheduledShipmentLoadBuilder.newInstance();

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
@@ -1,27 +1,30 @@
 /*
-  *********************************************************************** *
-  * project: org.matsim.*
-  *                                                                         *
-  * *********************************************************************** *
-  *                                                                         *
-  * copyright       :  (C) 2022 by the members listed in the COPYING,       *
-  *                   LICENSE and WARRANTY file.                            *
-  * email           : info at matsim dot org                                *
-  *                                                                         *
-  * *********************************************************************** *
-  *                                                                         *
-  *   This program is free software; you can redistribute it and/or modify  *
-  *   it under the terms of the GNU General Public License as published by  *
-  *   the Free Software Foundation; either version 2 of the License, or     *
-  *   (at your option) any later version.                                   *
-  *   See also COPYING, LICENSE and WARRANTY file                           *
-  *                                                                         *
-  * ***********************************************************************
+ *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       :  (C) 2022 by the members listed in the COPYING,       *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * ***********************************************************************
  */
 
 package org.matsim.freight.logistics.resourceImplementations;
 
-import java.util.ArrayList;
+import java.util.Objects;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.freight.carriers.Carrier;
@@ -45,9 +48,10 @@ import org.matsim.freight.logistics.shipment.LspShipmentUtils;
  */
 /*package-private*/ class CollectionCarrierScheduler extends LSPResourceScheduler {
 
+  Logger log = LogManager.getLogger(CollectionCarrierScheduler.class);
+
   private Carrier carrier;
   private CollectionCarrierResource resource;
-  private ArrayList<LSPCarrierPair> pairs;
   private final Scenario scenario;
 
   /**
@@ -57,13 +61,11 @@ import org.matsim.freight.logistics.shipment.LspShipmentUtils;
    * @param scenario the road pricing scheme
    */
   CollectionCarrierScheduler(Scenario scenario) {
-    this.pairs = new ArrayList<>();
     this.scenario = scenario;
   }
 
   @Override
   public void initializeValues(LSPResource resource) {
-    this.pairs = new ArrayList<>();
     if (resource.getClass() == CollectionCarrierResource.class) {
       this.resource = (CollectionCarrierResource) resource;
       this.carrier = this.resource.getCarrier();
@@ -89,7 +91,11 @@ import org.matsim.freight.logistics.shipment.LspShipmentUtils;
             .setCapacityDemand(lspShipment.getSize())
             .setServiceDuration(lspShipment.getDeliveryServiceTime())
             .build();
-    pairs.add(new LSPCarrierPair(lspShipment, carrierService));
+    //ensure that the ids of the lspShipment and the carrierService are the same. This is needed for updating the LSPShipmentPlan
+    if (! Objects.equals(lspShipment.getId().toString(), carrierService.getId().toString())) {
+      log.error("Id of LspShipment: {} and CarrierService: {} do not match", lspShipment.getId().toString(), carrierService.getId().toString(),
+              new IllegalStateException("Id of LspShipment and CarrierService do not match"));
+    }
     return carrierService;
   }
 
@@ -100,15 +106,12 @@ import org.matsim.freight.logistics.shipment.LspShipmentUtils;
         Tour tour = scheduledTour.getTour();
         for (TourElement element : tour.getTourElements()) {
           if (element instanceof ServiceActivity serviceActivity) {
-            for (LSPCarrierPair pair : pairs) {
-              if (pair.lspShipment == lspShipment
-                  && pair.carrierService.getId() == serviceActivity.getService().getId()) {
-                addShipmentLoadElement(lspShipment, tour, serviceActivity);
-                addShipmentTransportElement(lspShipment, tour, serviceActivity);
-                addShipmentUnloadElement(lspShipment, tour);
-                addCollectionTourEndEventHandler(pair.carrierService, lspShipment, resource, tour);
-                addCollectionServiceEventHandler(pair.carrierService, lspShipment, resource);
-              }
+            if (Objects.equals(lspShipment.getId().toString(), serviceActivity.getService().getId().toString())) {
+              addShipmentLoadElement(lspShipment, tour, serviceActivity);
+              addShipmentTransportElement(lspShipment, tour, serviceActivity);
+              addShipmentUnloadElement(lspShipment, tour);
+              addCollectionTourEndEventHandler(serviceActivity.getService(), lspShipment, resource, tour);
+              addCollectionServiceEventHandler(serviceActivity.getService(), lspShipment, resource);
             }
           }
         }
@@ -117,10 +120,10 @@ import org.matsim.freight.logistics.shipment.LspShipmentUtils;
   }
 
   private void addShipmentLoadElement(
-      LspShipment lspShipment, Tour tour, ServiceActivity serviceActivity) {
+          LspShipment lspShipment, Tour tour, ServiceActivity serviceActivity) {
 
     LspShipmentUtils.ScheduledShipmentLoadBuilder builder =
-        LspShipmentUtils.ScheduledShipmentLoadBuilder.newInstance();
+            LspShipmentUtils.ScheduledShipmentLoadBuilder.newInstance();
     builder.setResourceId(resource.getId());
 
     for (LogisticChainElement element : resource.getClientElements()) {
@@ -132,23 +135,23 @@ import org.matsim.freight.logistics.shipment.LspShipmentUtils;
     int serviceIndex = tour.getTourElements().indexOf(serviceActivity);
     Leg legBeforeService = (Leg) tour.getTourElements().get(serviceIndex - 1);
     double startTimeOfLoading =
-        legBeforeService.getExpectedDepartureTime() + legBeforeService.getExpectedTransportTime();
+            legBeforeService.getExpectedDepartureTime() + legBeforeService.getExpectedTransportTime();
     builder.setStartTime(startTimeOfLoading);
     builder.setEndTime(startTimeOfLoading + lspShipment.getDeliveryServiceTime());
 
     LspShipmentPlanElement load = builder.build();
     String idString =
-        load.getResourceId() + "" + load.getLogisticChainElement().getId() + load.getElementType();
+            load.getResourceId() + "" + load.getLogisticChainElement().getId() + load.getElementType();
     Id<LspShipmentPlanElement> id = Id.create(idString, LspShipmentPlanElement.class);
     LspShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, lspShipment.getId())
-        .addPlanElement(id, load);
+            .addPlanElement(id, load);
   }
 
   private void addShipmentTransportElement(
-      LspShipment lspShipment, Tour tour, Tour.ServiceActivity serviceActivity) {
+          LspShipment lspShipment, Tour tour, Tour.ServiceActivity serviceActivity) {
 
     LspShipmentUtils.ScheduledShipmentTransportBuilder builder =
-        LspShipmentUtils.ScheduledShipmentTransportBuilder.newInstance();
+            LspShipmentUtils.ScheduledShipmentTransportBuilder.newInstance();
     builder.setResourceId(resource.getId());
 
     for (LogisticChainElement element : resource.getClientElements()) {
@@ -170,23 +173,23 @@ import org.matsim.freight.logistics.shipment.LspShipmentUtils;
     builder.setCarrierService(serviceActivity.getService());
     LspShipmentPlanElement transport = builder.build();
     String idString =
-        transport.getResourceId()
-            + ""
-            + transport.getLogisticChainElement().getId()
-            + transport.getElementType();
+            transport.getResourceId()
+                    + ""
+                    + transport.getLogisticChainElement().getId()
+                    + transport.getElementType();
     Id<LspShipmentPlanElement> id = Id.create(idString, LspShipmentPlanElement.class);
     LspShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, lspShipment.getId())
-        .addPlanElement(id, transport);
+            .addPlanElement(id, transport);
   }
 
   private void addCollectionServiceEventHandler(
-      CarrierService carrierService, LspShipment lspShipment, LSPCarrierResource resource) {
+          CarrierService carrierService, LspShipment lspShipment, LSPCarrierResource resource) {
 
     for (LogisticChainElement element : this.resource.getClientElements()) {
       if (element.getIncomingShipments().getLspShipmentsWTime().contains(lspShipment)) {
         CollectionServiceEndEventHandler endHandler =
-            new CollectionServiceEndEventHandler(
-                carrierService, lspShipment, element, resource);
+                new CollectionServiceEndEventHandler(
+                        carrierService, lspShipment, element, resource);
         lspShipment.addSimulationTracker(endHandler);
         break;
       }
@@ -194,15 +197,15 @@ import org.matsim.freight.logistics.shipment.LspShipmentUtils;
   }
 
   private void addCollectionTourEndEventHandler(
-      CarrierService carrierService,
-      LspShipment lspShipment,
-      LSPCarrierResource resource,
-      Tour tour) {
+          CarrierService carrierService,
+          LspShipment lspShipment,
+          LSPCarrierResource resource,
+          Tour tour) {
     for (LogisticChainElement element : this.resource.getClientElements()) {
       if (element.getIncomingShipments().getLspShipmentsWTime().contains(lspShipment)) {
         LSPTourEndEventHandler handler =
-            new LSPTourEndEventHandler(
-					lspShipment, carrierService, element, resource, tour);
+                new LSPTourEndEventHandler(
+                        lspShipment, carrierService, element, resource, tour);
         lspShipment.addSimulationTracker(handler);
         break;
       }
@@ -212,7 +215,7 @@ import org.matsim.freight.logistics.shipment.LspShipmentUtils;
   private void addShipmentUnloadElement(LspShipment lspShipment, Tour tour) {
 
     LspShipmentUtils.ScheduledShipmentUnloadBuilder builder =
-        LspShipmentUtils.ScheduledShipmentUnloadBuilder.newInstance();
+            LspShipmentUtils.ScheduledShipmentUnloadBuilder.newInstance();
     builder.setResourceId(resource.getId());
     for (LogisticChainElement element : resource.getClientElements()) {
       if (element.getIncomingShipments().getLspShipmentsWTime().contains(lspShipment)) {
@@ -226,13 +229,13 @@ import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 
     LspShipmentPlanElement unload = builder.build();
     String idString =
-        unload.getResourceId()
-            + ""
-            + unload.getLogisticChainElement().getId()
-            + unload.getElementType();
+            unload.getResourceId()
+                    + ""
+                    + unload.getLogisticChainElement().getId()
+                    + unload.getElementType();
     Id<LspShipmentPlanElement> id = Id.create(idString, LspShipmentPlanElement.class);
     LspShipmentUtils.getOrCreateShipmentPlan(super.lspPlan, lspShipment.getId())
-        .addPlanElement(id, unload);
+            .addPlanElement(id, unload);
   }
 
   private double getUnloadEndTime(Tour tour) {
@@ -245,5 +248,4 @@ import org.matsim.freight.logistics.shipment.LspShipmentUtils;
     return unloadEndTime;
   }
 
-  private record LSPCarrierPair(LspShipment lspShipment, CarrierService carrierService) {}
 }

--- a/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
+++ b/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
@@ -171,13 +171,11 @@ import org.matsim.vehicles.VehicleType;
   }
 
   private CarrierService convertToCarrierService(LspShipment lspShipment) {
-    Id<CarrierService> serviceId =
-        Id.create(lspShipment.getId().toString(), CarrierService.class);
-    CarrierService.Builder builder =
-        CarrierService.Builder.newInstance(serviceId, lspShipment.getTo());
-    builder.setCapacityDemand(lspShipment.getSize());
-    builder.setServiceDuration(lspShipment.getDeliveryServiceTime());
-    CarrierService carrierService = builder.build();
+    Id<CarrierService> serviceId = Id.create(lspShipment.getId().toString(), CarrierService.class);
+    CarrierService carrierService = CarrierService.Builder.newInstance(serviceId, lspShipment.getTo())
+            .setCapacityDemand(lspShipment.getSize())
+            .setServiceDuration(lspShipment.getDeliveryServiceTime())
+            .build();
     pairs.add(new LSPCarrierPair(lspShipment, carrierService));
     return carrierService;
   }
@@ -189,10 +187,9 @@ import org.matsim.vehicles.VehicleType;
         Tour tour = scheduledTour.getTour();
         for (TourElement element : tour.getTourElements()) {
           if (element instanceof ServiceActivity serviceActivity) {
-            LSPCarrierPair carrierPair = new LSPCarrierPair(lspShipment, serviceActivity.getService());
             for (LSPCarrierPair pair : pairs) {
-              if (pair.lspShipment == carrierPair.lspShipment
-                  && pair.carrierService.getId() == carrierPair.carrierService.getId()) {
+              if (pair.lspShipment == lspShipment
+                  && pair.carrierService.getId() == serviceActivity.getService().getId()) {
                 addShipmentLoadElement(lspShipment, tour);
                 addShipmentTransportElement(lspShipment, tour, serviceActivity);
                 addShipmentUnloadElement(lspShipment, tour, serviceActivity);

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/CollectionLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/CollectionLSPSchedulingTest.java
@@ -192,29 +192,35 @@ public class CollectionLSPSchedulingTest {
 			assertEquals(2, shipment.getSimulationTrackers().size());
 			ArrayList<EventHandler> eventHandlers = new ArrayList<>(shipment.getSimulationTrackers());
 
+			{
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
 			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
 			assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertSame(endHandler.getCarrierService().getServiceStartTimeWindow(), shipment.getPickupTimeWindow());
+			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(2).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), collectionLSP.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements().iterator().next());
 			assertSame(endHandler.getLspShipment(), shipment);
 			assertSame(endHandler.getResourceId(), planElements.get(2).getResourceId());
 			assertSame(endHandler.getResourceId(), collectionLSP.getResources().iterator().next().getId());
+			}
 
+			{
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
 			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
 			assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertSame(serviceHandler.getCarrierService().getServiceStartTimeWindow(), shipment.getPickupTimeWindow());
+			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(serviceHandler.getElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), collectionLSP.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements().iterator().next());
 			assertSame(serviceHandler.getLspShipment(), shipment);
 			assertSame(serviceHandler.getResourceId(), planElements.get(1).getResourceId());
 			assertSame(serviceHandler.getResourceId(), collectionLSP.getResources().iterator().next().getId());
+			}
 		}
 
 		for (LogisticChain solution : collectionLSP.getSelectedPlan().getLogisticChains()) {

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
@@ -488,7 +488,8 @@ public class CompleteLSPSchedulingTest {
 			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
 			assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertSame(endHandler.getCarrierService().getServiceStartTimeWindow(), shipment.getPickupTimeWindow());
+			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(2).getLogisticChainElement());
@@ -505,7 +506,8 @@ public class CompleteLSPSchedulingTest {
 			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
 			assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertSame(serviceHandler.getCarrierService().getServiceStartTimeWindow(), shipment.getPickupTimeWindow());
+			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(serviceHandler.getElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), planElements.get(2).getLogisticChainElement());

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/FirstReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/FirstReloadLSPSchedulingTest.java
@@ -285,7 +285,8 @@ public class FirstReloadLSPSchedulingTest {
 			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
 			assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertSame(endHandler.getCarrierService().getServiceStartTimeWindow(), shipment.getPickupTimeWindow());
+			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(2).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), lsp.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements().iterator().next());
 			assertSame(endHandler.getLspShipment(), shipment);
@@ -297,7 +298,8 @@ public class FirstReloadLSPSchedulingTest {
 			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
 			assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertSame(serviceHandler.getCarrierService().getServiceStartTimeWindow(), shipment.getPickupTimeWindow());
+			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(serviceHandler.getElement(), planElements.getFirst().getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), lsp.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements().iterator().next());
 			assertSame(serviceHandler.getLspShipment(), shipment);

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MainRunLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MainRunLSPSchedulingTest.java
@@ -353,7 +353,8 @@ public class MainRunLSPSchedulingTest {
 			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
 			assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertSame(endHandler.getCarrierService().getServiceStartTimeWindow(), shipment.getPickupTimeWindow());
+			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(2).getLogisticChainElement());
@@ -370,7 +371,8 @@ public class MainRunLSPSchedulingTest {
 			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
 			assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertSame(serviceHandler.getCarrierService().getServiceStartTimeWindow(), shipment.getPickupTimeWindow());
+			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(serviceHandler.getElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), planElements.get(2).getLogisticChainElement());

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCollectionLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCollectionLSPSchedulingTest.java
@@ -200,7 +200,8 @@ public class MultipleShipmentsCollectionLSPSchedulingTest {
 			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
 			assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertSame(endHandler.getCarrierService().getServiceStartTimeWindow(), shipment.getPickupTimeWindow());
+			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(2).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), collectionLSP.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements().iterator().next());
 			assertSame(endHandler.getLspShipment(), shipment);
@@ -212,7 +213,8 @@ public class MultipleShipmentsCollectionLSPSchedulingTest {
 			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
 			assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertSame(serviceHandler.getCarrierService().getServiceStartTimeWindow(), shipment.getPickupTimeWindow());
+			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(serviceHandler.getElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), collectionLSP.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements().iterator().next());
 			assertSame(serviceHandler.getLspShipment(), shipment);

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
@@ -491,7 +491,8 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
 			assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertSame(endHandler.getCarrierService().getServiceStartTimeWindow(), shipment.getPickupTimeWindow());
+			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(2).getLogisticChainElement());
@@ -508,7 +509,8 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
 			assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertSame(serviceHandler.getCarrierService().getServiceStartTimeWindow(), shipment.getPickupTimeWindow());
+			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(serviceHandler.getElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), planElements.get(2).getLogisticChainElement());

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsFirstReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsFirstReloadLSPSchedulingTest.java
@@ -284,7 +284,8 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
 			assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertSame(endHandler.getCarrierService().getServiceStartTimeWindow(), shipment.getPickupTimeWindow());
+			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(2).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), lsp.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements().iterator().next());
 			assertSame(endHandler.getLspShipment(), shipment);
@@ -296,7 +297,8 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
 			assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertSame(serviceHandler.getCarrierService().getServiceStartTimeWindow(), shipment.getPickupTimeWindow());
+			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(serviceHandler.getElement(), planElements.getFirst().getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), lsp.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements().iterator().next());
 			assertSame(serviceHandler.getLspShipment(), shipment);

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsMainRunLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsMainRunLSPSchedulingTest.java
@@ -353,7 +353,8 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
 			assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertSame(endHandler.getCarrierService().getServiceStartTimeWindow(), shipment.getPickupTimeWindow());
+			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(2).getLogisticChainElement());
@@ -370,7 +371,8 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
 			assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertSame(serviceHandler.getCarrierService().getServiceStartTimeWindow(), shipment.getPickupTimeWindow());
+			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(serviceHandler.getElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), planElements.get(2).getLogisticChainElement());

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsSecondReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsSecondReloadLSPSchedulingTest.java
@@ -427,12 +427,14 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			ArrayList<LSPResource> resources = new ArrayList<>(lsp.getResources());
 
 			//CollectionTourEnd
+			{
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler collectionEndHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
 			assertSame(collectionEndHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
 			assertEquals(collectionEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(collectionEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertSame(collectionEndHandler.getCarrierService().getServiceStartTimeWindow(), shipment.getPickupTimeWindow());
+			assertEquals(collectionEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(collectionEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(collectionEndHandler.getLogisticChainElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(collectionEndHandler.getLogisticChainElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(collectionEndHandler.getLogisticChainElement(), planElements.get(2).getLogisticChainElement());
@@ -442,14 +444,16 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			assertSame(collectionEndHandler.getResourceId(), planElements.get(1).getResourceId());
 			assertSame(collectionEndHandler.getResourceId(), planElements.get(2).getResourceId());
 			assertSame(collectionEndHandler.getResourceId(), resources.getFirst().getId());
+			}
 
-			//CollectionServiceEnd
+			{//CollectionServiceEnd
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler collectionServiceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
 			assertSame(collectionServiceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
 			assertEquals(collectionServiceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(collectionServiceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertSame(collectionServiceHandler.getCarrierService().getServiceStartTimeWindow(), shipment.getPickupTimeWindow());
+			assertEquals(collectionServiceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(collectionServiceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(collectionServiceHandler.getElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(collectionServiceHandler.getElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(collectionServiceHandler.getElement(), planElements.get(2).getLogisticChainElement());
@@ -459,8 +463,9 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			assertSame(collectionServiceHandler.getResourceId(), planElements.get(1).getResourceId());
 			assertSame(collectionServiceHandler.getResourceId(), planElements.get(2).getResourceId());
 			assertSame(collectionServiceHandler.getResourceId(), resources.getFirst().getId());
+			}
 
-			//MainRunStart
+			{//MainRunStart
 			assertInstanceOf(LSPTourStartEventHandler.class, eventHandlers.get(2));
 			LSPTourStartEventHandler mainRunStartHandler = (LSPTourStartEventHandler) eventHandlers.get(2);
 			assertSame(mainRunStartHandler.getCarrierService().getLocationLinkId(), toLinkId);
@@ -477,8 +482,9 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			assertSame(mainRunStartHandler.getResourceId(), planElements.get(5).getResourceId());
 			assertSame(mainRunStartHandler.getResourceId(), planElements.get(6).getResourceId());
 			assertSame(mainRunStartHandler.getResourceId(), resources.get(2).getId());
+			}
 
-			//MainRunEnd
+			{//MainRunEnd
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.get(3));
 			LSPTourEndEventHandler mainRunEndHandler = (LSPTourEndEventHandler) eventHandlers.get(3);
 			assertSame(mainRunEndHandler.getCarrierService().getLocationLinkId(), toLinkId);
@@ -495,6 +501,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			assertSame(mainRunEndHandler.getResourceId(), planElements.get(5).getResourceId());
 			assertSame(mainRunEndHandler.getResourceId(), planElements.get(6).getResourceId());
 			assertSame(mainRunEndHandler.getResourceId(), resources.get(2).getId());
+			}
 		}
 
 		for (LogisticChain solution : lsp.getSelectedPlan().getLogisticChains()) {

--- a/src/test/java/org/matsim/freight/logistics/resourceImplementations/SecondReloadLSPSchedulingTest.java
+++ b/src/test/java/org/matsim/freight/logistics/resourceImplementations/SecondReloadLSPSchedulingTest.java
@@ -434,13 +434,14 @@ public class SecondReloadLSPSchedulingTest {
 			ArrayList<LogisticChainElement> solutionElements = new ArrayList<>(lsp.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements());
 			ArrayList<LSPResource> resources = new ArrayList<>(lsp.getResources());
 
-			//CollectionTourEnd
+			{//CollectionTourEnd
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler collectionEndHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
 			assertSame(collectionEndHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
 			assertEquals(collectionEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(collectionEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertSame(collectionEndHandler.getCarrierService().getServiceStartTimeWindow(), shipment.getPickupTimeWindow());
+			assertEquals(collectionEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(collectionEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(collectionEndHandler.getLogisticChainElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(collectionEndHandler.getLogisticChainElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(collectionEndHandler.getLogisticChainElement(), planElements.get(2).getLogisticChainElement());
@@ -450,14 +451,16 @@ public class SecondReloadLSPSchedulingTest {
 			assertSame(collectionEndHandler.getResourceId(), planElements.get(1).getResourceId());
 			assertSame(collectionEndHandler.getResourceId(), planElements.get(2).getResourceId());
 			assertSame(collectionEndHandler.getResourceId(), resources.getFirst().getId());
+			}
 
-			//CollectionServiceEnd
+			{//CollectionServiceEnd
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler collectionServiceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
 			assertSame(collectionServiceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
 			assertEquals(collectionServiceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(collectionServiceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertSame(collectionServiceHandler.getCarrierService().getServiceStartTimeWindow(), shipment.getPickupTimeWindow());
+			assertEquals(collectionServiceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(collectionServiceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(collectionServiceHandler.getElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(collectionServiceHandler.getElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(collectionServiceHandler.getElement(), planElements.get(2).getLogisticChainElement());
@@ -467,8 +470,9 @@ public class SecondReloadLSPSchedulingTest {
 			assertSame(collectionServiceHandler.getResourceId(), planElements.get(1).getResourceId());
 			assertSame(collectionServiceHandler.getResourceId(), planElements.get(2).getResourceId());
 			assertSame(collectionServiceHandler.getResourceId(), resources.getFirst().getId());
+			}
 
-			//MainRunStart
+			{//MainRunStart
 			assertInstanceOf(LSPTourStartEventHandler.class, eventHandlers.get(2));
 			LSPTourStartEventHandler mainRunStartHandler = (LSPTourStartEventHandler) eventHandlers.get(2);
 			assertSame(mainRunStartHandler.getCarrierService().getLocationLinkId(), toLinkId);
@@ -485,8 +489,9 @@ public class SecondReloadLSPSchedulingTest {
 			assertSame(mainRunStartHandler.getResourceId(), planElements.get(5).getResourceId());
 			assertSame(mainRunStartHandler.getResourceId(), planElements.get(6).getResourceId());
 			assertSame(mainRunStartHandler.getResourceId(), resources.get(2).getId());
+			}
 
-			//MainRunEnd
+			{//MainRunEnd
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.get(3));
 			LSPTourEndEventHandler mainRunEndHandler = (LSPTourEndEventHandler) eventHandlers.get(3);
 			assertSame(mainRunEndHandler.getCarrierService().getLocationLinkId(), toLinkId);
@@ -503,6 +508,7 @@ public class SecondReloadLSPSchedulingTest {
 			assertSame(mainRunEndHandler.getResourceId(), planElements.get(5).getResourceId());
 			assertSame(mainRunEndHandler.getResourceId(), planElements.get(6).getResourceId());
 			assertSame(mainRunEndHandler.getResourceId(), resources.get(2).getId());
+			}
 		}
 
 		for (LogisticChain solution : lsp.getSelectedPlan().getLogisticChains()) {


### PR DESCRIPTION
They were only used for internal bookkeeping. However, they are not needed because the data is also available as it is and no further object is needed to temporarily store available objects. It also makes the code somewhat leaner and clearer and then easier to integrate the CarrierShipments for VRP planning later on.