### PR TITLE
remove dependency to vsp contrib, as it is no longer needed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,12 +37,6 @@
 			<version>${project.parent.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.matsim.contrib</groupId>
-			<artifactId>vsp</artifactId>
-			<version>${project.parent.version}</version>
-		</dependency>
-		
 		<!--MATSim examples. Not transitive -->
 		<dependency>
 			<groupId>org.matsim</groupId>

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChains.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChains.java
@@ -47,7 +47,6 @@ import java.util.*;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.TransportMode;
@@ -173,7 +172,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChains {
     return config;
   }
 
-  private static @NotNull Controler prepareControler(Scenario scenario) {
+  private static Controler prepareControler(Scenario scenario) {
     log.info("Prepare controler");
     Controler controler = new Controler(scenario);
     controler.addOverridingModule(

--- a/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll.java
+++ b/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll.java
@@ -26,7 +26,6 @@ import java.util.*;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
 import org.matsim.analysis.personMoney.PersonMoneyEventsAnalysisModule;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
@@ -159,7 +158,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll {
     return config;
   }
 
-  private static @NotNull Controler prepareControler(Scenario scenario, RoadPricingScheme rpScheme) {
+  private static Controler prepareControler(Scenario scenario, RoadPricingScheme rpScheme) {
     log.info("Prepare controler");
     Controler controler = new Controler(scenario);
     controler.addOverridingModule(


### PR DESCRIPTION
The  `CarrierAnalysis` had been moved into the `freight` contrib (see https://github.com/matsim-org/matsim-libs/pull/3514), thus we can now remove the dependency to the `vsp` contrib.